### PR TITLE
add PomBase GPAD & GPI entries

### DIFF
--- a/metadata/datasets/pombase.yaml
+++ b/metadata/datasets/pombase.yaml
@@ -31,7 +31,6 @@ datasets:
    type: gaf
    dataset: pombase
    submitter: pombase
-   compression: gzip
    source: https://www.pombase.org/data/annotations/Gene_ontology/pombase.gpi
    entity_type:
    status: active
@@ -47,7 +46,6 @@ datasets:
    type: gaf
    dataset: pombase
    submitter: pombase
-   compression: gzip
    source: https://www.pombase.org/data/annotations/Gene_ontology/pombase.gpad
    entity_type:
    status: active

--- a/metadata/datasets/pombase.yaml
+++ b/metadata/datasets/pombase.yaml
@@ -23,4 +23,38 @@ datasets:
    taxa:
     - NCBITaxon:284812
     - NCBITaxon:4896
+ -
+   id: pombase.gpi
+   label: "pombase gpi file"
+   description: "gpi file for pombase from PomBase"
+   url: http://current.geneontology.org/annotations/pombase.gpi.gz
+   type: gaf
+   dataset: pombase
+   submitter: pombase
+   compression: gzip
+   source: https://www.pombase.org/data/annotations/Gene_ontology/pombase.gpi
+   entity_type:
+   status: active
+   species_code: Spom
+   taxa:
+    - NCBITaxon:284812
+    - NCBITaxon:4896
+ -
+   id: pombase.gpad
+   label: "pombase gpad file"
+   description: "gpad file for pombase from PomBase"
+   url: http://current.geneontology.org/annotations/pombase.gpad.gz
+   type: gaf
+   dataset: pombase
+   submitter: pombase
+   compression: gzip
+   source: https://www.pombase.org/data/annotations/Gene_ontology/pombase.gpad
+   entity_type:
+   status: active
+   species_code: Spom
+   taxa:
+    - NCBITaxon:284812
+    - NCBITaxon:4896
+
+
 


### PR DESCRIPTION
Note: Source URLs do not include ".gz", because @kimrutherford says that https connections to www.pombase.org are automatically compressed.