### PR TITLE
Fix --allow_paint arg order in Makefile-gaf-reprocess

### DIFF
--- a/scripts/Makefile-gaf-reprocess
+++ b/scripts/Makefile-gaf-reprocess
@@ -23,8 +23,8 @@ $(ROOT_PATH)/gaferencer-products/%: $(ROOT_PATH)/gaferencer-products/%.gz
 
 $(ROOT_PATH)/annotations_new/%.gaf: $(ROOT_PATH)/annotations/%.gaf $(ROOT_PATH)/gaferencer-products/all.gaferences.json
 	mkdir -p $(ROOT_PATH)/annotations_new
-	ontobio-parse-assocs.py -f $< -F gaf -o $@ -I $(ROOT_PATH)/gaferencer-products/all.gaferences.json --report-md /tmp/report.md --report-json /tmp/report.json convert --to gaf --allow_paint
+	ontobio-parse-assocs.py -f $< -F gaf -o $@ -I $(ROOT_PATH)/gaferencer-products/all.gaferences.json --report-md /tmp/report.md --report-json /tmp/report.json --allow_paint convert --to gaf
 
 $(ROOT_PATH)/annotations_new/%.gpad: $(ROOT_PATH)/annotations/%.gpad $(ROOT_PATH)/gaferencer-products/all.gaferences.json
 	mkdir -p $(ROOT_PATH)/annotations_new
-	ontobio-parse-assocs.py -f $< -F gpad -o $@ -I $(ROOT_PATH)/gaferencer-products/all.gaferences.json --report-md /tmp/report.md --report-json /tmp/report.json convert --to gpad --allow_paint
+	ontobio-parse-assocs.py -f $< -F gpad -o $@ -I $(ROOT_PATH)/gaferencer-products/all.gaferences.json --report-md /tmp/report.md --report-json /tmp/report.json --allow_paint convert --to gpad


### PR DESCRIPTION
Current cmd fails because `--allow_paint`, being at the end of the cmd, is parsed as an argument of subcommand `convert`, which it is not. 
```
13:23:48  ontobio-parse-assocs.py -f /opt/go-site/annotations/goa_dog_rna.gpad -F gpad -o /opt/go-site/annotations_new/goa_dog_rna.gpad -I /opt/go-site/gaferencer-products/all.gaferences.json --report-md /tmp/report.md --report-json /tmp/report.json convert --to gpad --allow_paint
13:23:52  usage: ontobio-parse-assocs.py [-h] [-r RESOURCE] [-f FILE] [-F FORMAT]
13:23:52                                 [-o OUTFILE] [--report-md REPORT_MD]
13:23:52                                 [--report-json REPORT_JSON] [-t TO]
13:23:52                                 [--filter-out EVIDENCE [EVIDENCE ...]]
13:23:52                                 [--filtered-file FILTERED_FILE]
13:23:52                                 [-T [TAXON [TAXON ...]]]
13:23:52                                 [--subject_prefix [SUBJECT_PREFIX [SUBJECT_PREFIX ...]]]
13:23:52                                 [--object_prefix [OBJECT_PREFIX [OBJECT_PREFIX ...]]]
13:23:52                                 [-I GAFERENCER_FILE] [-v] [--allow_paint]
13:23:52                                 {validate,filter,convert,map2slim} ...
13:23:52  ontobio-parse-assocs.py: error: unrecognized arguments: --allow_paint
```

This change makes it an arg of the overall `ontobio-parse-assocs.py` script by moving it before `convert`.