### PR TITLE
change instance to input, like in the repair portion of the schema

### DIFF
--- a/metadata/rules.schema.yaml
+++ b/metadata/rules.schema.yaml
@@ -69,7 +69,7 @@ mapping:
                 type: str
                 required: true
                 enum: ["rdf", "gaf", "gpad"]
-              "instance":
+              "input":
                 type: str
                 required: true
       "fail":
@@ -85,7 +85,7 @@ mapping:
                 type: str
                 required: true
                 enum: ["rdf", "gaf", "gpad"]
-              "instance":
+              "input":
                 type: str
                 required: true
       "repair":


### PR DESCRIPTION
The failing and passing example keys use `instance` currently, but the repair examples use `input` and `output`. Each example should use the same key name, and input seems apt.