### PR TITLE
makefile go-ontology dependency fix

### DIFF
--- a/pipeline/Makefile
+++ b/pipeline/Makefile
@@ -92,7 +92,7 @@ RDF_GEN = $(PY_BIN)/rdfgen.py
 	rm $*.gaf
 	gzip -f $*.gpi
 
-%_cam.ttl: %.gaf.gz $(ONT_MERGED)
+%_cam.ttl: %.gaf.gz $(ONT_MERGED) target/go-ontology.json
 	gzip -dcf  $< > $*.gaf
 	python3 $(RDF_GEN) convert -a gaf -r target/go-ontology.json -o $*_cam.ttl $*.gaf
 	gzip -cf $@ > $@.gz


### PR DESCRIPTION
Latest master pipeline run failed due to go-ontology.json not downloading. There were some dependencies in the Makefile that weren't completely filled out, but always work in the main runs. This is better, as it is more correct, and clearer, besides fixing the issue in the last master build. 