### PR TITLE
New Xenbase GO curator and contact detail information

### DIFF
--- a/metadata/group-contacts.csv
+++ b/metadata/group-contacts.csv
@@ -126,6 +126,7 @@ USC,Dustin Ebert,@dustine32,PAINT pipeline
 WormBase,Kimberly Van Auken,@vanaukenk,C.elegans
 Wikidata,Andrew Su,@andrewsu,
 Wikidata,Derek,@djow2019 ,
+Xenbase,Malcolm Fisher,@malcolmfisher103,Xenopus
 ZFIN,Sabrina Toro,@sabrinatoro,Zebra fish
 ZFIN,Doug Howe,@doughowe,Zebra fish
 Domain expert,,@khybiske,Chlamydia

--- a/metadata/users.yaml
+++ b/metadata/users.yaml
@@ -3113,6 +3113,20 @@
   nickname: 'Malcolm Fisher'
   organization: Xenbase
   uri: 'http://orcid.org/0000-0003-1074-8103'
+- 
+   accounts:
+    github: Xenbase2
+  authorizations:
+    noctua:
+      go:
+        allow-edit: true
+  email-md5:
+    - 
+  groups:
+    - 'http://www.xenbase.org'
+  nickname: 'Christina James-Zorn'
+  organization: Xenbase
+  uri: 'http://orcid.org/0000-0001-5495-4588'
 -
   accounts:
     github: chris-grove

--- a/metadata/users.yaml
+++ b/metadata/users.yaml
@@ -3114,7 +3114,7 @@
   organization: Xenbase
   uri: 'http://orcid.org/0000-0003-1074-8103'
 - 
-   accounts:
+  accounts:
     github: Xenbase2
   authorizations:
     noctua:


### PR DESCRIPTION
I would like to add another curator from Xenbase with Noctua editing privileges. The curator is Christina James-Zorn, who is coming to the Cambridge GO meeting and who I am trying to get her up to speed on using Noctua. Where can I submit her actual email? I added the 'email-md5' field but I have left it empty.

This commit also includes the addition of myself as a Xenbase contact to 'group-contacts.csv'.