### PR TITLE
fixing broken zip product in goa_uniprot_all

### DIFF
--- a/pipeline/Makefile
+++ b/pipeline/Makefile
@@ -93,6 +93,7 @@ GOA_UNIPROT_ALL = target/groups/goa/goa_uniprot_all_noiea.gpi target/groups/goa/
 # target/groups/goa/goa_uniprot_all.gaf.gz
 target/groups/goa/goa_uniprot_all_noiea.gaf: target/alltaxons.txt target/groups/goa/goa_uniprot_all-src.gaf.gz
 	gzip -dcf target/groups/goa/goa_uniprot_all-src.gaf.gz | ./util/goa_filter -v report=target/groups/goa/goa_uniprot_all_skipped.report -v noiea=target/groups/goa/goa_uniprot_all_noiea.gaf > target/groups/goa/goa_uniprot_all.gaf.tmp
+	mv target/groups/goa/goa_uniprot_all.gaf.tmp target/groups/goa/goa_uniprot_all.gaf
 	gzip -cf target/groups/goa/goa_uniprot_all.gaf > target/groups/goa/goa_uniprot_all.gaf.gz
 	gzip -cf target/groups/goa/goa_uniprot_all_noiea.gaf > target/groups/goa/goa_uniprot_all_noiea.gaf.gz
 


### PR DESCRIPTION
For finishing off https://github.com/geneontology/pipeline/issues/93

This correctly `mv`s the .tmp file into the real named file, that the gzip command is expecting.

This was not caught because there were stale products already existing with the right name from older local builds on my machine.