### PR TITLE
Changed species code in xenbase.yaml.

### DIFF
--- a/metadata/datasets/xenbase.yaml
+++ b/metadata/datasets/xenbase.yaml
@@ -19,7 +19,7 @@ datasets:
    source: ftp://ftp.xenbase.org/pub/GenePageReports/xenbase.gpi.gz
    entity_type: 
    status: active
-   species_code: Xtr, Xla
+   species_code: Xenopus
    taxa:
     - NCBITaxon:8364
     - NCBITaxon:8355


### PR DESCRIPTION
Changed dual species codes, 'Xtr, Xla', into single higher level genus, 'Xenopus', to fix issue with processing metadata in pipeline for generating NEO. 