### PR TITLE
Add TAIR:Communication: to db-xrefs.yaml

### DIFF
--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -3227,3 +3227,13 @@
       url_syntax: http://purl.obolibrary.org/obo/plana/references/[example_id]
       example_id: "0000001"
       example_url: http://purl.obolibrary.org/obo/plana/references/0000001
+- database: PROQUEST
+  name: Proquest Dissertations Publishing
+  generic_urls:
+    - http://www.proquest.com
+  entity_types:
+    - type_name: entity
+      type_id: BET:0000000
+      url_syntax: https://search.proquest.com/docview/[example_id]
+      example_id: PROQUEST:1426182399
+      example_url: https://search.proquest.com/docview/1426182399

--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -2819,6 +2819,12 @@
       url_syntax: http://arabidopsis.org/servlets/TairObject?accession=[example_id]
       example_id: TAIR:locus:2146653
       example_url: http://arabidopsis.org/servlets/TairObject?accession=locus:2146653
+    - type_name: communication
+      type_id: BET:0000000
+      id_syntax: Communication:[0-9]{7,12}
+      url_syntax: http://arabidopsis.org/servlets/TairObject?type=communication&id=[example_id]
+      example_id: TAIR:Communication:1345790
+      example_url: http://arabidopsis.org/servlets/TairObject?type=communication&id=1345790
 - database: taxon
   name: NCBI Taxonomy
   synonyms:

--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -3227,13 +3227,3 @@
       url_syntax: http://purl.obolibrary.org/obo/plana/references/[example_id]
       example_id: "0000001"
       example_url: http://purl.obolibrary.org/obo/plana/references/0000001
-- database: PROQUEST
-  name: Proquest Dissertations Publishing
-  generic_urls:
-    - http://www.proquest.com
-  entity_types:
-    - type_name: entity
-      type_id: BET:0000000
-      url_syntax: https://search.proquest.com/docview/[example_id]
-      example_id: PROQUEST:1426182399
-      example_url: https://search.proquest.com/docview/1426182399


### PR DESCRIPTION
I'm not 100% sure I did this right, but I tried to follow what was done for TAIR:gene and TAIR:locus.  We found that we had a few reference links with TAIR:Communication and wanted them added to db-xrefs.yaml.  Should also point out that links in AmiGO seem to work without this added, but for other downstream projects thought this should be added.