### PR TITLE
adding schema for a list of tags in rules, only allowing gzip if any for datasets

### DIFF
--- a/metadata/datasets.schema.yaml
+++ b/metadata/datasets.schema.yaml
@@ -79,6 +79,7 @@ mapping:
             type: str
             required: false
             unique: false
+            enum: ['', gzip]
           "source":
             type: str
             required: false

--- a/metadata/rules.schema.yaml
+++ b/metadata/rules.schema.yaml
@@ -27,6 +27,13 @@ mapping:
     type: str
     required: true
     enum: ["hard", "soft"]
+  "tags":
+    type: seq
+    required: false
+    sequence:
+      - type: str
+        pattern: /[a-zA-Z_][\w]*/
+        unique: true
   "issues":
     required: false
     type: any

--- a/metadata/rules/gorule-0000026.md
+++ b/metadata/rules/gorule-0000026.md
@@ -5,6 +5,7 @@ title: IBA annotations must have been sourced from the PAINT inference pipeline
 type: filter
 fail_mode: hard
 status: implemented
+tags: [silent]
 contact: "go-quality@mailman.stanford.edu"
 ---
 This seeks to filter out paint annotations that have leaked into the main mod GAF
@@ -12,6 +13,6 @@ sources. In this way, we only have these paint annotations coming directly from
 paint.
 
 If the GAF file being validated is not paint, and the line has evidence IBA,
-then throw out that line. 
+then throw out that line.
 
 See also GORULE:0000037

--- a/pipeline/Makefile
+++ b/pipeline/Makefile
@@ -129,7 +129,7 @@ target/groups/goa/goa_uniprot_all-owltools-check.txt: target/groups/goa/goa_unip
 GOA_UNIPROT_ALL_URL ?= $(shell grep -A 10 "id: goa_uniprot_all.gaf" ../metadata/datasets/goa.yaml | grep source: | awk '{ print $$2 }')
 target/groups/goa/goa_uniprot_all-src.gaf.gz:
 	mkdir -p target/groups/goa
-	wget --retry-connrefused --waitretry=10 -t 10 --no-check-certificate $(GOA_UNIPROT_ALL_URL) -O $@.tmp && mv $@.tmp $@
+	wget -nv --retry-connrefused --waitretry=10 -t 10 --no-check-certificate $(GOA_UNIPROT_ALL_URL) -O $@.tmp && mv $@.tmp $@
 
 target/alltaxons.txt:
 	python3 util/model_organism.py taxons ../metadata/datasets/ --out target/alltaxons.txt


### PR DESCRIPTION
Precursor for silencing gorule 26. Also adds the change so only gzip or empty is allowed for the `compression` field in datasets.