### PR TITLE
updating ontobio to 2.7.0

### DIFF
--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,3 +1,3 @@
 PyYAML
-ontobio==2.6.3
+ontobio==2.7.0
 click


### PR DESCRIPTION
Main change here is ability to specify "rule sets". Be default, the main pipeline kernel will still behave the same with no change. Other scripts that perform annotation parsing (like ontobio-parse-assocs) will be default not run rules.