### PR TITLE
Updated Xenbase entity id and url syntaxes.

### DIFF
--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -2803,28 +2803,28 @@
   entity_types:
     - type_name: gene
       type_id: SO:0000704
-      id_syntax: XB-GENE-[0-9]+
+      id_syntax: XB-(GENE|LINE|TRANSGENE|MORPHOLINO)-[0-9]+
       url_syntax: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=[example_id]
       example_id: Xenbase:XB-GENE-6255962
       example_url: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=XB-GENE-6255962
     - type_name: morpholino oligo
       type_id: SO:0000034
-      id_syntax: XB-MORPHOLINO-[0-9]+
-      url_syntax: http://www.xenbase.org/common/xsearch.do?searchValue=[example_id]
+      id_syntax: XB-(GENE|LINE|TRANSGENE|MORPHOLINO)-[0-9]+
+      url_syntax: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=[example_id]
       example_id: Xenbase:XB-MORPHOLINO-17250301
-      example_url: http://www.xenbase.org/common/xsearch.do?searchValue=XB-MORPHOLINO-17250301
+      example_url: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=XB-MORPHOLINO-17250301
     - type_name: transgene
       type_id: SO:0000902
-      id_syntax: XB-TRANSGENE-[0-9]+
-      url_syntax: http://www.xenbase.org/common/xsearch.do?searchValue=[example_id]
+      id_syntax: XB-(GENE|LINE|TRANSGENE|MORPHOLINO)-[0-9]+
+      url_syntax: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=[example_id]
       example_id: Xenbase:XB-TRANSGENE-17326811
-      example_url: http://www.xenbase.org/common/xsearch.do?searchValue=XB-TRANSGENE-17326811
+      example_url: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=XB-TRANSGENE-17326811
     - type_name: strain
       type_id: EFO:0005135
-      id_syntax: XB-LINE-[0-9]+
-      url_syntax: http://www.xenbase.org/common/xsearch.do?searchValue=[example_id]
+      id_syntax: XB-(GENE|LINE|TRANSGENE|MORPHOLINO)-[0-9]+
+      url_syntax: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=[example_id]
       example_id: Xenbase:XB-LINE-1248
-      example_url: http://www.xenbase.org/common/xsearch.do?searchValue=XB-LINE-1248
+      example_url: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=XB-LINE-1248
 - database: YeastFunc
   name: Yeast Function
   generic_urls:


### PR DESCRIPTION
Changed all Xenbase entity type url_syntax entries to 'http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=[example_id]' and id_syntax entries to 'XB-(GENE|LINE|TRANSGENE|MORPHOLINO)-[0-9]+'. In line with discussion in #1206.