### PR TITLE
Update users.yaml

### DIFF
--- a/metadata/users.yaml
+++ b/metadata/users.yaml
@@ -601,9 +601,9 @@
 -
   uri: 'GOC:aruk'
   xref: 'GOC:aruk'
-  nickname: 'Annotation of amyloid-beta binding proteins'
+  nickname: 'Annotation of proteins associated with dementia'
   organization: ARUK-UCL
-  comment: "Annotation of amyloid-beta binding proteins, funded by Alzheimer's Research UK"
+  comment: "Annotation of proteins associated with dementia, funded by Alzheimer's Research UK"
 -
   nickname: 'Aleksandra Shypitsyna'
   email-md5:


### PR DESCRIPTION
Updated nickname and comment of "GOC:aruk" to reflect shift of funding focus (from amyloid-beta binding proteins to, more generally, proteins associated with dementia).