### PR TITLE
Update downloads-page-template.html

### DIFF
--- a/scripts/downloads-page-template.html
+++ b/scripts/downloads-page-template.html
@@ -257,8 +257,7 @@
 	      The Gene Ontology Consortium is supported by a P41 grant
 	      from the National Human Genome Research Institute (NHGRI)
 	      [grant <a href="http://projectreporter.nih.gov/project_info_description.cfm?aid=8641714&amp;icde=0"
-			rel="external" title="National Human Genome Research
-					      Institute grant 5U41HG002273-14">5U41HG002273-14</a>]. The
+			rel="external" title="National Human Genome Research Institute grant 5U41HG002273-14">5U41HG002273-14</a>]. The
 	      Gene Ontology Consortium would like to acknowledge the
 	      assistance of many more people than can be listed
 	      here. Please visit

--- a/scripts/downloads-page-template.html
+++ b/scripts/downloads-page-template.html
@@ -245,8 +245,7 @@
 		4.0</a>)<br /><a href="http://help.geneontology.org/"
 				 title="Contact the GO helpdesk">Helpdesk</a>
 	      • <a href="http://geneontology.org/page/go-citation-policy"
-		   title="How to cite the GO
-			  project">Citation/attribution</a>
+		   title="How to cite the GO project">Citation/attribution</a>
 	      • <a href="http://geneontology.org/page/use-and-license"
 		   title="Terms of use for the GO project">Terms of use</a><br /> Member of
 	      the <a href="http://www.obofoundry.org/" rel="external"

--- a/scripts/downloads-page-template.html
+++ b/scripts/downloads-page-template.html
@@ -242,15 +242,13 @@
 			   title="The Gene Ontology project website">the Gene
 		Ontology</a>
 	      (<a href="http://geneontology.org/page/use-and-license">CC-BY
-		4.0</a>)<br /><a href="http://geneontology.org/form/contact-go"
+		4.0</a>)<br /><a href="http://help.geneontology.org/"
 				 title="Contact the GO helpdesk">Helpdesk</a>
 	      • <a href="http://geneontology.org/page/go-citation-policy"
 		   title="How to cite the GO
 			  project">Citation/attribution</a>
 	      • <a href="http://geneontology.org/page/use-and-license"
-		   title="Terms of use for the GO project">Terms of use</a>
-	      • <a href="http://geneontology.org/rss.xml" title="GO News
-								 RSS feed">RSS</a><br /> Member of
+		   title="Terms of use for the GO project">Terms of use</a><br /> Member of
 	      the <a href="http://www.obofoundry.org/" rel="external"
 		     title="Open Biological and Biomedical Ontologies">Open
 		Biological and Biomedical Ontologies</a>
@@ -265,8 +263,7 @@
 	      Gene Ontology Consortium would like to acknowledge the
 	      assistance of many more people than can be listed
 	      here. Please visit
-	      the <a href="http://geneontology.org/page/go-acknowledgements">acknowledgements
-		page</a> for the full list.
+	      the <a href="http://geneontology.org/docs/annotation-contributors/">annotation contributors page</a> for the full list.
 	    </small>
 	  </p>
 


### PR DESCRIPTION
https://github.com/geneontology/geneontology.github.io/issues/184

Couple more changes to footer:

Footer link on "Helpdesk" currently 404s, should go to http://help.geneontology.org/
Footer link to RSS 404s, should be removed
Footer link to "acknowledgements page" currently 404s, should go to http://geneontology.org/docs/annotation-contributors/