### PR TITLE
fixing ontobio path to use virtual environment

### DIFF
--- a/pipeline/Makefile
+++ b/pipeline/Makefile
@@ -44,15 +44,6 @@ proc:
 	./util/dataset-metadata-processor.py $(METADATA_DIR)/*.yaml
 
 # ----------------------------------------
-# Install Virtualenv
-# ----------------------------------------
-PY_ENV=target/env
-
-$(PY_ENV):
-	python3 -m venv $(PY_ENV)
-
-
-# ----------------------------------------
 # OWLTools checks
 # ----------------------------------------
 
@@ -76,10 +67,9 @@ OWLTOOLS_GAFCHECK = owltools $(CATALOG_DETAILS) $(GAF_OWL) \
 # Makefile for building GAFs
 # ----------------------------------------
 # this defines 'all_targets'
-target/Makefile: ./util/generate-makefile.py $(PY_ENV)
+target/Makefile: ./util/generate-makefile.py
 	mkdir -p target
-	$(PY_ENV)/bin/pip3 install -r requirements.txt
-	$(PY_ENV)/bin/python3 $< ../metadata/datasets/*.yaml > $@.tmp && mv $@.tmp $@
+	python3 $< ../metadata/datasets/*.yaml > $@.tmp && mv $@.tmp $@
 
 include target/Makefile
 

--- a/pipeline/environment.sh
+++ b/pipeline/environment.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+python3 -m venv target/env
+. target/env/bin/activate
+
+pip3 install -r requirements.txt

--- a/pipeline/util/generate-makefile.py
+++ b/pipeline/util/generate-makefile.py
@@ -109,7 +109,7 @@ def generate_targets(ds, alist):
         rule(src_gaf_zip(ds),[targetdir(ds)],
              'wget --no-check-certificate {url} -O $@.tmp && mv $@.tmp $@ && touch $@'.format(url=url))
     rule(filtered_gaf(ds),src_gaf_zip(ds),
-         'gzip -dcf $< > {src_gaf}\n\ttarget/env/bin/ontobio-parse-assocs.py --filter-out IEA -f {src_gaf} -o {filtered_gaf} -m {target}{ds}.report validate'.format(src_gaf=src_gaf(ds), filtered_gaf=filtered_gaf(ds), target=targetdir(ds), ds=ds))
+         'gzip -dcf $< > {src_gaf}\n\tontobio-parse-assocs.py --filter-out IEA -f {src_gaf} -o {filtered_gaf} -m {target}{ds}.report validate'.format(src_gaf=src_gaf(ds), filtered_gaf=filtered_gaf(ds), target=targetdir(ds), ds=ds))
     rule(owltools_gafcheck(ds),filtered_gaf(ds),
          '$(OWLTOOLS_GAFCHECK)')
     rule(filtered_gpad(ds),filtered_gaf(ds),

--- a/pipeline/util/generate-makefile.py
+++ b/pipeline/util/generate-makefile.py
@@ -109,7 +109,7 @@ def generate_targets(ds, alist):
         rule(src_gaf_zip(ds),[targetdir(ds)],
              'wget --no-check-certificate {url} -O $@.tmp && mv $@.tmp $@ && touch $@'.format(url=url))
     rule(filtered_gaf(ds),src_gaf_zip(ds),
-         'gzip -dcf $< > {src_gaf}\n\tontobio-parse-assocs.py --filter-out IEA -f {src_gaf} -o {filtered_gaf} -m {target}{ds}.report validate'.format(src_gaf=src_gaf(ds), filtered_gaf=filtered_gaf(ds), target=targetdir(ds), ds=ds))
+         'gzip -dcf $< > {src_gaf}\n\ttarget/env/bin/ontobio-parse-assocs.py --filter-out IEA -f {src_gaf} -o {filtered_gaf} -m {target}{ds}.report validate'.format(src_gaf=src_gaf(ds), filtered_gaf=filtered_gaf(ds), target=targetdir(ds), ds=ds))
     rule(owltools_gafcheck(ds),filtered_gaf(ds),
          '$(OWLTOOLS_GAFCHECK)')
     rule(filtered_gpad(ds),filtered_gaf(ds),


### PR DESCRIPTION
This was working if you had `activate`d your virtual environment. But in a make system, like we would have Jenkins, we won't be `activate`ing the venv. So we need to make all calls to installed python in the virtual env at `target/env/bin` so I corrected our invocation of `ontobio-parse-assocs.py`. This should help the jenkins build.