### PR TITLE
adding shex reports page gen and template

### DIFF
--- a/scripts/shex-reports-page-gen.py
+++ b/scripts/shex-reports-page-gen.py
@@ -1,0 +1,175 @@
+# python3 ./scripts/shex-reports-page-gen.py --report ./pipeline-report.json --template ./scripts/shex-reports-page-template.html --date 2019-03-26 > shex-report.html
+
+import click
+import pystache
+import json
+import datetime
+import yamldown
+import os
+import glob
+
+this_script = os.path.abspath(__file__)
+
+# 1) Wrap blog in single item list
+# 2) add `id` field to blob
+
+
+@click.command()
+@click.option("--report", type=click.File("r"), required=True)
+@click.option("--template", type=click.File("r"), required=True)
+@click.option("--date", default=str(datetime.date.today()))
+@click.option("--suppress-rule-tag", multiple=True)
+def main(report, template, date, suppress_rule_tag):
+    # Make the input json look more like the "combined report" from reports-page-gen.py
+    report_json = json.load(report)
+    report_json["id"] = "gocam"
+    report_json = [report_json]
+
+    # header:
+    # [
+    #     {"id": "mgi"},
+    #     {"id": "goa_chicken"}
+    #     ...
+    # ]
+    header = sorted([{"id": dataset["id"]} for dataset in report_json], key=lambda h: h["id"])
+    # click.echo(json.dumps(header, indent=4))
+
+    rules_directory = os.path.normpath(os.path.join(os.path.dirname(this_script), "../metadata/rules"))
+
+    rules_descriptions = dict()
+    # Rule Descriptions is a map of rule ID to a {"title": rule title, "tags": list of possible rule tags}
+    for rule_path in glob.glob(os.path.join(rules_directory, "gorule*.md")):
+        with open(rule_path) as rule_file:
+            rule = yamldown.load(rule_file)[0]
+            rule_id = rule["id"].lower().replace(":", "-")
+
+            rules_descriptions[rule_id] = {
+                "title": rule["title"],
+                "tags": rule.get("tags", [])
+            }
+
+
+    rule_by_dataset = dict()
+    # {
+    #     "gorule-0000005": {
+    #         "mgi": 30,
+    #         "sgd": 25,
+    #         "blah": 45
+    #     },
+    #     "gorule-0000006": {
+    #         "mgi": 20,
+    #         "sgd": 11
+    #     }
+    # }
+
+    # [
+    #     {
+    #         "rule": "gorule-0000005",
+    #         "dataset": [
+    #             {
+    #                 "id": "mgi",
+    #                 "messages": 20
+    #             }
+    #         ]
+    #     }
+    # ]
+    ###################################
+    # {
+    #     "gorule-0000005": {
+    #         "rule": "gorule-0000005",
+    #         "mgi": 20,
+    #         "sgd": 11,
+    #         "wb": 300
+    #     },
+    #     "other": {
+    #         "rule": "other",
+    #         "mgi": 25,
+    #         "sgd": 25,
+    #         "wb": 33
+    #     }
+    # }
+
+    bootstrap_context_mapping = {
+        "warning": "warning",
+        "error": "danger",
+        "info": "primary"
+    }
+
+    for dataset in report_json:
+        # Rule: rule ID, messages: List of each message from parsing
+        for rule, messages in dataset["messages"].items():
+            if any([tag in rules_descriptions.get(rule, {}).get("tags", []) for tag in suppress_rule_tag ]):
+                # For any that is passed in to be suppressed, if it is a tag in the rule, then skip the rule.
+                continue
+
+            # If we haven't added the rule, then add the messages, level, and rule ID to the value (keyed to the rule ID)
+            if rule not in rule_by_dataset:
+                level = messages[0]["level"].lower() if len(messages) > 0 else "info"
+                rule_by_dataset[rule] = {
+                    dataset["id"]: len(messages),
+                    "level": level,
+                    "rule": rule
+                }
+            else:
+                rule_by_dataset[rule][dataset["id"]] = len(messages)
+                # We can only increase `level`. If level is info, but messages are warn or error, than we reset.
+                # If level is warning, then only error will replace, since it's "higher".
+                if rule_by_dataset[rule]["level"] == "info" and len(messages) > 0 and messages[0]["level"].lower() in ["error", "warning"]:
+                    rule_by_dataset[rule]["level"] = messages[0]["level"].lower()
+                elif rule_by_dataset[rule]["level"] == "warning" and len(messages) > 0 and messages[0]["level"].lower() == "error":
+                    rule_by_dataset[rule]["level"] = "error"
+
+
+    # Add empty cells in as 0s
+    for h in header:
+        # h: {"id": "mgi"}
+        for rule, amounts in rule_by_dataset.items():
+            # rule: "gorule-0000006", amounts: {"mgi": 20, "sgd": 11, ...}
+            # If the header name (the dataset name) is not accounted in the amounts dict, add it as 0
+            if h["id"] not in amounts:
+                amounts[h["id"]] = 0
+
+    # Sort the list of rules -> {set of dataset:number of messages} by rule title (alphabet)
+    rows = sorted(rule_by_dataset.values(), key=lambda n: n["rule"])
+
+    # Each "cell" is actually a row in the table.
+    # Each `v` below is a cell contents along the row
+    cells = []
+    for row in rows:
+        contents = []
+        level = bootstrap_context_mapping[row["level"]]
+        for key, val in row.items():
+            if key == "rule":
+                continue
+
+            if key == "level":
+                continue
+
+            v = {
+                "dataset": key,
+                "amount": val,
+                "has-zero-messages": val==0,
+                "level": level if val > 0 else "primary"
+            }
+            contents.append(v)
+
+        contents = sorted(contents, key=lambda d: d["dataset"])
+        cell = {
+            "rule": row["rule"],
+            "title": rules_descriptions.get(row["rule"], {}).get("title", ""),
+            "messages": contents,
+            "is-other": row["rule"] == "other"
+        }
+        cells.append(cell)
+
+    # print(json.dumps(cells[0:4], indent=4))
+
+    rendered = pystache.render(template.read(), {"header": header, "rules": cells, "date": date})
+
+    print(rendered)
+    # rendered = Template(template.read()).render({"header": sorted(header, key=lambda n: n["id"]),
+    #     "rules": sorted(rule_by_dataset.values(), key=lambda n: n["rule"])})
+    # print(rendered)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/shex-reports-page-template.html
+++ b/scripts/shex-reports-page-template.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN"
+	  "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd">
+<html lang="en" dir="ltr"
+      xmlns:content="http://purl.org/rss/1.0/modules/content/"
+      xmlns:dc="http://purl.org/dc/terms/"
+      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      xmlns:og="http://ogp.me/ns#"
+      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+      xmlns:sioc="http://rdfs.org/sioc/ns#"
+      xmlns:sioct="http://rdfs.org/sioc/types#"
+      xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+
+    <head profile="http://www.w3.org/1999/xhtml/vocab">
+        <meta charset="utf-8"/>
+        <!-- <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"> -->
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <link rel="shortcut icon" href="http://geneontology.org/sites/default/files/go-logo-favicon_0.ico" type="image/vnd.microsoft.icon" />
+        <link rel="shortcut icon" href="logo-circle.ico">
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"></script>
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous"/>
+        <link rel="stylesheet" href="https://cdn.datatables.net/1.10.13/css/jquery.dataTables.min.css" crossorigin="anonymous"/>
+        <!-- <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.1.0/vue.js"></script> -->
+        <!-- <script type="text/javascript" src="RUD.bundle.js"></script> -->
+
+        <!-- <link rel="stylesheet" href="style.css"> -->
+
+        <title>Reports</title>
+
+        <script>
+        $(document).ready(function(){
+            $('[data-toggle="tooltip"]').tooltip();
+        });
+        </script>
+    </head>
+
+    <body>
+        <div class="container-fluid">
+        <h2 id="test">GO Rule Violations by Group Dataset</h2>
+        Generated on {{ date }}<br/>
+        <div class="table-responsive">
+        <table id="sourcestable" class="table table-sm table-striped rud-compact-table table-bordered table-hover">
+        <thead>
+            <tr>
+                <th scope="col">Rule</th>
+                {{ #header }}
+                <th scope="col"><a href="{{ id }}-report.html#rmd">{{ id }}</a></th>
+                {{ /header }}
+            </tr>
+        </thead>
+        <tbody>
+            {{ #rules }}
+            <tr>
+                <th scope="row" style="white-space: wrap;">
+                {{ #is-other }}
+                <p class="large">Other</p>
+                {{ /is-other }}
+                {{ ^is-other }}
+                <p class="small" style="white-space: wrap; font-weight: inherit; margin-bottom: 0rem; width: 32em;">{{ title }}: </br>
+                <u><a style="font-weight: bolder;" href="https://github.com/geneontology/go-site/blob/master/metadata/rules/{{ rule }}.md">{{ rule }}</a></u>
+                </p>
+                {{ /is-other }}
+                </th>
+                {{ #messages }}
+                <td class="table-{{ level }}">
+                    {{ #has-zero-messages }}
+                    {{ amount }}
+                    {{ /has-zero-messages }}
+                    {{ ^has-zero-messages }}
+                    <a href="{{ dataset }}-report.html#{{ rule }}" data-toggle="tooltip" data-html="true" data-placement="top" title="{{ dataset }}<br>{{ rule }}: ({{ title }})">{{ amount }}</a>
+                    {{ /has-zero-messages }}
+                </td>
+                {{ /messages }}
+            </tr>
+            {{ /rules }}
+        </tbody>
+        </table>
+        </div>
+        </div>
+    </body>
+
+</html>


### PR DESCRIPTION
This is a script that folds a json that looks like:

```
{
  "taxon": "taxon unknown",
  "number_of_models": 12,
  "number_of_models_in_error": 0,
  "number_of_correct_models": 0,
  "messages": {
    "gorule-0000019": [
      {
        "level": "ERROR",
        "model-id": "gomodel:5b528b1100000186",
        "type": "Violates GO Rule",
        "obj": "",
        "taxon": "taxon unknown",
        "message": "GORULE:0000019: Model is logically inconsistent",
        "rule": 19
      },
...
```

into a report html that mirrors the gorule report page.

Report screenshot attached as an example
![Screenshot from 2020-03-18 14-24-39](https://user-images.githubusercontent.com/1422171/77016557-3add8280-6935-11ea-9a21-99f62f302160.png)

**Note!** These hyperlinks won't go anywhere, and so is currently misleading. This is just spending the minimum time making this work with the reports.
.