### PR TITLE
Adding previous-groups entry (test)

### DIFF
--- a/metadata/users.yaml
+++ b/metadata/users.yaml
@@ -4048,6 +4048,8 @@
 -
   nickname: 'Josh Jaffery'
   organization: WB
+  previous-groups:
+    - 'http://wormbase.org/'
   uri: 'GOC:jja'
   xref: 'GOC:jja'
 -


### PR DESCRIPTION
Adding a previous-groups entry for a former WormBase curator.
Will need to be on the look out that adding this information doesn't have any unintended downstream effects.....