### PR TITLE
Added gaf and gpad files for Xenbase.

### DIFF
--- a/metadata/datasets/xenbase.yaml
+++ b/metadata/datasets/xenbase.yaml
@@ -7,51 +7,48 @@ project_url: "http://www.xenbase.org/"
 funding_source: "National Institute of Child Health and Human Development, grant P41 HD064556"
 email_report: "malcolm.fisher@cchmc.org"
 datasets:
- -
-   id: xenbase.gpi
-   label: "Xenbase gpi file"
-   description: "gpi file for Xenbase"
-   url: http://current.geneontology.org/annotations/xenbase.gpi.gz
-   type: gpi
-   dataset: xenbase
-   submitter: xenbase
-   compression: gzip
-   source: ftp://ftp.xenbase.org/pub/GenePageReports/xenbase.gpi.gz
-   entity_type:
-   status: active
-   species_code: Xenopus
-   taxa:
-    - NCBITaxon:8364
-    - NCBITaxon:8355
--
-   id: xenbase.gpad
-   label: "Xenbase gpad file"
-   description: "gpad file for Xenopus from Xenbase"
-   url: http://current.geneontology.org/annotations/xenbase.gpad.gz
-   type: gpad
-   dataset: xenbase
-   submitter: xenbase
-   compression: gzip
-   source: ftp://ftp.xenbase.org/pub/DataExchange/GO/xenbase.gpad.gz
-   entity_type:
-   status: active
-   species_code: Xenopus
-   taxa:
-    - NCBITaxon:8364
-    - NCBITaxon:8355
--
-   id: xenbase.gaf
-   label: "Xenbase gaf file"
-   description: "gaf file for Xenopus from Xenbase"
-   url: http://current.geneontology.org/annotations/xenbase.gaf.gz
-   type: gaf
-   dataset: xenbase
-   submitter: xenbase
-   compression: gzip
-   source: ftp://ftp.xenbase.org/pub/DataExchange/GO/xenbase.gaf.gz
-   entity_type:
-   status: active
-   species_code: Xenopus
-   taxa:
-    - NCBITaxon:8364
-    - NCBITaxon:8355
+  - id: xenbase.gpi
+    label: "Xenbase gpi file"
+    description: "gpi file for Xenbase"
+    url: http://current.geneontology.org/annotations/xenbase.gpi.gz
+    type: gpi
+    dataset: xenbase
+    submitter: xenbase
+    compression: gzip
+    source: ftp://ftp.xenbase.org/pub/GenePageReports/xenbase.gpi.gz
+    entity_type:
+    status: active
+    species_code: Xenopus
+    taxa:
+      - NCBITaxon:8364
+      - NCBITaxon:8355
+  - id: xenbase.gpad
+    label: "Xenbase gpad file"
+    description: "gpad file for Xenopus from Xenbase"
+    url: http://current.geneontology.org/annotations/xenbase.gpad.gz
+    type: gpad
+    dataset: xenbase
+    submitter: xenbase
+    compression: gzip
+    source: ftp://ftp.xenbase.org/pub/DataExchange/GO/xenbase.gpad.gz
+    entity_type:
+    status: active
+    species_code: Xenopus
+    taxa:
+      - NCBITaxon:8364
+      - NCBITaxon:8355
+  - id: xenbase.gaf
+    label: "Xenbase gaf file"
+    description: "gaf file for Xenopus from Xenbase"
+    url: http://current.geneontology.org/annotations/xenbase.gaf.gz
+    type: gaf
+    dataset: xenbase
+    submitter: xenbase
+    compression: gzip
+    source: ftp://ftp.xenbase.org/pub/DataExchange/GO/xenbase.gaf.gz
+    entity_type:
+    status: active
+    species_code: Xenopus
+    taxa:
+      - NCBITaxon:8364
+      - NCBITaxon:8355

--- a/metadata/datasets/xenbase.yaml
+++ b/metadata/datasets/xenbase.yaml
@@ -11,6 +11,7 @@ datasets:
    id: xenbase.gpi
    label: "Xenbase gpi file"
    description: "gpi file for Xenbase"
+   url: http://current.geneontology.org/annotations/xenbase.gpad.gz
    type: gpi
    dataset: xenbase
    submitter: xenbase

--- a/metadata/datasets/xenbase.yaml
+++ b/metadata/datasets/xenbase.yaml
@@ -11,7 +11,7 @@ datasets:
    id: xenbase.gpi
    label: "Xenbase gpi file"
    description: "gpi file for Xenbase"
-   url: http://current.geneontology.org/annotations/xenbase.gpad.gz
+   url: http://current.geneontology.org/annotations/xenbase.gpi.gz
    type: gpi
    dataset: xenbase
    submitter: xenbase

--- a/metadata/datasets/xenbase.yaml
+++ b/metadata/datasets/xenbase.yaml
@@ -22,3 +22,35 @@ datasets:
    taxa:
     - NCBITaxon:8364
     - NCBITaxon:8355
+-
+   id: xenbase.gpad
+   label: "Xenbase gpad file"
+   description: "gpad file for Xenopus from Xenbase"
+   url: http://current.geneontology.org/annotations/xenbase.gpad.gz
+   type: gpad
+   dataset: xenbase
+   submitter: xenbase
+   compression: gzip
+   source: ftp://ftp.xenbase.org/pub/DataExchange/GO/xenbase.gpad.gz
+   entity_type:
+   status: active
+   species_code: Xenopus
+   taxa:
+    - NCBITaxon:8364
+    - NCBITaxon:8355
+-
+   id: xenbase.gaf
+   label: "Xenbase gaf file"
+   description: "gaf file for Xenopus from Xenbase"
+   url: http://current.geneontology.org/annotations/xenbase.gaf.gz
+   type: gaf
+   dataset: xenbase
+   submitter: xenbase
+   compression: gzip
+   source: ftp://ftp.xenbase.org/pub/DataExchange/GO/xenbase.gaf.gz
+   entity_type:
+   status: active
+   species_code: Xenopus
+   taxa:
+    - NCBITaxon:8364
+    - NCBITaxon:8355


### PR DESCRIPTION
This adds the requisite metadata for the GOC pipeline to pick up the annotation files produced by Xenbase. 

I hope this is all correct. I'm not sure if I should have added the destination URL for the 'current.geneontology.org' site, I was using the zfin.yaml file as a template.

There are some discrepancies between the contents of the Xenbase gaf and gpad files, due to issues converting noctua annotations to gaf format, but that shouldn't affect the metadata here at all and hopefully both files will be in better sync in the near future.