### PR TITLE
Try and fix default upgrading of pyyaml from 5.x to 6.x

### DIFF
--- a/graphstore/rule-runner/setup.py
+++ b/graphstore/rule-runner/setup.py
@@ -8,7 +8,7 @@ setup(
     install_requires=[
         "click",
         "requests",
-        "pyYaml",
+        "pyYaml==5.4.1",
         "pykwalify==1.6.0",
         "SPARQLWrapper==1.8.0",
         "yamldown",


### PR DESCRIPTION
attempt to fix sparta pyyaml issue by locking pyyaml version to 5.x series, instead of new default 6; work on #1750