### PR TITLE
Use ROBOT instead of riot for JSON-LD conversion.

### DIFF
--- a/scripts/yaml2turtle.sh
+++ b/scripts/yaml2turtle.sh
@@ -11,6 +11,7 @@ contextyaml=$1
 inputyaml=$2 
 outputttl=$3
 tmpfile=`mktemp`.jsonld
+echo "Using temp file: $tmpfile"
 echo '{"@context": ' >$tmpfile
 yaml2json $contextyaml >>$tmpfile
 echo ', "@graph": ' >>$tmpfile

--- a/scripts/yaml2turtle.sh
+++ b/scripts/yaml2turtle.sh
@@ -2,16 +2,18 @@
 
 # This script will convert a YAML file to Turtle format,
 # given a JSON-LD context, also in YAML format.
+# Since ROBOT is used, other file extensions for the output 
+# can select other formats in addition to Turtle.
 # Run: ./yaml2turtle.sh context.yaml data.yaml data.ttl
 
 contextyaml=$1
 # expected to have an array at the root
 inputyaml=$2 
 outputttl=$3
-tmpfile=`mktemp`
+tmpfile=`mktemp`.jsonld
 echo '{"@context": ' >$tmpfile
 yaml2json $contextyaml >>$tmpfile
 echo ', "@graph": ' >>$tmpfile
 yaml2json $inputyaml >>$tmpfile
-echo '}' >>$tmpfile 
-riot --syntax=jsonld --output=turtle $tmpfile >$outputttl
+echo '}' >>$tmpfile
+robot convert -i $tmpfile -o $outputttl


### PR DESCRIPTION
Change JSON-LD conversion script to use ROBOT. This removes the dependency on Jena tools, as requested in https://github.com/geneontology/pipeline/issues/11.