### PR TITLE
Create GO_REF:0000112

### DIFF
--- a/metadata/gorefs/GO_REF:0000112
+++ b/metadata/gorefs/GO_REF:0000112
@@ -1,0 +1,10 @@
+--- 
+authors: Ivan Erill, James Hu, Community Assessment of Community Annotation with Ontologies
+id: GO_REF:0000112
+year: 2017
+layout: goref
+---
+
+## Gene Ontology annotation by CACAO biocurators
+
+This GO reference describes the criteria used by biocurators participating in the Community Assessment of Community Annotation with Ontologies (CACAO) to annotate gene products from genomes of interest through the use of computational methods to establish and manually validate function or homology to gene products. In particular, this GO reference describes the criteria used to make annotations based on evidence codes ISS, ISA, ISO, ISM and IGC. To perform ISS-, ISA-, and ISO-based annotations on a gene product, CACAO biocurators use sequence- and structure-based search algorithms (e.g. BLASTP, HHPred) to establish homology, conservation of sequence and structure functional determinants between the target gene product and gene products from other organisms with published GO annotations supported by experimental codes and lacking NOT qualifiers. These gene products are referenced in the WITH field of the annotation using their xref database accession. ISM-based annotations make use of published computational methods (e.g. TMHMM, SignalP) to predict gene product structure, localization or function. IGC-based annotations are made on the basis of suggestive evidence for function based on synteny. Parameters and criteria for use of all computational methods (e.g. e-value) are listed and versioned in the publicly available CACAO documentation (http://gowiki.tamu.edu/). Annotations made by CACAO biocurators are reviewed by CACAO team instructors before their release.


### PR DESCRIPTION
Request for GO_REF for  in silico-based, curator reviewed GO annotations in the context of the Community Assessment of Community Annotation with Ontologies (CACAO). The intent of this GO reference is to provide detailed criteria for the use of computational methods to assign function/process/component attributes to gene products in published genomes, allowing curators participating in CACAO to perform annotations based on the results of such methods using the GO_REF as a source. The specific criteria and rationales used for each computational method are described and versioned in the CACAO GO_REF category (http://gowiki.tamu.edu/wiki/index.php/Category:CACAO_GO_REF).