### PR TITLE
Update rgd.yaml

### DIFF
--- a/metadata/datasets/rgd.yaml
+++ b/metadata/datasets/rgd.yaml
@@ -16,7 +16,7 @@ datasets:
    dataset: rgd
    submitter: rgd
    compression: gzip
-   source: http://geneontology.org/gene-associations/submission/gene_association.rgd.gz
+   source: https://github.com/rat-genome-database/rgd-annotation-files/blob/master/gene_association.rgd.gz
    entity_type:
    status: active
    species_code: Rnor


### PR DESCRIPTION
As of Oct 12, 2018, we will provide the current (weekly) file of rat GO annotations in GAF format at RGD github site. 

The file http://geneontology.org/gene-associations/submission/gene_association.rgd.gz will not be updated any longer.