### PR TITLE
Paint merged

### DIFF
--- a/metadata/datasets/paint.yaml
+++ b/metadata/datasets/paint.yaml
@@ -2,7 +2,7 @@ id: paint
 label: PAINT
 description: "GO data for PAINT"
 datasets:
- -    
+ -
    id: paint_cgd.gaf
    label: "paint_cgd gaf file"
    description: "gaf file for paint_cgd from PAINT"
@@ -12,14 +12,14 @@ datasets:
    submitter: paint
    compression: gzip
    source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_cgd.gaf.gz
-   entity_type: 
+   entity_type:
    status: active
-   species_code: 
+   species_code:
    taxa:
     - NCBITaxon:5476
    merges_into: cgd
-   
- -    
+
+ -
    id: paint_dictybase.gaf
    label: "paint_dictybase gaf file"
    description: "gaf file for paint_dictybase from PAINT"
@@ -29,7 +29,7 @@ datasets:
    submitter: paint
    compression: gzip
    source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_dictyBase.gaf.gz
-   entity_type: 
+   entity_type:
    status: active
    species_code: Ddis
    taxa:
@@ -38,8 +38,8 @@ datasets:
     - NCBITaxon:44689
     - NCBITaxon:5782
    merges_into: dictybase
-   
- -    
+
+ -
    id: paint_ecocyc.gaf
    label: "paint_ecocyc gaf file"
    description: "gaf file for paint_ecocyc from PAINT"
@@ -49,14 +49,14 @@ datasets:
    submitter: paint
    compression: gzip
    source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_ecocyc.gaf.gz
-   entity_type: 
+   entity_type:
    status: active
-   species_code: 
+   species_code:
    taxa:
     - NCBITaxon:83333
    merges_into: ecocyc
-   
- -    
+
+ -
    id: paint_fb.gaf
    label: "paint_fb gaf file"
    description: "gaf file for paint_fb from PAINT"
@@ -66,14 +66,14 @@ datasets:
    submitter: paint
    compression: gzip
    source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_fb.gaf.gz
-   entity_type: 
+   entity_type:
    status: active
    species_code: Dmel
    taxa:
     - NCBITaxon:7227
    merges_into: fb
-   
- -    
+
+ -
    id: paint_goa_chicken.gaf
    label: "paint_goa_chicken gaf file"
    description: "gaf file for paint_goa_chicken from PAINT"
@@ -85,11 +85,11 @@ datasets:
    source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_chicken.gaf.gz
    entity_type: chicken
    status: active
-   species_code: 
+   species_code:
    taxa:
-   merges_into: goa
-   
- -    
+   merges_into: goa_chicken
+
+ -
    id: paint_goa_human.gaf
    label: "paint_goa_human gaf file"
    description: "gaf file for paint_goa_human from PAINT"
@@ -101,11 +101,11 @@ datasets:
    source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_human.gaf.gz
    entity_type: human
    status: active
-   species_code: 
+   species_code:
    taxa:
-   merges_into: goa
-   
- -    
+   merges_into: goa_human
+
+ -
    id: paint_mgi.gaf
    label: "paint_mgi gaf file"
    description: "gaf file for paint_mgi from PAINT"
@@ -115,14 +115,14 @@ datasets:
    submitter: paint
    compression: gzip
    source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_mgi.gaf.gz
-   entity_type: 
+   entity_type:
    status: active
    species_code: Mmus
    taxa:
     - NCBITaxon:10090
    merges_into: mgi
-   
- -    
+
+ -
    id: paint_other.gaf
    label: "paint_other gaf file"
    description: "gaf file for paint_other from PAINT"
@@ -132,13 +132,13 @@ datasets:
    submitter: paint
    compression: gzip
    source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_other.gaf.gz
-   entity_type: 
+   entity_type:
    status: active
-   species_code: 
+   species_code:
    taxa:
    merges_into: other
-   
- -    
+
+ -
    id: paint_pombase.gaf
    label: "paint_pombase gaf file"
    description: "gaf file for paint_pombase from PAINT"
@@ -148,15 +148,15 @@ datasets:
    submitter: paint
    compression: gzip
    source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_pombase.gaf.gz
-   entity_type: 
+   entity_type:
    status: active
    species_code: Spom
    taxa:
     - NCBITaxon:284812
     - NCBITaxon:4896
    merges_into: pombase
-   
- -    
+
+ -
    id: paint_rgd.gaf
    label: "paint_rgd gaf file"
    description: "gaf file for paint_rgd from PAINT"
@@ -166,14 +166,14 @@ datasets:
    submitter: paint
    compression: gzip
    source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_rgd.gaf.gz
-   entity_type: 
+   entity_type:
    status: active
    species_code: Rnor
    taxa:
     - NCBITaxon:10116
    merges_into: rgd
-   
- -    
+
+ -
    id: paint_sgd.gaf
    label: "paint_sgd gaf file"
    description: "gaf file for paint_sgd from PAINT"
@@ -183,7 +183,7 @@ datasets:
    submitter: paint
    compression: gzip
    source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_sgd.gaf.gz
-   entity_type: 
+   entity_type:
    status: active
    species_code: Scer
    taxa:
@@ -193,8 +193,8 @@ datasets:
     - NCBITaxon:4932
     - NCBITaxon:559292
    merges_into: sgd
-   
- -    
+
+ -
    id: paint_tair.gaf
    label: "paint_tair gaf file"
    description: "gaf file for paint_tair from PAINT"
@@ -204,14 +204,14 @@ datasets:
    submitter: paint
    compression: gzip
    source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_tair.gaf.gz
-   entity_type: 
+   entity_type:
    status: active
    species_code: Atal
    taxa:
     - NCBITaxon:3702
    merges_into: tair
-   
- -    
+
+ -
    id: paint_wb.gaf
    label: "paint_wb gaf file"
    description: "gaf file for paint_wb from PAINT"
@@ -221,14 +221,14 @@ datasets:
    submitter: paint
    compression: gzip
    source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_wb.gaf.gz
-   entity_type: 
+   entity_type:
    status: active
    species_code: Cele
    taxa:
     - NCBITaxon:6239
    merges_into: wb
-   
- -    
+
+ -
    id: paint_zfin.gaf
    label: "paint_zfin gaf file"
    description: "gaf file for paint_zfin from PAINT"
@@ -238,10 +238,9 @@ datasets:
    submitter: paint
    compression: gzip
    source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_zfin.gaf.gz
-   entity_type: 
+   entity_type:
    status: active
    species_code: Drer
    taxa:
     - NCBITaxon:7955
    merges_into: zfin
-   

--- a/pipeline/Makefile
+++ b/pipeline/Makefile
@@ -111,6 +111,10 @@ target/groups/goa_uniprot_all/goa_uniprot_all.gaf.gz: target/alltaxons.txt targe
 target/alltaxons.txt:
 	python3 util/model_organism.py taxons ../metadata/datasets/ --out target/alltaxons.txt
 
+target/merged:
+	python3 util/paint_merge.py merge ../metadata/datasets/paint.yaml target/groups/
+	touch target/merged
+
 # ----------------------------------------
 # Makefile for building GAFs
 # ----------------------------------------
@@ -160,7 +164,7 @@ BG_PROPERTIES = conf/blazegraph.properties
 LOAD_TARGETS = $(ONT_MERGED) target/rdf target/noctua-models/models
 
 
-target/blazegraph.jnl: $(BGJAR) target/rdf target/noctua-models
+target/blazegraph.jnl: target/merged $(BGJAR) target/rdf target/noctua-models
 	blazegraph-runner --journal=target/blazegraph.jnl --properties=conf/blazegraph.properties load --use-ontology-graph $(LOAD_TARGETS)
 	blazegraph-runner --journal=target/blazegraph.jnl --properties=conf/blazegraph.properties reason --source-graphs-query=$(CAM_GRAPH_QUERY) --ontology=$(GO_GRAPHSTORE_URI) --append-graph-name="_inferred"
 

--- a/pipeline/util/paint_merge.py
+++ b/pipeline/util/paint_merge.py
@@ -29,6 +29,14 @@ def merges_into_path(merges_into, groups_dir):
     return os.path.abspath(os.path.join(groups_dir, merges_into, merge_into_gaf))
 
 def append_zip_into_zip(merger, merge_into):
+    if not os.path.exists(merger):
+        click.echo(click.style("{} does not exist, skipping".format(merger), fg="red"), err=True)
+        return
+
+    if not os.path.exists(merge_into):
+        click.echo(click.style("{} does not exist, skipping".format(merge_into), fg="red"), err=True)
+        return
+
     base, leaf = os.path.split(merge_into)
     merged_leaf = leaf.split(".gaf.gz")[0] + "_merged.gaf.gz"
     final = os.path.join(base, merged_leaf)

--- a/pipeline/util/paint_merge.py
+++ b/pipeline/util/paint_merge.py
@@ -1,0 +1,45 @@
+import click
+import os
+import yaml
+import gzip
+import shutil
+
+@click.group()
+def cli():
+    pass
+
+@cli.command()
+@click.argument("paint_metadata", type=click.File("r"))
+@click.argument("groups_dir", type=click.Path(exists=True))
+def merge(paint_metadata, groups_dir):
+    metapaint = yaml.load(paint_metadata)
+    merger_groups = metapaint["datasets"]
+    merge_data = { dataset_id_to_path(dataset["id"], groups_dir): merges_into_path(dataset["merges_into"], groups_dir) for dataset in merger_groups if dataset["merges_into"] != "other" }
+
+    for paint_gaf, mod_gaf in merge_data.items():
+        click.echo("merging {} into {}".format(paint_gaf, mod_gaf))
+        append_zip_into_zip(paint_gaf, mod_gaf)
+
+def dataset_id_to_path(dataset_id, groups_dir):
+    paint_dir = dataset_id.split(".")[0]
+    return os.path.abspath(os.path.join(groups_dir, paint_dir, "{}.gz".format(dataset_id)))
+
+def merges_into_path(merges_into, groups_dir):
+    merge_into_gaf = "{}.gaf.gz".format(merges_into)
+    return os.path.abspath(os.path.join(groups_dir, merges_into, merge_into_gaf))
+
+def append_zip_into_zip(merger, merge_into):
+    base, leaf = os.path.split(merge_into)
+    merged_leaf = leaf.split(".gaf.gz")[0] + "_merged.gaf.gz"
+    final = os.path.join(base, merged_leaf)
+
+    final_zip = gzip.GzipFile(final, mode="w")
+    merger_zip = gzip.GzipFile(merger)
+    merge_into_zip = gzip.GzipFile(merge_into)
+
+    final_zip.write(merge_into_zip.read())
+    final_zip.write(merger_zip.read())
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
So this has a script that merges the paint gaf zips (defined by the metadata) into the corresponding mod gaf zips. This produces a product `target/groups/{mod}/{mod_merged}.gaf.gz`. I produced a separate file just so that we can filter how we grab our data products. 