### PR TITLE
invalid db-xrefs.yaml

### DIFF
--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -1783,7 +1783,7 @@
       example_id: MGD:Adcy9
 - database: MGI
   name: Mouse Genome Informatics
-  rdf_uri_prefix: http://identifiers.org/mgi/MGI:
+  rdf_uri_prefix: "http://identifiers.org/mgi/MGI:"
   generic_urls:
     - http://www.informatics.jax.org/
   entity_types:


### PR DESCRIPTION
Please can you fix this invalid yaml, you can't have an unquoted string ending in : 

e.g.   rdf_uri_prefix: http://identifiers.org/mgi/MGI:

http://yaml-online-parser.appspot.com/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgeneontology%2Fgo-site%2Fmaster%2Fmetadata%2Fdb-xrefs.yaml