### PR TITLE
Updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Any of the files here can be edited via the [go-site page on github](https://git
 
 The location of all core GO-related metadata. Most notably:
 
- - [db-xrefs.yaml](metadata/db-xrefs.yaml) - prefix registry
+ - [db-xrefs.yaml](metadata/db-xrefs.yaml) - prefix registry, for anything that is col1 of a GAF, or the prefix of a CURIE/Identifier
  - [users.yaml](metadata/users.yaml) - metadata on GOC members and contributors
- - [groups.yaml](metadata/groups.yaml) - metadata on GOC groups
+ - [groups.yaml](metadata/groups.yaml) - metadata on GOC groups, for anything that cann be the value of a 'contributor' or 'assigned_by'
  - [datasets/](metadata/datasets/) - metadata on contributed and released files
  - [rules/](metadata/rules/) - metadata on cGO annotation QC rules
 


### PR DESCRIPTION
> db-xrefs.yaml should be for anything that is col1 of a GAF, or the prefix of a CURIE/Identifier
> groups.yaml for anythig that cann be the value of a contributor or assigned_by

From https://github.com/geneontology/go-site/pull/1026