### PR TITLE
Update dbxrefs.yaml for WB identifiers, URLs

### DIFF
--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -3291,22 +3291,34 @@
   entity_types:
     - type_name: gene
       type_id: SO:0000704
-      id_syntax: (WP:CE[0-9]{5})|(WB(Gene|Var|RNAi|Transgene)[0-9]{8})
-      url_syntax: http://www.wormbase.org/db/gene/gene?name=[example_id]
+      id_syntax: (CE[0-9]{5})|(WB(Gene|Var|RNAi|Transgene)[0-9]{8})
+      url_syntax: http://www.wormbase.org/get?name=[example_id]
       example_id: WB:WBGene00003001
-      example_url: http://www.wormbase.org/db/get?class=Gene;name=WBGene00003001
+      example_url: http://www.wormbase.org/get?name=WBGene00003001
     - type_name: variation
       type_id: VariO:0001
-      id_syntax: (WP:CE[0-9]{5})|(WB(Gene|Var|RNAi|Transgene)[0-9]{8})
-      url_syntax: http://www.wormbase.org/db/gene/gene?name=[example_id]
-      example_id: WB:WBGene00003001
-      example_url: http://www.wormbase.org/db/get?class=Gene;name=WBGene00003001
+      id_syntax: (CE[0-9]{5})|(WB(Gene|Var|RNAi|Transgene)[0-9]{8})
+      url_syntax: http://www.wormbase.org/get?name=[example_id]
+      example_id: WB:WBVar00089843
+      example_url: http://www.wormbase.org/get?name=WBVar00089843
+    - type_name: RNAi
+      type_id: 
+      id_syntax: (CE[0-9]{5})|(WB(Gene|Var|RNAi|Transgene)[0-9]{8})
+      url_syntax: http://www.wormbase.org/get?name=[example_id]
+      example_id: WB:WBRNAi00110325
+      example_url: http://www.wormbase.org/get?name=WBRNAi00110325
+    - type_name: Transgene
+      type_id: SO:0000902
+      id_syntax: (CE[0-9]{5})|(WB(Gene|Var|RNAi|Transgene)[0-9]{8})
+      url_syntax: http://www.wormbase.org/get?name=[example_id]
+      example_id: WB:WBTransgene00000059
+      example_url: http://www.wormbase.org/get?name=WBTransgene00000059
     - type_name: protein
       type_id: PR:000000001
-      id_syntax: (WP:CE[0-9]{5})|(WB(Gene|Var|RNAi|Transgene)[0-9]{8})
-      url_syntax: http://www.wormbase.org/db/gene/gene?name=[example_id]
-      example_id: WB:WBGene00003001
-      example_url: http://www.wormbase.org/db/get?class=Gene;name=WBGene00003001
+      id_syntax: (CE[0-9]{5})|(WB(Gene|Var|RNAi|Transgene)[0-9]{8})
+      url_syntax: http://www.wormbase.org/get?name=[example_id]
+      example_id: WB:CE00274
+      example_url: http://www.wormbase.org/get?name=CE00274
 - database: WB_REF
   name: WormBase database of nematode biology
   generic_urls:

--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -3302,7 +3302,7 @@
       example_id: WB:WBVar00089843
       example_url: http://www.wormbase.org/get?name=WBVar00089843
     - type_name: RNAi
-      type_id: 
+      type_id: topic:3523 
       id_syntax: (CE[0-9]{5})|(WB(Gene|Var|RNAi|Transgene)[0-9]{8})
       url_syntax: http://www.wormbase.org/get?name=[example_id]
       example_id: WB:WBRNAi00110325


### PR DESCRIPTION
@kltm 
I've updated the entries for the WB URLs and IDs.
Three things to check with you, though:
1) I don't have a type_id for RNAi.  These identifiers refer to curated RNAi experiments but searching for 'RNAi experiment' on Ontobee uncovered this:  http://bioportal.bioontology.org/ontologies/EDAM?p=classes&conceptid=topic_3523
Would that possibly work?
2) The example IDs are in the format WB:blah but the actual example URL strips the WB which means that in the URL syntax we're not really using the full example_id.  Is that okay?
3) I did update the id_syntax wrt the protein identifiers because we no longer use the WP: prefix in WB so these would definitely not be correct.  Please let me know, though, if I should revert these back.
Thx.