### PR TITLE
removing taxon:4081 from sgn metadata

### DIFF
--- a/metadata/datasets/sgn.yaml
+++ b/metadata/datasets/sgn.yaml
@@ -21,4 +21,3 @@ datasets:
    status: active
    species_code: Solanaceae
    taxa:
-    - NCBITaxon:4081


### PR DESCRIPTION
Here's the change to remove NCBITaxon:4081 from sgn to stop filtering taxon:4081 from goa_uniprot_all.