### PR TITLE
Submit GAF file and add metadata for PHI-base

### DIFF
--- a/metadata/datasets/phibase.yaml
+++ b/metadata/datasets/phibase.yaml
@@ -1,0 +1,20 @@
+id: phibase
+label: PHI-base
+description: 'GO data for PHI-base'
+project_name: 'PHI-base'
+contact_email: 'contact@phi-base.org'
+project_url: 'http://www.phi-base.org/'
+funding_source: 'BBSRC'
+email_report: 'contact@phi-base.org'
+datasets:
+ -
+   id: phibase.gaf
+   label: 'PHI-base gaf file'
+   description: 'gaf file for phibase from PHI-base'
+   url: http://current.geneontology.org/annotations/phibase.gaf.gz
+   type: gaf
+   dataset: phibase
+   submitter: phibase
+   source: https://raw.githubusercontent.com/PHI-base/data/master/phibase.gaf
+   entity_type:
+   status: active

--- a/metadata/group-contacts.csv
+++ b/metadata/group-contacts.csv
@@ -81,6 +81,9 @@ PAMGO_MGG,Not actively maintainted/GO_Central,@pgarmiri,contact @mgiglio99 for q
 PAMGO_MGG,Not actively maintainted/GO_Central,@vanaukenk,contact @mgiglio99 for queries
 ParkinsonsUK-UCL,Barbara Kramarz,@BarbaraCzub,
 ParkinsonsUK-UCL,Ruth Lovering,@RLovering,
+PHI-base,Alayne Cuzick,@cuzicka,PHI-base biocurator
+PHI-base,James Seager,@jseager7,Software developer
+PHI-base,Martin Urban,@martin2urban,Database manager
 PINC (ProtInc),Not actively maintainted/GO_Central,@pgarmiri,no contact person
 PINC (ProtInc),Not actively maintainted/GO_Central,@pgaudet,no contact person
 PINC (ProtInc),Not actively maintainted/GO_Central,@vanaukenk,no contact person

--- a/metadata/groups.yaml
+++ b/metadata/groups.yaml
@@ -410,3 +410,7 @@
   label: DiBest-Unical
   id: https://www.unical.it/portale/strutture/dipartimenti_240/dibest
   shorthand: DIBU
+-
+  label: PHI-base
+  id: http://www.phi-base.org
+  shorthand: PHI-base

--- a/metadata/users.yaml
+++ b/metadata/users.yaml
@@ -4176,3 +4176,19 @@
   nickname: 'Fernando Bolio'
   organization: WB
   uri: 'https://orcid.org/0000-0003-2506-9234'
+-
+  accounts:
+    github: cuzicka
+  groups:
+    - 'http://www.phi-base.org'
+  nickname: 'Alayne Cuzick'
+  organization: PHI-base
+  uri: 'https://orcid.org/0000-0001-8941-3984'
+-
+  accounts:
+    github: jseager7
+  groups:
+    - 'http://www.phi-base.org'
+  nickname: 'James Seager'
+  organization: PHI-base
+  uri: 'https://orcid.org/0000-0001-7487-610X'


### PR DESCRIPTION
[PHI-base](http://www.phi-base.org/) has been creating GO annotations as part of its pathogen&ndash;host interaction curation. This pull request should provide the metadata needed to submit our annotations to GO.

PHI-base is a multi-species database, and our annotation tool ([PHI-Canto](https://canto.phi-base.org/), derived from PomBase's [Canto](https://curation.pombase.org/)) can annotate genes from any species in UniProt, so populating the `taxa` list in phibase.yaml didn't seem practical. I could populate it with all the taxa that we've annotated so far, but then presumably the list would need to be updated whenever new species were annotated.

We're using GitHub as the URL for our GAF file, which probably isn't ideal, but it's likely to be more stable than the PHI-base website, which is currently undergoing redevelopment. I've opted to disable compression since I don't want to lose text diffs on the source repository (plus I don't think it makes sense to version control compressed files). If compression is required (or just preferred) then I can supply the GAF file using a separate repository, or some other hosting source.
