### PR TITLE
Update db-xrefs.yaml

### DIFF
--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -1721,9 +1721,9 @@
     - type_name: gene
       type_id: SO:0000704
       id_syntax: \d+
-      url_syntax: http://www.ncbi.nlm.nih.gov/sites/entrez?cmd=Retrieve&db=gene&list_uids=[example_id]
+      url_syntax: http://www.ncbi.nlm.nih.gov/gene/[example_id]
       example_id: NCBI_Gene:4771
-      example_url: http://www.ncbi.nlm.nih.gov/sites/entrez?cmd=Retrieve&db=gene&list_uids=4771
+      example_url: http://www.ncbi.nlm.nih.gov/gene/4771
 - database: NCBI_gi
   name: NCBI databases
   generic_urls:


### PR DESCRIPTION
The url_syntax for NCBIGene was a non standard form I was able to find no where else except here in GO. 
url_syntax: http://www.ncbi.nlm.nih.gov/sites/entrez?cmd=Retrieve&db=gene&list_uids=[example_id]

I propose changing it to reflect what is in identifiers.org and that I've also seen around. url_syntax: http://www.ncbi.nlm.nih.gov/gene/[example_id] 

NCBI publishes no guidance about which is THE authoritative version to use, but url_syntax: http://www.ncbi.nlm.nih.gov/gene/[example_id] instinctively sounds like a better bet than the multiple permutations I discovered (eg. [here](https://docs.google.com/spreadsheets/d/1OCJuB5obyKsOY-_Fc9-QTj2m1KTiGfEien5NxQyGFAQ/edit#gid=19403651)).