### PR TITLE
adding 2.2 as gaf output version in gaf reprocess step

### DIFF
--- a/scripts/Makefile-gaf-reprocess
+++ b/scripts/Makefile-gaf-reprocess
@@ -23,7 +23,7 @@ $(ROOT_PATH)/gaferencer-products/%: $(ROOT_PATH)/gaferencer-products/%.gz
 
 $(ROOT_PATH)/annotations_new/%.gaf: $(ROOT_PATH)/annotations/%.gaf $(ROOT_PATH)/gaferencer-products/all.gaferences.json
 	mkdir -p $(ROOT_PATH)/annotations_new
-	ontobio-parse-assocs.py -f $< -F gaf -o $@ -I $(ROOT_PATH)/gaferencer-products/all.gaferences.json --report-md /tmp/report.md --report-json /tmp/report.json --allow_paint convert --to gaf
+	ontobio-parse-assocs.py -f $< -F gaf -o $@ -I $(ROOT_PATH)/gaferencer-products/all.gaferences.json --report-md /tmp/report.md --report-json /tmp/report.json --allow_paint convert --to gaf -n 2.2
 
 $(ROOT_PATH)/annotations_new/%.gpad: $(ROOT_PATH)/annotations/%.gpad $(ROOT_PATH)/gaferencer-products/all.gaferences.json
 	mkdir -p $(ROOT_PATH)/annotations_new


### PR DESCRIPTION
for a partial fix of https://github.com/geneontology/pipeline/issues/212.