### PR TITLE
Fixing typo in URL

### DIFF
--- a/metadata/datasets/mgi.yaml
+++ b/metadata/datasets/mgi.yaml
@@ -38,7 +38,7 @@ datasets:
    id: mgi.gpi
    label: "mgi gpi file"
    description: "gpi file for mgi from Mouse Genome Informatics"
-   url: http://geneontoloty.org/gpad-gpi/release/mgi.gpi.gz
+   url: http://geneontology.org/gpad-gpi/release/mgi.gpi.gz
    type: gpi
    dataset: mgi
    submitter: mgi


### PR DESCRIPTION
This should get to the bottom of https://github.com/geneontology/noctua/issues/383