### PR TITLE
Removed GDB fixes #619

### DIFF
--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -941,16 +941,6 @@
       type_id: BET:0000000
       id_syntax: \d{7}
       example_id: FYPO:0000001
-- database: GDB
-  name: Human Genome Database
-  generic_urls:
-    - http://www.gdb.org/
-  entity_types:
-    - type_name: entity
-      type_id: BET:0000000
-      url_syntax: http://www.gdb.org/gdb-bin/genera/accno?accessionNum=GDB:[example_id]
-      example_id: GDB:306600
-      example_url: http://www.gdb.org/gdb-bin/genera/accno?accessionNum=GDB:306600
 - database: GenBank
   name: GenBank
   description: The NIH genetic sequence database, an annotated collection of all publicly available DNA sequences.


### PR DESCRIPTION
Used to be Human Genome Database - PMC147203
See https://en.wikipedia.org/wiki/GDB_Human_Genome_Database
Defunct.