### PR TITLE
adding PLANA_REF

### DIFF
--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -3200,3 +3200,14 @@
       url_syntax: http://zfin.org/cgi-bin/ZFIN_jump?record=[example_id]
       example_id: ZFIN:ZDB-GENE-990415-103
       example_url: http://zfin.org/cgi-bin/ZFIN_jump?record=ZDB-GENE-990415-103
+- database: PLANA_REF
+  name: Planaria Ontology Database References
+  generic_urls:
+    - http://purl.obolibrary.org/obo/plana/references/
+  entity_types:
+    - type_name: entity
+      type_id: BET:0000000
+      id_syntax: \d{7}
+      url_syntax: http://purl.obolibrary.org/obo/plana/references/[example_id]
+      example_id: "0000001"
+      example_url: http://purl.obolibrary.org/obo/plana/references/0000001

--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -3208,6 +3208,6 @@
     - type_name: entity
       type_id: BET:0000000
       id_syntax: \d{7}
-      url_syntax: http://purl.obolibrary.org/obo/plana/references/[example_id]
+      url_syntax: http://purl.obolibrary.org/obo/plana/references/planaref-[example_id].md
       example_id: "0000001"
-      example_url: http://purl.obolibrary.org/obo/plana/references/0000001
+      example_url: http://purl.obolibrary.org/obo/plana/references/planaref-0000001.md

--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -3208,6 +3208,6 @@
     - type_name: entity
       type_id: BET:0000000
       id_syntax: \d{7}
-      url_syntax: http://purl.obolibrary.org/obo/plana/references/planaref-[example_id].md
+      url_syntax: http://purl.obolibrary.org/obo/plana/references/[example_id]
       example_id: "0000001"
-      example_url: http://purl.obolibrary.org/obo/plana/references/planaref-0000001.md
+      example_url: http://purl.obolibrary.org/obo/plana/references/0000001


### PR DESCRIPTION
I would like to add our planarian reference pages for ontology terms that have no universal IDs to this yaml.

I followed the directory structure for [GO_REF go-site](https://github.com/geneontology/go-site/tree/master/metadata/gorefs) for our [PLANA_REF reference pages](https://github.com/obophenotype/planaria-ontology/tree/master/metadata/planarefs)

And I followed the GO_REF format in the YAML.
