### PR TITLE
Update requirements.txt to ontobio==2.7.9

### DIFF
--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,3 +1,3 @@
 PyYAML
-ontobio==2.7.8
+ontobio==2.7.9
 click


### PR DESCRIPTION
Update `ontobio` to `2.7.9` to pull in https://github.com/biolink/ontobio/pull/584 to help with https://github.com/geneontology/go-annotation/issues/2677.

In short, this adds more one relation (existence_starts_and_ends_during) to the list used by the GO pipeline annotation extension parser and also updates relation -> label lookup:

exists_during - GOREL:0000032
existence_starts_and_ends_during - RO:0002491