### PR TITLE
added zfin.gpi information in the ZFIN yaml

### DIFF
--- a/metadata/datasets/zfin.yaml
+++ b/metadata/datasets/zfin.yaml
@@ -23,3 +23,18 @@ datasets:
    taxa:
     - NCBITaxon:7955
 
+ -    
+   id: zfin.gpi
+   label: "zfin gpi file"
+   description: "gpi file for zfin from Zebrafish Information Network"
+   url: http://geneontology.org/gene-associations/zfin.gpi.gz
+   type: gpi
+   dataset: zfin
+   submitter: zfin
+   compression: gzip
+   source: https://zfin.org/downloads/zfin.gpi.gz 
+   entity_type: 
+   status: active
+   species_code: Drer
+   taxa:
+    - NCBITaxon:7955


### PR DESCRIPTION
The previous gpi information which I submitted in October was missing in this file (?).
I have added this information.
Note that compared to the previous version, we now have a compressed version of the file.