### PR TITLE
Update go logo URLs

### DIFF
--- a/scripts/downloads-page-template.html
+++ b/scripts/downloads-page-template.html
@@ -17,7 +17,7 @@
     <!-- <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"> -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <link rel="shortcut icon" href="http://geneontology.org/sites/default/files/go-logo-favicon_0.ico" type="image/vnd.microsoft.icon" />
+    <link rel="shortcut icon" href="http://geneontology.org/assets/go-logo-favicon.ico" type="image/vnd.microsoft.icon" />
     <link rel="shortcut icon" href="logo-circle.ico">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.datatables.net/1.10.13/css/jquery.dataTables.min.css" crossorigin="anonymous">
@@ -38,7 +38,7 @@
       </button>
 
       <a class="navbar-brand" href="index.html#home">
-    	<img src="http://geneontology.org/sites/default/files/go-logo-icon.mini__0.png" height="30" class="d-inline-block align-top" alt="">
+    	<img src="http://geneontology.org/assets/go-logo-icon.mini.png" height="30" class="d-inline-block align-top" alt="">
     	Gene Ontology Consortium
       </a>
 


### PR DESCRIPTION
This template was using old URLs no longer available since the Drupal switch to GH pages