### PR TITLE
Change str formatting for compatibility and update header for #1530

### DIFF
--- a/scripts/github_issue_summary.py
+++ b/scripts/github_issue_summary.py
@@ -20,7 +20,7 @@ def make_html_safe(s):
 
 
 def print_single_issue(issue):
-    line = f"<li><a href=\"{issue['html_url']}\">{issue['number']}</a> {make_html_safe(issue['title'])}</li>"
+    line = "<li><a href=\"{}\">{}</a> {}</li>".format(issue['html_url'], issue['number'], make_html_safe(issue['title']))
     print(line)
 
 
@@ -32,25 +32,25 @@ def print_issues(issues, event_type: str, printed_ids: set):
             to_prints.append(issue)
             printed_count += 1
             printed_ids.add(issue["number"])
-    print(f"<h3>{event_type} Tickets</h3>")
+    print("<h3>{} Tickets</h3>".format(event_type))
     if printed_count > 0:
-        print(f"There are {printed_count} {event_type.lower()} tickets.")
+        print("There are {} {} tickets.".format(printed_count, event_type.lower()))
         print("<ul>")
         [print_single_issue(i) for i in to_prints]
         print("</ul>")
     else:
-        print(f"<p>There have been no {event_type.lower()} tickets.</p>")
+        print("<p>There have been no {} tickets.</p>".format(event_type.lower()))
 
 
 def get_issues(repo: str, event_type: str, start_date: str):
-    url = f"https://api.github.com/search/issues?q=repo:{repo}+{event_type}:=>{start_date}&type=Issues&per_page=100"
+    url = "https://api.github.com/search/issues?q=repo:{}+{}:=>{}&type=Issues&per_page=100".format(repo, event_type, start_date)
     resp = requests.get(url)
     if resp.status_code == 200:
         resp_objs = json.loads(resp.content)
         issues = resp_objs.get("items", [])
         return issues
     else:
-        raise Exception(f"HTTP error status code: {resp.status_code} for url: {url}")
+        raise Exception("HTTP error status code: {} for url: {}".format(resp.status_code, url))
 
 
 if __name__ == "__main__":
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     new_issues = get_issues(args.repo_name, "created", yesterday)
     updated_issues = get_issues(args.repo_name, "updated", yesterday)
 
-    print(f"<h2>Summary for tickets from {yesterday} to {today}</h2>")
+    print("<h2>Summary for tickets in {} from {} to {}</h2>".format(args.repo_name, yesterday, today))
     ids = set()
     print_issues(new_issues, "New", ids)
     print_issues(updated_issues, "Updated", ids)

--- a/scripts/github_issue_summary.py
+++ b/scripts/github_issue_summary.py
@@ -63,7 +63,10 @@ if __name__ == "__main__":
     new_issues = get_issues(args.repo_name, "created", yesterday)
     updated_issues = get_issues(args.repo_name, "updated", yesterday)
 
-    print("<h2>Summary for tickets in {} from {} to {}</h2>".format(args.repo_name, yesterday, today))
+    repo_name = args.repo_name
+    if "/" in repo_name:
+        repo_name = repo_name.rsplit("/", maxsplit=1)[-1]
+    print("<h2>Summary for tickets in {} from {} to {}</h2>".format(repo_name, yesterday, today))
     ids = set()
     print_issues(new_issues, "New", ids)
     print_issues(updated_issues, "Updated", ids)


### PR DESCRIPTION
Stopped using `f"{var}"` style formatting (in case script is run with python version <3.6).

Also, new email header changed from (an example):
```
<h2>Summary for tickets from 2021-05-03 to 2021-05-04</h2>
```
To this, clearly displaying the repo name:
```
<h2>Summary for tickets in geneontology/go-ontology from 2021-05-03 to 2021-05-04</h2>
```