### PR TITLE
swap out rdfox for arachne

### DIFF
--- a/pipeline/Makefile
+++ b/pipeline/Makefile
@@ -5,7 +5,7 @@ RDFOX_MEM ?= 32G
 GAF_OWL = target/go-gaf.owl
 ONT_MERGED = target/go-graphstore-merged.ttl
 
-all: target/Makefile extra_files $(REPORT) 
+all: target/Makefile extra_files $(REPORT)
 
 all_blazegraph: all target/blazegraph.jnl
 
@@ -115,4 +115,4 @@ target/blazegraph.jnl: $(BGJAR) target/rdf target/inferred
 # 	$(BG) -defaultGraph http://geneontology.org/rdf/inferred/ conf/blazegraph.properties $<
 
 bg-start:
-	java -server -Xmx8g -Dbigdata.propertyFile=conf/blazegraph.properties -jar $(BGJAR)
+	java -server -Xmx32g -Djetty.port=8899 -Djetty.overrideWebXml=conf/readonly_cors.xml -Dbigdata.propertyFile=conf/blazegraph.properties -cp target/jars/blazegraph-jar.jar:target/jars/jetty-servlets.jar com.bigdata.rdf.sail.webapp.StandaloneNanoSparqlServer

--- a/pipeline/conf/readonly_cors.xml
+++ b/pipeline/conf/readonly_cors.xml
@@ -6,7 +6,7 @@
   <context-param>
     <description>When true, the REST API will not permit mutation operations.</description>
     <param-name>readOnly</param-name>
-    <param-value>true</param-value>
+    <param-value>false</param-value>
   </context-param>
   <context-param>
     <param-name>queryTimeout</param-name>

--- a/pipeline/util/generate-makefile.py
+++ b/pipeline/util/generate-makefile.py
@@ -117,7 +117,7 @@ def generate_targets(ds, alist):
     rule(ttl(ds),"{} $(ONT_MERGED)".format(filtered_gaf(ds)),
          'MINERVA_CLI_MEMORY=16G minerva-cli.sh $(ONT_MERGED) --gaf $< --gaf-lego-individuals --skip-merge --format turtle -o $@.tmp && mv $@.tmp $@')
     rule(inferred_ttl(ds), "{} $(ONT_MERGED)".format(ttl(ds)),
-        "mkdir -p target/inferred\n\tarachne --ontology=$(ONT_MERGED) --data=$(<D) --export=$@ --inferred-only")
+        "mkdir -p target/inferred\n\tarachne --ontology=$(ONT_MERGED) --data=$< --export=$@ --inferred-only")
 
 
 def create_targetdir(ds):

--- a/pipeline/util/generate-makefile.py
+++ b/pipeline/util/generate-makefile.py
@@ -47,7 +47,7 @@ def main():
 
     for (ds,alist) in artifacts_by_dataset.items():
         generate_targets(ds, alist)
-        
+
     targets = [all_files(ds) for ds in artifacts_by_dataset.keys()]
     rule('all_targets', targets)
 
@@ -117,7 +117,7 @@ def generate_targets(ds, alist):
     rule(ttl(ds),"{} $(ONT_MERGED)".format(filtered_gaf(ds)),
          'MINERVA_CLI_MEMORY=16G minerva-cli.sh $(ONT_MERGED) --gaf $< --gaf-lego-individuals --skip-merge --format turtle -o $@.tmp && mv $@.tmp $@')
     rule(inferred_ttl(ds), "{} $(ONT_MERGED)".format(ttl(ds)),
-        "mkdir -p target/inferred\n\texport JAVA_OPTS=\"-Xmx$(RDFOX_MEM)\" && rdfox-cli --ontology=$(ONT_MERGED) --rules=rules.dlog --data=$(<D) --threads=24 --reason --export=$@ --inferred-only --excluded-properties=exclude.txt")
+        "mkdir -p target/inferred\n\tarachne --ontology=$(ONT_MERGED) --data=$(<D) --export=$@ --inferred-only")
 
 
 def create_targetdir(ds):


### PR DESCRIPTION
So this assumes we have `arachne` on the path. Not sure if that's the direction we want to go. Also, this PR only currently works with a change I made to arachne that's not released yet that only grabs .ttl files in the folder supplied by the --data option. So we should wait to merge this until Jim can look at my other PR, merge, and then release a new arachne.