### PR TITLE
adding a pass, fail, and repair schema to go rule yaml portions

### DIFF
--- a/metadata/rules.schema.yaml
+++ b/metadata/rules.schema.yaml
@@ -94,6 +94,9 @@ mapping:
                 type: str
                 required: true
                 enum: ["rdf", "gaf", "gpad"]
-              "instance":
+              "input":
+                type: str
+                required: true
+              "output":
                 type: str
                 required: true

--- a/metadata/rules.schema.yaml
+++ b/metadata/rules.schema.yaml
@@ -45,3 +45,55 @@ mapping:
           "code":
             type: str
             required: false
+  "examples":
+    type: map
+    required: false
+    mapping:
+      "pass":
+        type: seq
+        required: false
+        sequence:
+          - type: map
+            mapping:
+              "comment":
+                type: str
+                required: true
+              "format":
+                type: str
+                required: true
+                enum: ["rdf", "gaf", "gpad"]
+              "instance":
+                type: str
+                required: true
+      "fail":
+        type: seq
+        required: false
+        sequence:
+          - type: map
+            mapping:
+              "comment":
+                type: str
+                required: true
+              "format":
+                type: str
+                required: true
+                enum: ["rdf", "gaf", "gpad"]
+              "instance":
+                type: str
+                required: true
+      "repair":
+        type: seq
+        required: false
+        sequence:
+          - type: map
+            mapping:
+              "comment":
+                type: str
+                required: true
+              "format":
+                type: str
+                required: true
+                enum: ["rdf", "gaf", "gpad"]
+              "instance":
+                type: str
+                required: true


### PR DESCRIPTION
This is for https://github.com/geneontology/go-site/issues/956. 

The only difference I've done in the schema implementation is to have the key called `repair` rather than transform. If `repair` is agreeable (since that's the language we use for that type of rule already), then this is good. Otherwise I can always change it to previously used `transform`.