### PR TITLE
adding option in downloader that will unzip and zip all sources

### DIFF
--- a/pipeline/Makefile
+++ b/pipeline/Makefile
@@ -64,7 +64,7 @@ SUPPRESS_THESE_TAGS = $(foreach tag,$(GORULE_TAGS_TO_SUPPRESS),--suppress-rule-r
 %.sources:
 	# See comment in %.groups on this construct
 	$(eval group := $(lastword $(subst /, ,$*)))
-	python3 ../scripts/download_source_gafs.py group $(group) -d $(METADATA_DIR)/datasets --target target/groups/$(group) --type gaf $(DONT_VALIDATE) --replace false
+	python3 ../scripts/download_source_gafs.py group $(group) -d $(METADATA_DIR)/datasets --target target/groups/$(group) --type gaf $(DONT_VALIDATE) --replace false --zip-unzip
 	touch $*.sources
 
 .PRECIOUS: %.gaferences.json


### PR DESCRIPTION
so I know we don't strictly need this now, but I was most of the way done when SGN got back to us.

This adds an option to the downloader that will unzip all zipped, and zip all unzipped upstream sources as they are downloaded. This is what is then passed on to gaferencer and ontobio.

Accompanying Makefile change.