### PR TITLE
Update gorule 33 description to say that it only reports

### DIFF
--- a/metadata/rules/gorule-0000033.md
+++ b/metadata/rules/gorule-0000033.md
@@ -10,6 +10,6 @@ implementations:
   - language: python
     source: https://github.com/biolink/ontobio/blob/master/ontobio/io/assocparser.py
 ---
-IDs in the Reference field should only be only from PMID, PMC, doi, or GO_REF. Group specific References will be filtered if there is also an accepted public ID. For example, if FB:FBrf0159398 and GO_REF:0000015 are both found, the FB ID will be removed. If only the group ID exists, a warning will be issued.
+IDs in the Reference field should only be only from PMID, PMC, doi, or GO_REF. Group specific References will be reported on if there is also an accepted public ID. For example, if FB:FBrf0159398 and GO_REF:0000015 are both found, the FB ID will be reported. Similarly, if only the group ID exists, a warning will be issued.
 
 The list of GO_REFs are here: https://github.com/geneontology/go-site/tree/master/metadata/gorefs.


### PR DESCRIPTION
The current version of the rule says that we repair and remove bad refs, but we don't, and the rule type is a report only, so the description should not claim that we repair or modify the annotation in any way.