### PR TITLE
Fixed SGN entity type 

### DIFF
--- a/metadata/datasets/sgn.yaml
+++ b/metadata/datasets/sgn.yaml
@@ -17,7 +17,7 @@ datasets:
    submitter: sgn
    compression: gzip
    source: ftp://ftp.solgenomics.net/ontology/GO/gene_association.sgn.gz
-   entity_type:
+   entity_type: gene
    status: active
    species_code: Solanaceae
    taxa: 


### PR DESCRIPTION
Checked in AmiGO: all SGN entities are of type 'gene'