### PR TITLE
Update requirements.txt to ontobio==2.7.12

### DIFF
--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,3 +1,3 @@
 PyYAML
-ontobio==2.7.9
+ontobio==2.7.12
 click


### PR DESCRIPTION
This will bring in `ontobio` changes from these PRs since `2.7.9`:
https://github.com/biolink/ontobio/pull/583
https://github.com/biolink/ontobio/pull/587
https://github.com/biolink/ontobio/pull/588
https://github.com/biolink/ontobio/pull/590
https://github.com/biolink/ontobio/pull/592

This will mainly help handle https://github.com/geneontology/go-annotation/issues/3934.