### PR TITLE
Added new Xenbase GO curator

### DIFF
--- a/metadata/users.yaml
+++ b/metadata/users.yaml
@@ -3127,6 +3127,20 @@
   uri: 'http://orcid.org/0000-0001-5495-4588'
 -
   accounts:
+    github: MardiNenni
+  authorizations:
+    noctua:
+      go:
+        allow-edit: true
+  email-md5:
+    -
+  groups:
+    - 'http://www.xenbase.org'
+  nickname: 'Mardi Nenni'
+  organization: Xenbase
+  uri: 'http://orcid.org/0000-0002-6238-1932'
+-
+  accounts:
     github: chris-grove
   authorizations:
     noctua:


### PR DESCRIPTION
Added details for a new curator from Xenbase to get access to Noctua for GO curation.