### PR TITLE
Update users.yaml

### DIFF
--- a/metadata/users.yaml
+++ b/metadata/users.yaml
@@ -617,8 +617,14 @@
 -
   accounts:
     github: zebrafishembryo
+  authorizations:
+    noctua:
+      go:
+        allow-edit: true
   email-md5:
     - 211b318809e38f23520d0bd64f4a2330
+  groups:
+    - 'http://geneontology.org'
   previous-groups:
     - 'http://www.ebi.ac.uk/GOA'
   nickname: 'Alice Dashow'

--- a/metadata/users.yaml
+++ b/metadata/users.yaml
@@ -617,12 +617,6 @@
 -
   accounts:
     github: zebrafishembryo
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
-    termgenie-go:
-      allow-write: true
   email-md5:
     - 211b318809e38f23520d0bd64f4a2330
   previous-groups:

--- a/metadata/users.yaml
+++ b/metadata/users.yaml
@@ -625,10 +625,9 @@
       allow-write: true
   email-md5:
     - 211b318809e38f23520d0bd64f4a2330
-  groups:
+  previous-groups:
     - 'http://www.ebi.ac.uk/GOA'
-  nickname: 'Aleksandra Shypitsyna'
-  organization: GOA
+  nickname: 'Alice Dashow'
   uri: 'http://orcid.org/0000-0003-3829-1600'
   xref: 'GOC:als'
 -


### PR DESCRIPTION
Editing as per @zebrafishembryo 's request through helpdesk.  I think groups and organization are optional fields, and previous-groups is in the schema although I don't see use of  previous-groups anywhere else in this yaml??