### PR TITLE
Add goref-0000115 to describe GO ncRNA annotation via RNAcentral and Rfam

### DIFF
--- a/metadata/gorefs/goref-0000115.md
+++ b/metadata/gorefs/goref-0000115.md
@@ -1,0 +1,20 @@
+--- 
+authors: RNAcentral (1). (1) European Bioinformatics Institute (EMBL-EBI), Hinxton, Cambridgeshire, United Kingdom
+id: GO_REF:0000115
+year: 2018
+layout: goref
+---
+
+## Automatic Gene Ontology annotation of non-coding RNA sequences through association of Rfam records with GO terms.
+
+Rfam (http://rfam.org, PMID:29112718) is a database of non-coding RNA families which are manually
+annotated with GO terms by Rfam curators. RNAcentral (http://rnacentral.org, PMID:27794554) maintains
+a comprehensive collection of non-coding RNA sequences that are regularly annotated with Rfam families
+using the Infernal software (PMID:24008419). When a non-coding RNA sequence is matched to one or more Rfam families
+by sequence similarity, the GO terms associated with the Rfam family are transitively assigned to the non-coding RNA sequence.
+Annotations resulting from the transfer of GO terms are assigned the ECO:0000256 evidence code
+(match to sequence model evidence used in automatic assertion) and include RNAcentral and Rfam accessions. 
+The annotations are available on the GOA and EMBL-EBI FTP sites. 
+The mapping between Rfam families and GO terms is available at http://www.geneontology.org/external2go/rfam2go, 
+and the Infernal software can be downloaded at http://eddylab.org/infernal. To report an annotation error or inconsistency, 
+or for further information, please visit the RNAcentral website at http://rnacentral.org.


### PR DESCRIPTION
## Background

[RNAcentral](http://rnacentral.org) is a comprehensive database of ncRNA sequences that integrates [27 specialised resources](http://rnacentral.org/expert-databases) and assigns unique and stable [identifiers](http://rnacentral.org/help#rnacentral-identifiers) to all sequences. The sequences are regularly annotated with [Rfam](http://rfam.org) families, which are associated with GO terms through literature curation. As a result, the GO terms from Rfam families can be automatically assigned to RNAcentral sequences by transitivity ([ECO:0000256](https://www.ebi.ac.uk/QuickGO/term/ECO:0000256)).

## Why create goref-0000115?

A new goref is required to describe how the GO terms are added to RNAcentral sequences. Once it is available, @tonysawfordebi, @blakesweeney, and myself will set up a pipeline to provide GO annotations of ncRNA sequences to GOA. 

Please let me know if you have any feedback. Thank you for looking into this! 