### PR TITLE
fixing how rule validation works so rule error will be caught by travis

### DIFF
--- a/graphstore/rule-runner/rulerunner/main.py
+++ b/graphstore/rule-runner/rulerunner/main.py
@@ -164,7 +164,11 @@ def load_yamldown(path):
     """
     try:
         with open(path, "r") as f:
-            return yamldown.load(f)[0]
+            load = yamldown.load(f)[0]
+            if load == None:
+                raise click.ClickException("No rule present at {}".format(path))
+
+            return load
 
     except Exception as e:
         raise click.ClickException(str(e))

--- a/metadata/rules/gorule-0000032.md
+++ b/metadata/rules/gorule-0000032.md
@@ -1,1 +1,11 @@
+---
+layout: rule
+id: GORULE:0000031
+title: "Annotation relations are replaced when not provided by source."
+type: repair
+fail_mode: hard
+status: implemented
+contact: "go-quality@mailman.stanford.edu"
+implementations:
+---
 GO_REF Collection References allowed for each ECO are as follows:


### PR DESCRIPTION
This will make sure that a validation error occurs when there is no yaml in the yamldown, and is just straight text.