### PR TITLE
Update gorule-0000061.md

### DIFF
--- a/metadata/rules/README.md
+++ b/metadata/rules/README.md
@@ -1024,7 +1024,7 @@ GAF2.2 files require a gene product to term (gp2term) relation in Column 4. Allo
 * For `GO:0008150 "biological process"`: 
     * If the annotation is to the root term `"biological process"`, then the allowed gp2term relation is `RO:0002331 "involved_in"`. If the gp2term relation is different, it is repaired to `RO:0002331 "involved_in"`.
     * If the annotation is to is a subclass descendant of `"biological process"` then the allowed gp2term relations are `RO:0002331 "involved_in"`, `RO:0002264 "acts upstream or within"`, `RO:0004032 "acts upstream of or within, positive effect"`, `RO:0004033 "acts upstream of or within, negative effect"`, `RO:0002263 "acts upstream of"`, `RO:0004034 "acts upstream of, positive effect"`, `RO:0004035 "acts upstream of, negative effect"`. 
-* For `GO:0008372 "cellular component"`
+* For `GO:0005575 "cellular component"`
     * If the annotation is to the root term `"cellular_component"`, then the allowed gp2term relation is `RO:0002432 "is_active_in"`. If the gp2term relation is different, it is repaired to `RO:0002432 "is_active_in"`.
     * The gp2term relation `RO_0002325 "colocalizes_with"` for `"GO:0032991 "protein-containing complex"` is not allowed and is filtered.
     * If the annotation is to `"GO:0032991 "protein-containing complex"` or a subclass descendant of, then the allowed gp2term relation is `"BFO:0000050 "part of"`. If the gp2term relation is different, is repaired to `"BFO:0000050 "part of"`.

--- a/metadata/rules/gorule-0000061.md
+++ b/metadata/rules/gorule-0000061.md
@@ -16,7 +16,7 @@ GAF2.2 files require a gene product to term (gp2term) relation in Column 4. Allo
 * For `GO:0008150 "biological process"`: 
     * If the annotation is to the root term `"biological process"`, then the allowed gp2term relation is `RO:0002331 "involved_in"`. If the gp2term relation is different, it is repaired to `RO:0002331 "involved_in"`.
     * If the annotation is to is a subclass descendant of `"biological process"` then the allowed gp2term relations are `RO:0002331 "involved_in"`, `RO:0002264 "acts upstream or within"`, `RO:0004032 "acts upstream of or within, positive effect"`, `RO:0004033 "acts upstream of or within, negative effect"`, `RO:0002263 "acts upstream of"`, `RO:0004034 "acts upstream of, positive effect"`, `RO:0004035 "acts upstream of, negative effect"`. 
-* For `GO:0008372 "cellular component"`
+* For `GO:0005575 "cellular component"`
     * If the annotation is to the root term `"cellular_component"`, then the allowed gp2term relation is `RO:0002432 "is_active_in"`. If the gp2term relation is different, it is repaired to `RO:0002432 "is_active_in"`.
     * The gp2term relation `RO_0002325 "colocalizes_with"` for `"GO:0032991 "protein-containing complex"` is not allowed and is filtered.
     * If the annotation is to `"GO:0032991 "protein-containing complex"` or a subclass descendant of, then the allowed gp2term relation is `"BFO:0000050 "part of"`. If the gp2term relation is different, is repaired to `"BFO:0000050 "part of"`.


### PR DESCRIPTION
Updating cellular component GO ID to `GO:0005575` rather than deprecated GO:0008372.