### PR TITLE
Updated id syntax on QTLdb and CorrDB

### DIFF
--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -2906,9 +2906,9 @@
     - type_name: QTL
       type_id: QTL_ID:0000000
       url_syntax: https://www.animalgenome.org/QTLdb/q?id=[example_id]
-      id_syntax: QTL_ID:\d+
-      example_id: QTL_ID:23155
-      example_url: https://www.animalgenome.org/QTLdb/q?id=QTL_ID:23155
+      id_syntax: \d+
+      example_id: 23155
+      example_url: https://www.animalgenome.org/QTLdb/q?id=23155
 - database: Animal_CorrDB
   name: CorrDB
   generic_urls:
@@ -2918,9 +2918,9 @@
     - type_name: Correlation
       type_id: CorrID:000000
       url_syntax: https://www.animalgenome.org/CorrDB/q/?id=[example_id]
-      id_syntax: CorrID:\d+
-      example_id: CorrID:37232
-      example_url: https://www.animalgenome.org/CorrDB/q/?id=CorrID:37232
+      id_syntax: \d+
+      example_id: 37232
+      example_url: https://www.animalgenome.org/CorrDB/q/?id=37232
 - database: AlphaFold
   name: AlphaFold Protein Structure Database
   generic_urls:


### PR DESCRIPTION
Removed text part: e.g. QTL_ID:23155 >> 23155; Corr_ID:37232 >> 37232