### PR TITLE
adding rules example to travis check with runner script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
    - sudo pip3 install pyyaml
    - sudo pip3 install typing
    - sudo pip3 install graphstore/rule-runner
+   - sudo pip3 install -r pipeline/requirements.txt
 
 ## Possible other way.
 install:
@@ -32,6 +33,7 @@ script:
   ## Somewhat awkwardly reuse sparta to check non-go-rules files that
   ## are still structured yamldown/frontmatter.
   - mkdir -p /tmp/foo && mcp 'metadata/gorefs/goref-0000*' '/tmp/foo/gorule-0000#1' && sparta valid --rules /tmp/foo/ --schema metadata/gorefs.schema.yaml
+  - ./scripts/rule-example-validation.sh
 notifications:
   email:
     - sjcarbon@lbl.gov

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ before_install:
    - sudo pip3 install typing
    - sudo pip3 install graphstore/rule-runner
    - docker pull geneontology/dev-base:latest
-   - sudo pip3 install -r pipeline/requirements.txt
-
 ## Possible other way.
 install:
   - gem install kwalify

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
   ## Somewhat awkwardly reuse sparta to check non-go-rules files that
   ## are still structured yamldown/frontmatter.
   - mkdir -p /tmp/foo && mcp 'metadata/gorefs/goref-0000*' '/tmp/foo/gorule-0000#1' && sparta valid --rules /tmp/foo/ --schema metadata/gorefs.schema.yaml
-  - docker run -it -v $(pwd):/tmp/go-site -w /tmp/go-site geneontology/dev-base:latest /bin/bash -c "pip3 install -r pipeline/requirements.txt && ./script/rule-example-validation.sh"
+  - docker run -it -v $(pwd):/tmp/go-site -w /tmp/go-site geneontology/dev-base:latest /bin/bash -c "pip3 install -r pipeline/requirements.txt && ./scripts/rule-example-validation.sh"
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ rvm: "1.9.3"
 dist: trusty
 sudo: required
 
+services:
+  - docker
+
 before_install:
    - sudo apt-get update -qq
    - sudo apt-get install -y python3 -qq
@@ -12,6 +15,7 @@ before_install:
    - sudo pip3 install pyyaml
    - sudo pip3 install typing
    - sudo pip3 install graphstore/rule-runner
+   - docker pull geneontology/dev-base:latest
    - sudo pip3 install -r pipeline/requirements.txt
 
 ## Possible other way.
@@ -33,7 +37,8 @@ script:
   ## Somewhat awkwardly reuse sparta to check non-go-rules files that
   ## are still structured yamldown/frontmatter.
   - mkdir -p /tmp/foo && mcp 'metadata/gorefs/goref-0000*' '/tmp/foo/gorule-0000#1' && sparta valid --rules /tmp/foo/ --schema metadata/gorefs.schema.yaml
-  - ./scripts/rule-example-validation.sh
+  - docker run -it -v $(pwd):/tmp/go-site -w /tmp/go-site geneontology/dev-base:latest /bin/bash -c "pip3 install -r pipeline/requirements.txt && ./script/rule-example-validation.sh"
+
 notifications:
   email:
     - sjcarbon@lbl.gov

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,3 +1,3 @@
 PyYAML
-ontobio==1.12.1
+ontobio==1.13.1
 click

--- a/scripts/rule-example-validation.sh
+++ b/scripts/rule-example-validation.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -x
+
+test_dir=/tmp/test-$(date +%Y-%m-%dT%H%M%S)
+mkdir $test_dir
+wget http://snapshot.geneontology.org/ontology/go.json -O $test_dir/go-ontology.json
+validate.py rule --metadata metadata/ --ontology $test_dir/go-ontology.json --out $test_dir/out.json
+cat $test_dir/out.json
+validate_exit=$?
+rm -rf $test_dir
+
+exit $validate_exit


### PR DESCRIPTION
For https://github.com/geneontology/go-site/issues/970
- adds a script to run the rule example validations
- updates ontobio version to 1.13.1
- runs the script as a part of the travis checks in go-site