### PR TITLE
Update GO annotations for L. major and T. brucei

### DIFF
--- a/metadata/datasets/genedb.yaml
+++ b/metadata/datasets/genedb.yaml
@@ -16,7 +16,7 @@ datasets:
    dataset: genedb_lmajor
    submitter: genedb
    compression: gzip
-   source: http://geneontology.org/gene-associations/submission/gene_association.GeneDB_Lmajor.gz
+   source: ftp://ftp.sanger.ac.uk/pub/project/pathogens/gff3/CURRENT/Lmajor.gaf
    entity_type: 
    status: active
    species_code: 
@@ -48,7 +48,7 @@ datasets:
    dataset: genedb_tbrucei
    submitter: genedb
    compression: gzip
-   source: http://geneontology.org/gene-associations/submission/gene_association.GeneDB_Tbrucei.gz
+   source: ftp://ftp.sanger.ac.uk/pub/project/pathogens/gff3/CURRENT/Tbruceibrucei927.gaf
    entity_type: 
    status: active
    species_code: 


### PR DESCRIPTION
Source URLs have been changed for these two organisms and you can pull the data for these from the respective ftp links.