### PR TITLE
Issue 1003 yamlmatter and consequences

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
    - sudo apt-get install -y python3 -qq
    - sudo apt-get install -y python3-yaml -qq
    - sudo apt-get install -y python3-pip -qq
+   - sudo apt-get install -y mmv
    - sudo pip3 install typing
    - sudo pip3 install graphstore/rule-runner
 
@@ -28,6 +29,9 @@ script:
   - kwalify -E -f metadata/datasets.schema.yaml metadata/datasets/*.yaml 2>&1 | tee out.log && grep 'INVALID\|ERROR' out.log; test $? -ne 0
   - sparta valid --rules metadata/rules/ --schema metadata/rules.schema.yaml
   - python3 ./scripts/sanity-check-users-and-groups.py --verbose --users metadata/users.yaml --groups metadata/groups.yaml; test $? -eq 0
+  ## Somewhat awkwardly reuse sparta to check non-go-rules files that
+  ## are still structured yamldown/frontmatter.
+  - mkdir -p /tmp/foo && mcp 'metadata/gorefs/goref-0000*' '/tmp/foo/gorule-0000#1' && sparta valid --rules /tmp/foo/ --schema metadata/gorefs.schema.yaml
 notifications:
   email:
     - sjcarbon@lbl.gov

--- a/metadata/gorefs.schema.yaml
+++ b/metadata/gorefs.schema.yaml
@@ -1,0 +1,43 @@
+type: map
+mapping:
+  "layout":
+    type: str
+    required: true
+    enum: [goref]
+  "id":
+    type: str
+    required: true
+    pattern: /GO_REF:[0-9]{7}/
+  "authors":
+    type: str
+    required: true
+  "year":
+    type: number
+    required: false
+  "external_accession":
+    type: seq
+    required: false
+    sequence:
+      - type: str
+        required: false
+        pattern: /[a-zA-Z\_]+:[0-9a-zA-Z\_]+/
+  "alt_id":
+    type: seq
+    required: false
+    sequence:
+      - type: str
+        required: false
+        pattern: /GO_REF:[0-9]{7}/
+  # "alt_id":
+  #   type: str
+  #   required: false
+  #   pattern: /GO_REF:[0-9]{7}/
+  "url":
+    type: str
+    required: false
+  "citation":
+    type: str
+    required: false
+  "is_obsolete":
+    type: bool
+    required: false

--- a/metadata/gorefs/goref-0000006.md
+++ b/metadata/gorefs/goref-0000006.md
@@ -1,11 +1,11 @@
 ---
 authors: Mouse Genome Informatics scientific curators
 citation: "PMID:11374909"
-external_accession: 
+external_accession:
   - MGI:2152097
   - J:72246
 id: "GO_REF:0000006"
-is_obsolete: 'true'
+is_obsolete: True
 year: 2001
 layout: goref
 ---

--- a/metadata/gorefs/goref-0000029.md
+++ b/metadata/gorefs/goref-0000029.md
@@ -1,10 +1,12 @@
 ---
 authors: GOA-UniProt curators
 id: "GO_REF:0000029"
-year: 2001-2007
+year: 2007
 layout: goref
 ---
 
 ## Gene Ontology annotation based on information extracted from curated UniProtKB entries
+
+Active 2001-2007.
 
 Method by which GO terms were manually assigned to UniProt KnowledgeBase accessions, using either a NAS or TAS evidence code, by applying information extracted from the corresponding publicly-available, manually curated UniProtKB entry. Such GO annotations were submitted by the GOA-UniProt group from 2001, but this annotation practice was discontinued in 2007.

--- a/metadata/gorefs/goref-0000033.md
+++ b/metadata/gorefs/goref-0000033.md
@@ -1,11 +1,10 @@
 ---
 authors: Pascale Gaudet, Michael Livstone, Paul Thomas, The Reference Genome Project
-external_accession: 
+external_accession:
   - SGD_REF:S000146947
   - TAIR:Communication:501741973
   - MGI:MGI:4459044
   - "J:161428 "
-  - PAINT_REF:[0-9]{7}
   - ZFIN:ZDB-PUB-110330-1
   - FB:FBrf0232076
 id: "GO_REF:0000033"

--- a/metadata/gorefs/goref-0000051.md
+++ b/metadata/gorefs/goref-0000051.md
@@ -1,10 +1,12 @@
 ---
 authors: PomBase curators
 id: "GO_REF:0000051"
-year: 2006-2012
+year: 2012
 layout: goref
 ---
 
 ## S. pombe keyword mapping
+
+Active 2006-2012.
 
 Keywords derived from manually curated primary annotation, e.g. gene product descriptions, are mapped to GO terms. Annotations made by this method have the evidence code Non-traceable Author Statement (NAS), and are filtered from the PomBase annotation files wherever another annotation exists that is equally or more specific, and supported by experimental or manually evaluated comparative evidence (such as ISS and its subtypes). Formerly GOC:pombekw2GO.

--- a/metadata/gorefs/goref-0000111.md
+++ b/metadata/gorefs/goref-0000111.md
@@ -1,5 +1,6 @@
 ---
-external_accession: 
+authors: TBD
+external_accession:
   - FB:FBrf0233689
 id: "GO_REF:0000111"
 year: 2016


### PR DESCRIPTION
As part of the larger program to get GO.references reflecting reality again (see https://github.com/geneontology/go-site/issues/993), we want to have some schema checking on the gorefs. This effort continues with (https://github.com/geneontology/go-site/compare/issue-1003-yamlmatter), but it appears that several of the gorefs do not follow the proposed new schema.

I'd like a review to both okay the schema and the (fairly minimal) changes to the gorefs so that we can proceed with #993 .

