### PR TITLE
adding allowed evidence to gorefs schema

### DIFF
--- a/metadata/gorefs.schema.yaml
+++ b/metadata/gorefs.schema.yaml
@@ -28,6 +28,12 @@ mapping:
       - type: str
         required: false
         pattern: /GO_REF:[0-9]{7}/
+  "evidence_codes":
+    type: seq
+    required: false
+    sequence:
+      - type: str
+        pattern: /ECO:[0-9]{7}/
   # "alt_id":
   #   type: str
   #   required: false


### PR DESCRIPTION
This adds machine readable yaml for the go references for allowed ECO IDs used with a particular GO_REF. https://github.com/geneontology/go-site/issues/790#issuecomment-425160398