### PR TITLE
update sgn url to include gzip

### DIFF
--- a/metadata/datasets/sgn.yaml
+++ b/metadata/datasets/sgn.yaml
@@ -16,7 +16,7 @@ datasets:
    dataset: sgn
    submitter: sgn
    compression: gzip
-   source: ftp://ftp.solgenomics.net/ontology/GO/gene_association.sgn
+   source: ftp://ftp.solgenomics.net/ontology/GO/gene_association.sgn.gz
    entity_type:
    status: active
    species_code: Solanaceae


### PR DESCRIPTION
The url ftp://ftp.solgenomics.net/ontology/GO/gene_association.sgn.gz seems to be the correct one now.