### PR TITLE
sparql implementation for gorule 8

### DIFF
--- a/metadata/rules/gorule-0000008.md
+++ b/metadata/rules/gorule-0000008.md
@@ -27,6 +27,35 @@ implementations:
              'GO:0048585', 'GO:0048584', 'GO:0048583', 'GO:0001071', 'GO:0000988')
     language: SQL
     source: ~
+  - language: sparql
+    code: |-
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX oboinowl: <http://www.geneontology.org/formats/oboInOwl#>
+      PREFIX go: <http://purl.obolibrary.org/obo/go#>
+      PREFIX metago: <http://geneontology.org/>
+      PREFIX owl: <http://www.w3.org/2002/07/owl#>
+
+      SELECT ?s ?p ?o ?too_high ?gaf
+      WHERE {
+        VALUES ?dont_annotate { go:gocheck_do_not_manually_annotate go:gocheck_do_not_annotate }
+
+        ?too_high oboinowl:inSubset ?dont_annotate .
+
+        GRAPH ?gaf {
+          # ?gaf metago:graphType metago:gafCam .
+
+          ?s ?p ?o .
+          ?b owl:annotatedSource ?s ;
+             owl:annotatedTarget ?o ;
+             owl:annotatedProperty ?p .
+
+          ?b <http://geneontology.org/lego/evidence> ?e .
+
+          ?o a ?too_high .
+        }
+      }
+
 ---
 Some terms are too high-level to provide useful information when used
 for annotation, regardless of the evidence code used.


### PR DESCRIPTION
This sparql query will find all classes that have the do_not_annotate properties on them. Then, any annotations or ?sub ?pred ?obj where the ?obj is one of the do_not_annotate classes represents a violation of this rule.