### PR TITLE
Update gorule-0000008.md

### DIFF
--- a/metadata/rules/gorule-0000008.md
+++ b/metadata/rules/gorule-0000008.md
@@ -11,12 +11,12 @@ implementations:
     source: https://github.com/biolink/ontobio/blob/master/ontobio/io/qc.py
 examples:
   fail:
-    - comment: fails because GO:0031572 is in the subset gocheck_do_not_manually_annotate
+    - comment: fails because GO:0005622 is in the subset gocheck_do_not_manually_annotate
       format: gaf
       input: "UniProtKB	Q9DGE2	mapk14a		GO:0005622	PMID:10995439	IDA		C	Mitogen-activated protein kinase 14A	mapk14a|mapk14	protein	taxon:7955	20180129	UniProt"
-    - comment: fails because GO:0031572 is in the subset gocheck_do_not_manually_annotate
+    - comment: fails because GO:0000910 is in the subset gocheck_do_not_manually_annotate
       format: gaf
-      input: "UniProtKB	Q9WVH3	Foxo4		GO:0031572	PMID:12048180	IDA		P	Forkhead box protein O4	Foxo4|Afx|Afx1	protein	taxon:10090	20110425	MGI"
+      input: "UniProtKB	Q9WVH3	Foxo4		GO:0000910	PMID:12048180	IDA		P	Forkhead box protein O4	Foxo4|Afx|Afx1	protein	taxon:10090	20110425	MGI"
   pass: 
     - comment: Should pass
       format: gaf


### PR DESCRIPTION
Correct comment and update second example with GO:0000910, which actually is in the subset. GO:0031572 has been deprecated and the replacement term is not in the subset.
Tagging @pgaudet in case there is a better term to use here--I just picked one randomly that satisfied the criteria.