### PR TITLE
Add IAO to db-xrefs.

### DIFF
--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -1161,6 +1161,12 @@
   entity_types:
     - type_name: entity
       type_id: BET:0000000
+- database: IAO
+  name: Information Artifact Ontology
+  description: Ontology of information entities, including ontology metadata relations.
+  rdf_uri_prefix: http://purl.obolibrary.org/obo/IAO_
+  generic_urls:
+    - http://purl.obolibrary.org/obo/iao
 - database: IMG
   name: Integrated Microbial Genomes; JGI web site for genome annotation
   generic_urls:


### PR DESCRIPTION
I am adding two IAO relations to the GO ontology ('editor note' and 'term tracker item') at @pgaudet's request. It seems like IAO needs to be added here for one of the ontology checks to pass.