### PR TITLE
Update Makefile-gaf-reprocess to trigger all GO rules again

### DIFF
--- a/scripts/Makefile-gaf-reprocess
+++ b/scripts/Makefile-gaf-reprocess
@@ -23,11 +23,11 @@ $(ROOT_PATH)/gaferencer-products/%: $(ROOT_PATH)/gaferencer-products/%.gz
 
 $(ROOT_PATH)/annotations_new/%.gaf: $(ROOT_PATH)/annotations/%.gaf $(ROOT_PATH)/gaferencer-products/all.gaferences.json
 	mkdir -p $(ROOT_PATH)/annotations_new
-	ontobio-parse-assocs.py -f $< -F gaf -o $@ -I $(ROOT_PATH)/gaferencer-products/all.gaferences.json --report-md /tmp/report.md --report-json /tmp/report.json --allow_paint convert --to gaf -n 2.2
+	ontobio-parse-assocs.py -f $< -F gaf -o $@ -I $(ROOT_PATH)/gaferencer-products/all.gaferences.json --report-md /tmp/report.md --report-json /tmp/report.json --allow_paint -l all convert --to gaf -n 2.2
 
 $(ROOT_PATH)/annotations_new/%.gpad: $(ROOT_PATH)/annotations/%.gpad $(ROOT_PATH)/gaferencer-products/all.gaferences.json
 	mkdir -p $(ROOT_PATH)/annotations_new
-	ontobio-parse-assocs.py -f $< -F gpad -o $@ -I $(ROOT_PATH)/gaferencer-products/all.gaferences.json --report-md /tmp/report.md --report-json /tmp/report.json --allow_paint convert --to gpad
+	ontobio-parse-assocs.py -f $< -F gpad -o $@ -I $(ROOT_PATH)/gaferencer-products/all.gaferences.json --report-md /tmp/report.md --report-json /tmp/report.json --allow_paint -l all convert --to gpad
 
 ####################################################################################################
 ### Noctua GPAD
@@ -57,7 +57,7 @@ $(ROOT_PATH)/noctua_sources/noctua_%-src.gpad: $(ROOT_PATH)/noctua_sources/noctu
 
 $(ROOT_PATH)/noctua_target/noctua_%.gpad: $(ROOT_PATH)/noctua_sources/noctua_%-src.gpad $(ROOT_PATH)/go-ontology.json
 	mkdir -p $(ROOT_PATH)/noctua_target
-	ontobio-parse-assocs.py -f $< -F gpad -o $@ -r $(ROOT_PATH)/go-ontology.json --report-md $(ROOT_PATH)/noctua_target/noctua_$*.report.md --report-json $(ROOT_PATH)/noctua_target/noctua_$*.report.json convert --to gpad -n 1.2
+	ontobio-parse-assocs.py -f $< -F gpad -o $@ -r $(ROOT_PATH)/go-ontology.json --report-md $(ROOT_PATH)/noctua_target/noctua_$*.report.md --report-json $(ROOT_PATH)/noctua_target/noctua_$*.report.json -l all convert --to gpad -n 1.2
 
 $(ROOT_PATH)/noctua_target/noctua_%.gpad.gz: $(ROOT_PATH)/noctua_target/noctua_%.gpad
 	pigz $<


### PR DESCRIPTION
For https://github.com/geneontology/go-ontology/issues/21642

A quick test to determine if setting `-l all` will blow away that TC invalid PomBase IBA. Start with the current state (no `-l all`):
```
$ ontobio-parse-assocs.py -f target/groups/pombase/pombase.gaf -F gaf -o pombase_filter.gaf -I all.gaferences.json --report-md report.md --report-json report.json --allow_paint convert --to gaf -n 2.2
$ grep SPBC1347.06c pombase_filter.gaf | grep GO:0016055
PomBase	SPBC1347.06c	cki1	involved_in	GO:0016055	PMID:21873635	IBA	PANTHER:PTN000226268|UniProtKB:P49674	P	cki1	ck1	protein_coding_gene	taxon:284812	20170228	GO_Central
$ grep SPBC1347.06c report.md | grep GO:0016055
(nothing)
```
IBA is still in output GAF; nothing in report for the line. Now add the `-l all` option:
```
$ ontobio-parse-assocs.py -f target/groups/pombase/pombase.gaf -F gaf -o pombase_filter.gaf -I all.gaferences.json --report-md report.md --report-json report.json --allow_paint -l all convert --to gaf -n 2.2
$ grep SPBC1347.06c pombase_filter.gaf | grep GO:0016055
(nothing)
$ grep SPBC1347.06c report.md | grep GO:0016055
* ERROR - Violates GO Rule: GORULE:0000013: Taxon-appropriate annotation check -- `PomBase	SPBC1347.06c	cki1	involved_in	GO:0016055	PMID:21873635	IBA	PANTHER:PTN000226268|UniProtKB:P49674	P	cki1	ck1	protein_coding_gene	taxon:284812	20170228	GO_Central
```
IBA is correctly filtered out of output GAF and reported.

Also, added `-l all` to the `noctua_*` ontobio-parse-assocs line to re-trigger the relation repair for https://github.com/geneontology/pipeline/issues/220.