### PR TITLE
Updated file set & source locations

### DIFF
--- a/metadata/datasets/dictybase.yaml
+++ b/metadata/datasets/dictybase.yaml
@@ -7,17 +7,53 @@ project_url: "http://dictybase.org"
 funding_source: "NIH (NIGMS and NHGRI)"
 email_report: "dictybase@northwestern.edu"
 datasets:
- -    
+ -
+   id: dictybase.gpa
+   label: "dictybase gpad file"
+   description: "gpad file for dictyBase from dictyBase"
+   url: http://geneontology.org/gpad-gpi/release/dictyBase.gpa.gz
+   type: gpad
+   dataset: dictybase
+   submitter: dictybase
+   compression: gzip
+   source: ftp://ftp.ebi.ac.uk/pub/contrib/goa/dictyBase.gpa.gz
+   entity_type:
+   status: active
+   species_code: Ddis
+   taxa:
+    - NCBITaxon:352472
+    - NCBITaxon:366501
+    - NCBITaxon:44689
+    - NCBITaxon:5782
+ -
+   id: dictybase.gpi
+   label: "dictybase gpi file"
+   description: "gpi file for dictyBase from dictyBase"
+   url: http://geneontology.org/gpad-gpi/release/dictyBase.gpi.gz
+   type: gpi
+   dataset: dictybase
+   submitter: dictybase
+   compression: gzip
+   source: ftp://ftp.ebi.ac.uk/pub/contrib/goa/dictyBase.gpa.gz
+   entity_type:
+   status: active
+   species_code: Ddis
+   taxa:
+    - NCBITaxon:352472
+    - NCBITaxon:366501
+    - NCBITaxon:44689
+    - NCBITaxon:5782
+ -
    id: dictybase.gaf
    label: "dictybase gaf file"
    description: "gaf file for dictybase from dictyBase"
-   url: http://geneontology.org/gene-associations/gene_association.dictyBase.gz
+   url: http://geneontology.org/gene-associations/dictyBase.gaf.gz
    type: gaf
    dataset: dictybase
    submitter: dictybase
    compression: gzip
-   source: http://geneontology.org/gene-associations/submission/gene_association.dictyBase.gz
-   entity_type: 
+   source: ftp://ftp.ebi.ac.uk/pub/contrib/goa/dictyBase.gaf.gz
+   entity_type:
    status: active
    species_code: Ddis
    taxa:


### PR DESCRIPTION
As a temporary measure, until dictyBase have finalised the updates to their database, GOA are generating a GPAD, GPI, and GAF file on their behalf. These files are located on the GOA ftp site, and are updated weekly.