### PR TITLE
Deleted KEGG parent

### DIFF
--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -1588,13 +1588,6 @@
       url_syntax: http://www.jstor.org/stable/[example_id]
       example_id: JSTOR:3093870
       example_url: http://www.jstor.org/stable/3093870
-- database: KEGG
-  name: Kyoto Encyclopedia of Genes and Genomes
-  generic_urls:
-    - http://www.genome.ad.jp/kegg/
-  entity_types:
-    - type_name: entity
-      type_id: BET:0000000
 - database: KEGG_ENZYME
   name: KEGG Enzyme Database
   rdf_uri_prefix: http://identifiers.org/kegg.enzyme/


### PR DESCRIPTION
The KEGG parent database did not have any URL to link to, so I deleted it (following 2019-08-19 ontology call).