### PR TITLE
gorule 1 now does not reference columns or syntactic features of GAF …

### DIFF
--- a/metadata/rules/gorule-0000001.md
+++ b/metadata/rules/gorule-0000001.md
@@ -8,21 +8,16 @@ implementations:
   - language: perl
     source: http://www.geneontology.org/software/utilities/filter-gene-association.pl
 ---
-The following basic checks ensure that submitted gene association files
-conform to the GAF spec, and come from the original GAF check script.
+The following basic checks ensure that submitted and parsed gene association files
+conform to some GO specific specifications, and come from the original GAF check script.
 
--   Each line of the GAF file is checked for the correct number of
-    columns, the cardinality of the columns, leading or trailing
-    whitespace
--   Col 1 and all DB abbreviations must be in
+-   All DB abbreviations must be in
     [GO.xrf\_abbs](http://www.geneontology.org/cgi-bin/xrefs.cgi) (case
     may be incorrect)
 -   All GO IDs must be extant in current ontology
 -   Qualifier, evidence, aspect and DB object columns must be within the
     list of allowed values
 -   DB:Reference, Taxon and GO ID columns are checked for minimal form
--   Date must be in YYYYMMDD format
 -   All IEAs over a year old are removed
 -   Taxa with a 'representative' group (e.g. MGI for Mus musculus,
     FlyBase for Drosophila) must be submitted by that group only
-


### PR DESCRIPTION
…as those should be taken care of in parsing.

I removed the date requirement as the date field should already be validated in parsing. I also removed a reference to particular columns, and left only the type of data in that column (col 1 vs DB abbreviations). I also made it clear that Go Rules should only happen _after_ a GAF file has been parsed. So Go Rules only take correct GAF or Association collections (built from a GAF).