### PR TITLE
`gorefs.json` similar to `gorefs.yaml`

### DIFF
--- a/metadata/gorefs/gorefs.json
+++ b/metadata/gorefs/gorefs.json
@@ -1,0 +1,1272 @@
+[
+    {
+        "authors": "GOA-UniProt curators",
+        "id": "GO_REF:0000029",
+        "is_obsolete": true,
+        "year": 2007,
+        "layout": "goref",
+        "title": "OBSOLETE Gene Ontology annotation based on information extracted from curated UniProtKB entries",
+        "comments": [
+            "Active 2001-2007.",
+            "Method by which GO terms were manually assigned to UniProt KnowledgeBase accessions, using either a NAS or TAS evidence code, by applying information extracted from the corresponding publicly-available, manually curated UniProtKB entry. Such GO annotations were submitted by the GOA-UniProt group from 2001, but this annotation practice was discontinued in 2007."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000078",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation for the transport or vesicle-mediated transport of a chemical from and/or to a cell component as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the transport or vesicle-mediated transport of a chemical entity (ChEBI) from and/or to a cellular component as a biological process. The underlying equivalence axiom templates are \"GO:0006810 and 'transports or maintains localization of' some X [ and 'has_target_start_location' some F] [ and 'has_target_end_location' some T]\" (transport) and \"GO:0016192 and 'transports or maintains localization of' some X [ and 'has_target_start_location' some F] [ and 'has_target_end_location' some T]\" (vesicle-mediated transport), where F and T are cellular components and X is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI has been described in the following publication: PMID:23895341."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000068",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of metabolic triad (metabolism, catabolism, biosynthesis) as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes each describing the metabolism, catabolism, or biosynthesis of a chemical entity (ChEBI) as a process. The underlying equivalence axiom templates are \"GO:0008152 and 'has participant' some X\" (metabolism), \"GO:0009056 and 'has input' some X\" (catabolism), \"GO:0009058 and 'has output' some X\" and (biosynthesis),  where X is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI has been described in the following publication: PMID:23895341."
+        ]
+    },
+    {
+        "authors": "UniProt-GOA",
+        "id": "GO_REF:0000039",
+        "year": 2011,
+        "layout": "goref",
+        "title": "OBSOLETE Gene Ontology annotation based on the manual assignment of UniProtKB Subcellular Location terms in UniProtKB/Swiss-Prot entries.",
+        "comments": [
+            "Transitive assignment of GO terms based on the UniProtKB Subcellular Location vocabulary. UniProtKB Subcellular Location is a controlled vocabulary used to supply subcellular location information to UniProtKB entries in the SUBCELLULAR LOCATION lines. Terms from this vocabulary are annotated manually to UniProtKB/Swiss-Prot entries. Further information on the UniProtKB manual annotation method is available at http://www.uniprot.org/faq/45.<br>When a UniProtKB Subcellular Location term describes a concept that is within the scope of the Gene Ontology, it is investigated to determine whether it is appropriate to map the term to an equivalent term in GO. The mapping between UniProtKB Subcellular Location terms and GO terms is carried out manually. Definitions and hierarchies of the terms in the two resources are compared and the mapping generated will reflect the most correct correspondence. The translation table between GO terms and UniProtKB Subcellular Location terms is maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/spsl2go."
+        ]
+    },
+    {
+        "authors": "Ensembl curators, GOA curators",
+        "id": "GO_REF:0000019",
+        "is_obsolete": true,
+        "year": 2006,
+        "layout": "goref",
+        "title": "OBSOLETE Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara",
+        "comments": [
+            "GO terms from a source species are projected on to one or more target species based on gene orthology obtained from the Ensembl Compara system. Only one to one and apparent one to one orthologies are used for a restricted range of species. Only GO annotations with a manual experimental evidence type of IDA, IEP, IGI, IMP or IPI are projected. Projected GO annotations using this technique will receive the evidence code, inferred from electronic annotation, 'IEA'. The Ensembl protein identifier of the annotation source is indicated in the 'With' column of the GOA association file."
+        ]
+    },
+    {
+        "authors": "GOA curators",
+        "id": "GO_REF:0000108",
+        "year": 2016,
+        "layout": "goref",
+        "title": "Automatic assignment of GO terms using logical inference, based on on inter-ontology links.",
+        "comments": [
+            "GO terms are automatically assigned based on inter-ontology links to generate inferred annotations. Annotations from Molecular Function to Biological Process can be propagated, as well as between Biological Process and Cellular Component. Annotations that are created using this inference method receive either the evidence code ECO:0000366 (evidence based on logical inference from automatic annotation used in automatic assertion) or ECO:0000364 (evidence based on logical inference from manual annotation used in automatic assertion), depending on whether the source annotation has a manual or automatic evidence code. Both of these codes map up to the GO Inferred from Electronic Annotation (IEA) evidence code."
+        ]
+    },
+    {
+        "authors": "TIGR Arabidopsis annotation team",
+        "external_accession": [
+            "TAIR:Communication:501714663"
+        ],
+        "id": "GO_REF:0000048",
+        "is_obsolete": true,
+        "year": 2005,
+        "layout": "goref",
+        "title": "OBSOLETE TIGR's Eukaryotic Manual Gene Ontology Assignment Method",
+        "comments": [
+            "This describes TIGR curators' interpretation of a combination of evidence. Our internal software tools present us with a great deal of evidence based on domains, sequence similarities, signal sequences, paralogous proteins, etc. The curator interprets the body of evidence to make a decision about a GO assignment when an external reference is not available. The curator places one or more accessions that informed the decision in the \"with\" field."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000058",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of regulation in the Gene Ontology (biological process)",
+        "comments": [
+            "We have created a standard template for the definition of classes for the regulation of a biological process. This includes the definitions for positive and negative regulation. The equivalence axiom templates are \"GO:0065007 and 'regulates' some X\" (regulation), \"GO:0065007 and 'negatively_regulates' some X\" (negative regulation), and \"GO:0065007 and 'positively_regulates' some X\" (positive regulation), where X is a biological process."
+        ]
+    },
+    {
+        "authors": "DictyBase curators",
+        "external_accession": [
+            "dictyBase_REF:10158"
+        ],
+        "id": "GO_REF:0000018",
+        "is_obsolete": true,
+        "year": 2005,
+        "layout": "goref",
+        "title": "OBSOLETE dictyBase 'Inferred from Electronic Annotation (BLAST method)'",
+        "comments": [
+            "Gene Ontology (GO) annotations with the evidence code 'Inferred from Electronic Annotation' (IEA) are assigned automatically to gene products in dictyBase. All Dictyostelium protein sequences are analyzed by BLAST against GO gene association sequence files, identifying proteins in other organisms that align with Dictyostelium proteins with an E value less than or equal to e-50. GO annotations that have been manually assigned to these proteins from other species are then imported and attached to the corresponding gene product in dictyBase. The proteins from which the annotations are derived are displayed in the 'Evidence' column on the Gene Ontology evidence and references page."
+        ]
+    },
+    {
+        "authors": "TrypTag",
+        "id": "GO_REF:0000109",
+        "year": 2016,
+        "layout": "goref",
+        "title": "Gene Ontology annotation based on curation of genome-wide subcellular localisation of proteins using fluorescent protein tagging in Trypanosoma brucei",
+        "comments": [
+            "Trypanosomes are exquisitely structured cells in which protein localisation can be extremely informative for likely function. TrypTag is a project using expression of N- and C-terminal mNeonGreen fusion proteins from the endogenous loci to determine the subcellular localisation of every gene in the Trypanosoma brucei genome. GO Cellular Component terms are manually assigned by curators studying fluorescence microscope images of the resulting cells labelled with mNeonGreen fusion proteins. As trypanosomes are a pathogenic basal eukaryote, this will indicate likely function of both highly conserved eukaryote genes and parasite-specific genes. Resource URL: http://www.tryptag.org Protein subcellular localisation images can be viewed on the Tryptag website, e.g. http://www.tryptag.org?id=Tb927.8.1550"
+        ]
+    },
+    {
+        "authors": "Ensembl Genomes",
+        "id": "GO_REF:0000049",
+        "is_obsolete": true,
+        "year": 2012,
+        "layout": "goref",
+        "title": "OBSOLETE Automatic transfer of experimentally verified manual GO annotation data to fungal orthologs using Ensembl Compara",
+        "comments": [
+            "GO terms from a source species are projected onto one or more target species based on gene orthology obtained from the Ensembl Compara system. One to one, one to many and many to many orthologies are used but annotations are only projected between orthologs that have at least a 40% peptide identity to each other. Only GO annotations with an evidence type of IDA, IEP, IGI, IMP or IPI are projected, no annotations with a 'NOT' qualifier are projected and annotations to the GO:0005515 protein binding term are not projected. Projected GO annotations using this technique will receive the evidence code Inferred from Electronic Annotation (IEA). The model organism database identifier of the annotation source will be indicated in the 'With' column of the GOA association file.",
+            "Duplicate of GO_REF:0000107."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000059",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of regulation in the Gene Ontology (molecular function)",
+        "comments": [
+            "We have created a standard template for the definition of classes for the regulation of a molecular function. This includes the definitions for positive and negative regulation. The equivalence axiom templates are \"GO:0065007 and 'regulates' some X\" (regulation), \"GO:0065007 and 'negatively_regulates' some X\" (negative regulation), and \"GO:0065007 and 'positively_regulates' some X\" (positive regulation), where X is a molecular function."
+        ]
+    },
+    {
+        "authors": "Mouse Genome Informatics scientific curators",
+        "external_accession": [
+            "MGI:2154458",
+            "J:73065"
+        ],
+        "id": "GO_REF:0000008",
+        "year": 2001,
+        "layout": "goref",
+        "title": "Gene Ontology annotation by the MGI curatorial staff, curated orthology",
+        "comments": [
+            "The sequence conservation that permits the establishment of orthology between mouse and rat or mouse and human genes is a strong predictor of the conservation of function for the gene product across these species. Therefore, in instances where a mouse gene product has not been functionally characterized, but its human or rat orthologs have, Mouse Genome Informatics (MGI) curators append the GO terms associated with the orthologous gene(s) to the mouse gene. Only those GO terms assigned by experimental determination to the ortholog of the mouse gene will be adopted by MGI. GO terms that are assigned to the ortholog of the mouse gene computationally (i.e. IEA), will not be transferred to the mouse ortholog. The evidence code represented by this citation is Inferred by Sequence Orthology (ISO)."
+        ]
+    },
+    {
+        "authors": "PAMGO_MGG curators",
+        "id": "GO_REF:0000028",
+        "year": 2008,
+        "layout": "goref",
+        "title": "Criteria for IDA, IEP, ISS, IGC, RCA, and IEA assignment in PAMGO_MGG",
+        "comments": [
+            "This GO reference describes the criteria used in assigning the evidence codes of IDA (ECO:0000314), IEP (ECO:0000270), ISS (ECO:0000250), IGC (ECO_0000317), RCA (ECO:0000245) and IEA (ECO:0000501) to annotate gene products from PAMGO_MGG. Standard BLASTP from NCBI was used (http://www.ncbi.nih.gov/blast) to iteratively search reciprocal best hits and thus identify orthologs between predicted proteins of Magnaporthe grisea and GO proteins from multiple organisms with published association to GO terms. The alignments were manually reviewed for those hits with e-value equal to zero and with 80% or better coverage of both query and subject sequences, and for those hits with e&lt;=10^-20, pid &gt;=35 and sequence coverage &gt;=80%. Furthermore, experimental or reviewed data from literature and other sources were incorporated into the GO annotation. IDA was assigned to an annotation if normal function of its gene was determined through transfections into a cell line and overexpression. IEP was assigned to an annotation if according to microarray experiments, its gene was upregulated in a biological process and the fold change was equal to or bigger than 10, or if according to Massively Parallel Signature Sequencing (MPSS), its gene was upregulated only in a certain biological process and the fold change was equal to or bigger than 10. ISS was assigned to an annotation if the entry at the With_column was experimentally characterized and the pairwise alignments were manually reviewed. IGC was assigned to an annotation if it based on comparison and analysis of gene location and structure, clustering of genes, and phylogenetic reconstruction of these genes. RCA was assigned to an annotation if it based on integrated computational analysis of whole genome microarray data, and matches to InterPro, pfam, and COG etc. IEA was assigned to an annotation if its function assignment based on computational work, and no manual review was done."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000079",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of assembly or disassembly of a cell component as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the assembly or disassembly of a cellular component as a biological process. The underlying equivalence axiom templates are \"GO:0022607 and 'results_in_assembly_of' some C\" (assembly) and \"GO:0022411 and 'results_in_disassembly_of' some C\" (disassembly), where C is a cellular component."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000069",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of transmembrane transport of a chemical as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the transmembrane transport of a chemical entity (ChEBI) as a biological process. The underlying equivalence axiom template is \"GO:0055085 and 'transports or maintains localization of' some X\", where X is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI has been described in the following publication: PMID:23895341."
+        ]
+    },
+    {
+        "authors": "UniProt-GOA",
+        "id": "GO_REF:0000038",
+        "is_obsolete": true,
+        "year": 2011,
+        "layout": "goref",
+        "title": "OBSOLETE Gene Ontology annotation based on automatic assignment of UniProtKB keywords in UniProtKB/TrEMBL entries.",
+        "comments": [
+            "Transitive assignments using UniProtKB keywords. The UniProtKB keyword controlled vocabulary has been created and used by the UniProt Knowledgebase (UniProtKB) to supply 10 different categories of information to UniProtKB entries. Further information on the UniProtKB keyword resource can be found at http://www.uniprot.org/docs/keywlist. UniProtKB keywords are automatically assigned to UniProtKB/TrEMBL entries from the underlying nucleic acid databases and/or by the UniProt automatic annotation program. Further information on the prediction systems applied by UniProt is available here: http://www.uniprot.org/program/automatic_annotation.<br>When a UniProtKB keyword describes a concept that is within the scope of the Gene Ontology, it is investigated to determine whether it is appropriate to map the keyword to an equivalent term in GO. The mapping between UniProtKB keywords and GO terms is carried out manually. Definitions and hierarchies of the terms in the two resources are compared and the mapping generated will reflect the most correct correspondence. The translation table between GO terms and UniProtKB keywords is maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/uniprotkb_kw2go.",
+            "Duplicate of GO_REF:0000043."
+        ]
+    },
+    {
+        "authors": "FlyBase",
+        "id": "GO_REF:0000106",
+        "is_obsolete": true,
+        "year": 2016,
+        "layout": "goref",
+        "title": "OBSOLETE Gene Ontology annotation based on protein sequence records.",
+        "comments": [
+            "Between 1986 and 2005 GO annotations were made by FlyBase curators based on information in UniProtKB/Swiss-Prot protein sequence records. We no longer add GO annotations based on sequence records and are gradually replacing these GO annotations as other sources of evidence become available."
+        ]
+    },
+    {
+        "authors": "UniProt-GOA",
+        "id": "GO_REF:0000046",
+        "is_obsolete": true,
+        "year": 2012,
+        "layout": "goref",
+        "title": "OBSOLETE Gene Ontology annotation based on UniProtKB/TrEMBL Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt.",
+        "comments": [
+            "Transitive assignment of GO terms based on the UniProtKB/TrEMBL Subcellular Location vocabulary. UniProtKB Subcellular Location is a controlled vocabulary used to supply subcellular location information to UniProtKB entries in the SUBCELLULAR LOCATION lines. Terms from this vocabulary are annotated manually to UniProtKB/Swiss-Prot entries but are automatically assigned to UniProtKB/TrEMBL entries from the underlying nucleic acid databases and/or by the UniProt automatic annotation program.<br>Further information on these two different annotation methods is available at http://www.uniprot.org/faq/45 and http://www.uniprot.org/program/automatic_annotation.<br> The translation table between GO terms and UniProtKB Subcellular Location term is maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/spsl2go.<br>Please note that the GO term in the annotation assigned with this GO reference has been changed from that originally applied by the UniProtKB Subcellular Location2GO mapping. This change has been carried out by the UniProt group to ensure the GO annotation obeys the GO Consortium\u2019s ontology structure and taxonomic constraints. Further information on the rules used by UniProt to transform specific incorrect IEA annotations is available at http://www.ebi.ac.uk/QuickGO/AnnotationPostProcessing.html.",
+            "Duplicate of GO_REF:0000023."
+        ]
+    },
+    {
+        "authors": "GOA curators, UniProt curators",
+        "external_accession": [
+            "SGD_REF:S000125578"
+        ],
+        "id": "GO_REF:0000023",
+        "is_obsolete": true,
+        "year": 2007,
+        "layout": "goref",
+        "title": "OBSOLETE Gene Ontology annotation based on UniProtKB Subcellular Location vocabulary mapping.",
+        "comments": [
+            "Transitive assignment of GO terms based on the UniProtKB Subcellular Location vocabulary. UniProtKB Subcellular Location is a controlled vocabulary used to supply subcellular location information to UniProtKB entries in the SUBCELLULAR LOCATION lines. Terms from this vocabulary are annotated manually to UniProtKB/Swiss-Prot entries but  are automatically assigned to UniProtKB/TrEMBL entries from the underlying nucleic acid databases and/or by the UniProt automatic annotation program.<br>Further information on these two different annotation methods is available at http://www.uniprot.org/faq/45 and http://www.uniprot.org/program/automatic_annotation .<br>When a UniProtKB Subcellular Location term describes a concept that is within the scope of the Gene Ontology, it is investigated to determine whether it is appropriate to map the term to an equivalent term in GO. The mapping between UniProtKB Subcellular Location terms and GO terms is carried out manually. Definitions and hierarchies of the terms in the two resources are compared and the mapping generated will reflect the most correct correspondence. The translation table between GO terms and UniProtKB Subcellular Location term is maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/spsl2go .",
+            "Duplicate of GO_REF:0000039."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000072",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of chemical homeostasis and cellular chemical homeostasisl as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the homeostasis and cellular homeostasis for a chemical entity (ChEBI) as a biological process. The underlying equivalence axiom templates are \"GO:0048878 and 'regulates level of' some X\" (homeostasis) and \"GO:0055082 and 'regulates level of' some X\" (cellular homeostasis), where X is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI has been described in the following publication: PMID:23895341."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000081",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of plant formation as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the formation of a plant structure as a biological process. The underlying equivalence axiom template is \"'anatomical structure formation involved in morphogenesis' and 'results in formation of' some P\", where P is a plant anatomical entity (PO:0025131)."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000091",
+        "year": 2014,
+        "layout": "goref",
+        "title": "Representation of cell migration as biological processes in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the cell migration process for a cell type as a biological process. The underlying equivalence axiom template is \"'cell migration' and 'alters_location_of' some C\", where C is a native cell (CL:0000004)."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000062",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of processes occurring in parts of the cell in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing processes occurring in parts of the cell. The underlying equivalence axiom template is \"P and 'occurs in' some C\", where P is a biological process and C is a cellular component."
+        ]
+    },
+    {
+        "authors": "Pascale Gaudet, Michael Livstone, Paul Thomas, The Reference Genome Project",
+        "external_accession": [
+            "SGD_REF:S000146947",
+            "TAIR:Communication:501741973",
+            "MGI:MGI:4459044",
+            "J:161428 ",
+            "ZFIN:ZDB-PUB-110330-1",
+            "FB:FBrf0232076"
+        ],
+        "id": "GO_REF:0000033",
+        "url": "http://gocwiki.geneontology.org/index.php/PAINT",
+        "year": 2010,
+        "is_obsolete": true,
+        "layout": "goref",
+        "title": "OBSOLETE Annotation inferences using phylogenetic trees",
+        "comments": [
+            "This GO_REF was originally used to support PAINT annotations. The SOP has changed, and now phylogenetic annotations are supported using the identifier for the family itself.",
+            "The goal of the GO Reference Genome Project, described in PMID 19578431, is to provide accurate, complete and consistent GO annotations for all genes in twelve model organism genomes.To this end, GO curators are annotating evolutionary trees from the PANTHER database with GO terms describing molecular function, biological process and cellular component. GO terms based on experimental data from the scientific literature are used to annotate ancestral genes in the phylogenetic tree by sequence similarity (ISS), and unannotated descendants of these ancestral genes are inferred to have inherited these same GO annotations by descent. The annotations are done using a tool called PAINT (Phylogenetic Annotation and INference Tool)."
+        ]
+    },
+    {
+        "authors": "The GO Consortium",
+        "id": "GO_REF:0000056",
+        "year": 2013,
+        "is_obsolete": true,
+        "layout": "goref",
+        "title": "OBSOLETE Taxon constraints to detect inconsistencies in annotation and ontology structure.",
+        "comments": [
+            "GO is intended to cover the full range of species, therefore GO terms are defined to be taxon neutral, avoiding reliance on taxon information for full definition of the given process, function, or component. For certain terms, however, there is obvious implicit taxon specificity, such that the term should only be used to categorize gene products from particular species. Taxon specificity of GO terms is captured using relationships such as \"only_in_taxon\" and \"never_in_taxon\". All taxon constraints are inherited by sub-types and parts of the GO term they are applied to. Taxon constraints are used to prevent inappropriate annotations from being made by curators as well as to identify pre-existing annotations that violate the taxon constraints. Errors in annotations are automatically detected by looking for inconsistencies between the taxonomic origin of the annotated gene products and the implicit taxon specificity of the GO terms. The inconsistencies are passed on to curators for correction, in some cases the constraints need to be tightened or relaxed or the structure of the ontology needs to be adjusted. The taxon constraints are further described in this publication: Deegan, Dimmer and Mungall. BMC Bionformatics (2010) Formalization of taxon-based constraints to detect inconsistencies in annotaiton and ontology development. (PMID:20973947). "
+        ]
+    },
+    {
+        "authors": "GO Central curators, GOA curators, Rhea curators",
+        "citation": "PMID:30272209",
+        "id": "GO_REF:0000116",
+        "year": 2020,
+        "layout": "goref",
+        "title": "Automatic Gene Ontology annotation based on Rhea mapping.",
+        "comments": [
+            "Rhea (https://www.rhea-db.org/, PMID:30272209) is an expert-curated knowledgebase of chemical and transport reactions of biological interest - and the standard for enzyme and transporter annotation in UniProtKB (PMID:31688925). Rhea uses the chemical dictionary ChEBI (Chemical Entities of Biological Interest) to describe reaction participants and their chemical transformations in a computationally tractable manner. GO terms corresponding to Rhea reactions are assigned a Rhea database cross-reference. The corresponding GO term is automatically applied to all UniProt entries annotated with a Rhea reaction. The mapping file is available at: http://current.geneontology.org/ontology/external2go/rhea2go."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000076",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of transport or vesicle-mediated transport from cell component to cell component as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the transport or vesicle-mediated transport from cellular component to cellular component as a biological process. The underlying equivalence axiom templates are \"GO:0006810 and 'has_target_start_location' some F and 'has_target_end_location' some T\" (transport) and \"GO:0016192 and 'has_target_start_location' some F and 'has_target_end_location' some T\" (vesicle-mediated transport), where F and T are a cellular components."
+        ]
+    },
+    {
+        "authors": "PAMGO_GAT curators",
+        "id": "GO_REF:0000027",
+        "year": 2007,
+        "layout": "goref",
+        "title": "BLAST search criteria for ISS assignment in PAMGO_GAT",
+        "comments": [
+            "This GO reference describes the criteria used in assigning the evidence code of ISS via BLAST searches to annotate gene products from PAMGO_GAT. Standard BLASTP from NCBI was used (http://www.ncbi.nih.gov/blast) to query the non-redundant (NR) database. Hits are considered to be significant if the E-value is at or less than 10^-4. All other parameters are default according to http://www.ncbi.nih.gov/blast."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000085",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of cell apoptotic process as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the apoptotic process for a cell type as a biological process. The underlying equivalence axiom template is \"'apoptotic process' and 'occurs in' some C\", where C is a native cell (CL:0000003)."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000102",
+        "is_obsolete": true,
+        "year": 2015,
+        "layout": "goref",
+        "title": "OBSOLETE Representation of cellular component binding as molecular functions in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes cellular component binding as a molecular function. The underlying equivalence axiom template is \"'binding' and 'has input' some C\", where C is a cellular component (GO:0005575)."
+        ]
+    },
+    {
+        "authors": "UniProt-GOA",
+        "id": "GO_REF:0000042",
+        "is_obsolete": true,
+        "year": 2012,
+        "layout": "goref",
+        "title": "OBSOLETE Gene Ontology annotation through association of InterPro records with GO terms, accompanied by conservative changes to GO terms applied by UniProt.",
+        "comments": [
+            "Transitive assignment of GO terms based on InterPro classification. For any database entry (representing a protein or protein-coding gene) that has been annotated with one or more InterPro domains, The corresponding GO terms are obtained from a translation table of InterPro entries to GO terms (interpro2go) generated manually by the InterPro team at EBI. The mapping file is available at http://www.geneontology.org/external2go/interpro2go.<br>Please note that the GO term in the annotation assigned with this GO reference has been changed from that originally applied by the InterPro2GO mapping. This change has been carried out by the UniProt group to ensure the GO annotation obeys the GO Consortium\u2019s ontology structure and taxonomic constraints. Further information on the rules used by UniProt to transform specific incorrect IEA annotations is available at http://www.ebi.ac.uk/QuickGO/AnnotationPostProcessing.html.",
+            "Duplicate of GO_REF:0000002."
+        ]
+    },
+    {
+        "authors": "Human Protein Atlas",
+        "id": "GO_REF:0000052",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Gene Ontology annotation based on curation of immunofluorescence data",
+        "comments": [
+            "GO Cellular Component terms are manually assigned by curators studying high resolution confocal microscopy images of immunohistochemically stained tissue. The methodology uses antibody-based proteomics which combines high-throughput generation of affinity-purified antibodies with protein profiling in a variety of cells and tissues. Further information on the annotation methods can be found at http://www.proteinatlas.org/about/assays+annotation <br>Annotations are only exported to the GO Consortium if the localizations are supported by literature, according to the following validation grading:<br>Supportive - Subcellular localization supported by literature.<br>1) One/multiple localizations supported by literature.<br>2) Multiple localizations partly supported (at least one) by literature.<br>3) One/multiple localizations in cytoplasm (i.e. Golgi, mitochondria, ER etc) with literature supporting cytoplasmic localization. <br>Prior to February 2013, all Human Protein Atlas annotations were referenced by PMID:18029348 (Barbe et al. 2008 Mol. Cell Proteomics. 7:499-508), a paper describing the protein localization pilot study and methodology used by the Human Protein Atlas. However, it has been decided that these annotations are more correctly described by a GO reference.<br>Resource URL: http://www.proteinatlas.org <br>Protein subcellular localization images can be viewed on the Human Protein Atlas website, e.g. http://www.proteinatlas.org/ENSG00000175899/summary#ifcelline"
+        ]
+    },
+    {
+        "authors": "Ivan Erill, James Hu, Community Assessment of Community Annotation with Ontologies",
+        "id": "GO_REF:0000112",
+        "is_obsolete": true,
+        "year": 2017,
+        "layout": "goref",
+        "title": "OBSOLETE Gene Ontology annotation by CACAO biocurators",
+        "comments": [
+            "This GO reference describes the criteria used by biocurators participating in the Community Assessment of Community Annotation with Ontologies (CACAO) to annotate gene products from genomes of interest through the use of computational methods to establish and manually validate function or homology to gene products. In particular, this GO reference describes the criteria used to make annotations based on evidence codes ISS, ISA, ISO, ISM and IGC. To perform ISS-, ISA-, and ISO-based annotations on a gene product, CACAO biocurators use sequence- and structure-based search algorithms (e.g. BLASTP, HHPred) to establish homology, conservation of sequence and structure functional determinants between the target gene product and gene products from other organisms with published GO annotations supported by experimental codes and lacking NOT qualifiers. These gene products are referenced in the WITH field of the annotation using their xref database accession. ISM-based annotations make use of published computational methods (e.g. TMHMM, SignalP) to predict gene product structure, localization or function. IGC-based annotations are made on the basis of suggestive evidence for function based on synteny. Parameters and criteria for use of all computational methods (e.g. e-value) are listed and versioned in the publicly available CACAO documentation (http://gowiki.tamu.edu/). Annotations made by CACAO biocurators are reviewed by CACAO team instructors before their release."
+        ]
+    },
+    {
+        "alt_id": [
+            "GO_REF:0000005"
+        ],
+        "authors": "GOA curators, MGI curators",
+        "citation": "PMID:11374909",
+        "external_accession": [
+            "MGI:2152096",
+            "J:72245",
+            "ZFIN:ZDB-PUB-031118-3",
+            "SGD_REF:S000124037"
+        ],
+        "id": "GO_REF:0000003",
+        "year": 2001,
+        "layout": "goref",
+        "title": "Gene Ontology annotation based on Enzyme Commission mapping.",
+        "comments": [
+            "Transitive assignment using Enzyme Commission identifiers. This method is used for any database entry, such as a protein record in UniProtKB or TrEMBL, that has had an Enzyme Commission number assigned. The corresponding GO term is determined using the EC cross-references in the GO molecular function ontology. Also see Hill et al., Genomics (2001) 74:121-128. The mapping file is available at http://www.geneontology.org/external2go/ec2go.",
+            "Formerly GOA:spec."
+        ]
+    },
+    {
+        "authors": "Mouse Genome Informatics scientific curators and FlyBase",
+        "id": "GO_REF:0000095",
+        "year": 2014,
+        "layout": "goref",
+        "title": "Literature reference not indexed by PubMed",
+        "comments": [
+            "This article is not referenced in PubMed. Please see contributing data resource for details."
+        ]
+    },
+    {
+        "authors": "UniProt-GOA",
+        "id": "GO_REF:0000037",
+        "is_obsolete": true,
+        "year": 2011,
+        "evidence_codes": [
+            "ECO:0000501"
+        ],
+        "layout": "goref",
+        "title": "OBSOLETE Gene Ontology annotation based on manual assignment of UniProtKB keywords in UniProtKB/Swiss-Prot entries.",
+        "comments": [
+            "Transitive assignments using UniProtKB keywords. The UniProtKB keyword controlled vocabulary has been created and used by the UniProt Knowledgebase (UniProtKB) to supply 10 different categories of information to UniProtKB entries. Further information on the UniProtKB keyword resource can be found at http://www.uniprot.org/docs/keywlist. UniProtKB keywords are manually applied to UniProtKB/Swiss-Prot entries by UniProt curators. Further information on the UniProtKB manual annotation process is available at http://www.uniprot.org/faq/45.<br>When a UniProtKB keyword describes a concept that is within the scope of the Gene Ontology, it is investigated to determine whether it is appropriate to map the keyword to an equivalent term in GO. The mapping between UniProtKB keywords and GO terms is carried out manually. Definitions and hierarchies of the terms in the two resources are compared and the mapping generated will reflect the most correct correspondence. The translation table between GO terms and UniProtKB keywords is maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/uniprotkb_kw2go.",
+            "Duplicate of GO_REF:0000043."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000066",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of transport of a chemical entity as molecular function in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the transport of a chemical entity (ChEBI) as a molecular function. The underlying equivalence axiom template is \"GO:0005215 and 'transports or maintains localization of' some X\", where X is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI has been described in the following publication: PMID:23895341."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000077",
+        "year": 2013,
+        "is_obsolete": true,
+        "layout": "goref",
+        "title": "OBSOLETE Representation of transport of a cellular component as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the transport or vesicle-mediated transport of a cellular component as a biological process. The underlying equivalence axiom templates are \"GO:0006810 and 'transports or maintains localization of' some C\" (transport) and \"GO:0016192 and 'transports or maintains localization of' some C\" (vesicle-mediated transport), where C is a cellular component."
+        ]
+    },
+    {
+        "authors": "Jennifer Deegan nee Clark (1, 5), Alexander D. Diehl (1,7), Elisabeth Ehler (2), Georgine Faulkner (3), Erika Feltrin (4), Jennifer Fordham (2), Midori Harris (1, 5), Ralph Knoell (6) David Hill (1, 7), Paolo Laveder (8), Alessandra Nori (8), Carlo Reggiani (8), Vincenzo Sorrentino (9), Giorgio Valle (4), Pompeo Volpe (8) (1. The Gene Ontology Consortium, 2. King's College, London, UK, 3. ICGEB, Trieste, Italy, 4. CRIBI - University of Padua, Padua, Italy 5. EMBL-EBI, Hinxton, Cambridgeshire, UK, 6. University of Goettingen, Goettingen, Germany 7. Mouse Genome Informatics, Bar Harbor, ME, 8. University of Padua, Padua, Italy, 9. University of Siena, Siena, Italy)",
+        "citation": "PMID:19178689",
+        "id": "GO_REF:0000026",
+        "is_obsolete": true,
+        "year": 2007,
+        "layout": "goref",
+        "title": "OBSOLETE Improving the representation of muscle biology in the biological process and cellular component ontologies.",
+        "comments": [
+            "A meeting focused on the biology of skeletal and smooth muscle has been held on 24-25 July 2007 at the University of Padua, Italy, as a collaboration with the GO consortium and CRIBI Biotechnology Center. The aims of this effort were to provide a comprehensive representation of muscle biology in the biological process and cellular component ontologies and to improve the organization of muscle-specific terms to better describe the current knowledge of biological mechanisms in muscle tissue. Thus, the collaboration brought together experts in several areas of muscle biology and physiology who carried out a thorough review of the existing GO muscle terms as these terms were largely created by non-muscle experts using older definitions. In particular, several areas are being addressed actively in current research: the biological processes of muscle contraction, muscle plasticity, muscle development, and muscle regeneration; and the sarcoplasmic reticulum and membrane delimited compartments. This work resulted in the addition of 159 new terms and in the modification of 57 terms to bring them in line with current usage. Funding for the meeting was provided by Italian Telethon Foundation."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000084",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of plant structural organization as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the structural organization of a plant structure as a biological process. The underlying equivalence axiom template is \"'anatomical structure arrangement' and 'results in structural organization of' some P\", where P is a plant anatomical entity (PO:0025131)."
+        ]
+    },
+    {
+        "authors": "Michelle Gwinn, TIGR curators",
+        "id": "GO_REF:0000012",
+        "year": 2003,
+        "layout": "goref",
+        "title": "Pairwise alignment (TIGR)",
+        "comments": [
+            "Pairwise alignments are generated by taking two sequences and aligning them so that the maximum number of amino acids in each protein match, or are similar to, each other. Tools such as BLAST work by comparing a protein-of-interest individually with every protein in a database of known protein sequences and retaining only those matches with a high probability of being significant. Basic BLAST generates local alignments between proteins for regions of high similarity. Other pairwise alignment tools attempt to generate global (full-length) protein alignments. A tool called Blast_Extend_repraze (BER, http://ber.sourceforge.net) has some benefits over basic BLAST. Input into the BER tool includes the underlying DNA sequence for each protein as well as 300 nucleotides upstream and downstream of the predicted boundaries of the protein coding sequence. This allows annotators to see the DNA sequence that underlies the query protein as part of the alignment. In addition, the BER tool is able to look for continuation of regions of similarity through frameshifts and in-frame stop codons.  If such regions are found the alignment is continued. BER searches are done in a two-step process: step one is a BLAST search against a non-redundant protein database, significant BLAST hits are stored in a mini-database for each query protein; step two is a modified Smith-Waterman alignment between the query and the proteins in its mini-database. In order to assess whether a given BER alignment is good enough to assert that the query shares the function of the match protein, one must look at a several factors. First of all, the match protein must itself be experimentally characterized in order to avoid transitive annotation errors. In addition, any residues or secondary structures known to be important for function in the match protein must be conserved in the query. The alignment should be visually inspected to look for any areas of lesser quality that might indicate the two proteins do not share the same function. Although it is impossible to set cutoff values for percent identity and length of match that will apply for every alignment, there are some guidelines. In general at least 40% identity that extends over the full lengths of both proteins is required in order to even consider functional equivalence. However, this percentage is highly dependent on the length and complexity of the proteins. 40% identity between two proteins 500 amino acids long is much more significant that 40% identity between two proteins that are only 100 amino acids long. Therefore, the annotator's experience and knowledge of what is considered significant for the organism and protein family in question is very important. Some sets of proteins are much more highly conserved than others and therefore tolerances for percent identity may have to be adjusted. Finally, the alignment must be considered in the context of what else is known about the query protein and the organism as a whole."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000103",
+        "is_obsolete": true,
+        "year": 2015,
+        "layout": "goref",
+        "title": "OBSOLETE Representation of cellular component organization as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes cellular component organization as a biological process. The underlying equivalence axiom template is \"'cellular component organization' and 'results_in_organization_of' some C\", where C is a cellular component (GO:0005575)."
+        ]
+    },
+    {
+        "authors": "UniProt-GOA",
+        "id": "GO_REF:0000043",
+        "external_accession": [
+            "SGD_REF:S000148669",
+            "J:60000",
+            "TAIR:AnalysisReference:501756968",
+            "TAIR:AnalysisReference:501756970"
+        ],
+        "year": 2012,
+        "layout": "goref",
+        "title": "Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping",
+        "comments": [
+            "Transitive assignments using UniProtKB/Swiss-Prot keywords. The UniProtKB keyword controlled vocabulary contains 10 different categories of information to UniProtKB entries. Further information on the UniProtKB keyword resource can be found at https://www.uniprot.org/keywords/.\nUniProtKB keywords are assigned to UniProtKB/Swiss-Prot entries by UniProt curators as part of the UniProtKB manual curation process. UniProtKB keywords are also automatically assigned to UniProtKB/TrEMBL entries from the underlying nucleic acid databases and/or by the UniProt automatic annotation program.\nFurther information on the two different UniProt annotation methods is available at https://www.uniprot.org/help/keywords..\nWhen a UniProtKB keyword describes a concept that is within the scope of the Gene Ontology, a mapping is manually made to the corresponding GO term.The translation table between GO terms and UniProtKB keywords is maintained by the EBI GOA team and available at http://www.geneontology.org/external2go/uniprotkb_kw2go."
+        ]
+    },
+    {
+        "authors": "GO ontology editors ",
+        "id": "GO_REF:0000053",
+        "year": 2013,
+        "is_obsolete": true,
+        "layout": "goref",
+        "title": "OBSOLETE Automatic classification of GO using the ELK reasoner",
+        "comments": [
+            "We use the <a href=\"http://code.google.com/p/elk-reasoner/\">ELK reasoner</a> as part of an ontology development and release pipeline to automatically construct and check a large portion of the GO graph. The editors version of the GO (gene_ontology_write.obo) contains additional metadata, including provenance of graph links. Every week, the GO pipeline executes a process which first removes all links tagged as \"is_inferred\". The reasoner then generates a list of inferred links which are automatically added to the ontology with the \"is_inferred\" tag set. The pipeline generates a report describing which links have changed as a part of this process."
+        ]
+    },
+    {
+        "authors": "Marcio Luis Acencio (1), George Georghiou (2), Sandra Orchard (2), Liv Thommensen (1), Martin Kuiper (1) and Astrid L\u00e6greid (1). (1) Norwegian University of Science and Technology (NTNU), Trondheim, Norway; (2) European Bioinformatics Institute (EBI), Hinxton, Cambridgeshire, United Kingdom",
+        "id": "GO_REF:0000113",
+        "year": 2018,
+        "layout": "goref",
+        "title": "Gene Ontology annotation of human sequence-specific DNA binding transcription factors (DbTFs) based on the TFClass database",
+        "comments": [
+            "The TFClass (http://tfclass.bioinf.med.uni-goettingen.de/index.jsf) database provides a comprehensive classification of mammalian DNA binding transcription factors (DbTFs) based on their DNA binding domains (DBDs) (PMID:29087517). TFClass classifies mammalian DbTFs by a five-level classification in which the four highest levels represent groups defined by structural and sequence similarities (superclass, class, family, subfamily, and genera) (more details at http://www.edgar-wingender.de/TFClass_schema.html). This classification is based on the combination of background knowledge of the molecular structural features of DBDs (PMID:9340487, PMID:23427989) and phylogenetic trees constructed via multiple sequence alignment with hierarchical clustering of manually validated DBDs and/or full-length protein sequences retrieved from UniProt (PMID:23427989, PMID:23180794, PMID:23427989). ",
+            "The NTNU curation team has evaluated each family and assigned a molecular function annotation, GO:0000981 (DNA-binding transcription factor activity, RNA polymerase II-specific), and a cellular component annotation GO:0000790 (nuclear chromatin), as appropriate. The superclass/class/family or subfamily ID is specified in the \"With/From\" field. The annotations are supported by the evidence code ECO:0005556 (multiple sequence alignment evidence used in manual assertion). "
+        ]
+    },
+    {
+        "alt_id": [
+            "GO_REF:0000007",
+            "GO_REF:0000014",
+            "GO_REF:0000016",
+            "GO_REF:0000017"
+        ],
+        "authors": "DDB, FB, MGI, GOA, ZFIN curators",
+        "external_accession": [
+            "MGI:2152098",
+            "J:72247",
+            "ZFIN:ZDB-PUB-020724-1",
+            "FB:FBrf0174215",
+            "dictyBase_REF:10157",
+            "SGD_REF:S000124036"
+        ],
+        "id": "GO_REF:0000002",
+        "year": 2001,
+        "layout": "goref",
+        "title": "Gene Ontology annotation through association of InterPro records with GO terms.",
+        "comments": [
+            "Transitive assignment of GO terms based on InterPro classification. For any database entry (representing a protein or protein-coding gene) that has been annotated with one or more InterPro domains, The corresponding GO terms are obtained from a translation table of InterPro entries to GO terms (interpro2go) generated manually by the InterPro team at EBI. The mapping file is available at http://www.geneontology.org/external2go/interpro2go.",
+            "Formerly GOA:interpro. Note that GO annotations based on InterPro-to-GO transitive assignment may undergo subsequent filtering, e.g. to remove annotations redundant with manual curation; consult documentation from the annotation providers for further information."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000094",
+        "year": 2014,
+        "layout": "goref",
+        "title": "Representation of metazoan development as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the development of a metazoan structure as a biological process. The underlying equivalence axiom template is \"'anatomical structure development' and 'results in development of' some E\", where E is a anatomical entity (UBERON:0001062)."
+        ]
+    },
+    {
+        "authors": "GO Annotation working group",
+        "external_accession": [
+            "SGD_REF:S000147045"
+        ],
+        "id": "GO_REF:0000036",
+        "year": 2011,
+        "layout": "goref",
+        "title": "Manual annotations that require more than one source of functional data to support the assignment of the associated GO term",
+        "comments": [
+            "The Gene Ontology Consortium uses the IC (Inferred by Curator) evidence code when an annotation cannot be supported by any direct evidence, but can be inferred by GO annotations that have been annotated to the same gene/gene product identifier in conjunction with the curator's knowledge of biology (supporting GO annotations must not be IC-evidenced). In many cases an IC-evidenced annotation simply applies the same reference that was used in the supporting GO annotation.  The use of IC evidence code in an annotation with reference GO_REF:0000036 signifies a curator inferred the GO term based on evidence from multiple sources of evidence/GO annotations. The 'with/from' field in these annotations will therefore supply more than one GO identifier, obtained from the set of supporting GO annotations assigned to the same gene/gene product identifier which cite publicly-available references."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000067",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of binding to a chemical entity as molecular function in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the binding to a chemical entity (ChEBI) as a molecular function. The underlying equivalence axiom template is \"GO:0005488 and 'has input' some X\", where X is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI has been described in the following publication: PMID:23895341."
+        ]
+    },
+    {
+        "authors": "GOA curators",
+        "id": "GO_REF:0000107",
+        "year": 2016,
+        "layout": "goref",
+        "title": "Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara.",
+        "comments": [
+            "GO terms from a source species are projected onto one or more target species based on gene orthology obtained from Ensembl Compara. One-to-one, one-to-many and many-to-many orthology relations and anntations are transferred between orthologs that have at least a 40% peptide identity to each other. Only GO annotations with evidence codes ECO:0000314 (IDA), ECO:0000270 (IEP), ECO:0000316 (IGI), ECO:0000315 (IMP), and ECO:0000353 (IPI), or their descendants, are transferred; annotations with a 'NOT' qualifier are not transferred, and neither are annotations to GO:0005515 (protein binding). Annotations that are transferred using this method receive the evidence code ECO:0000265 (sequence orthology evidence used in automatic assertion), which maps up to the GO Inferred from Electronic Annotation (IEA) evidence code.  The model organism database identifier of the annotation source will be indicated in the 'With' column of the GOA association file."
+        ]
+    },
+    {
+        "authors": "GO curators",
+        "id": "GO_REF:0000047",
+        "year": 2012,
+        "layout": "goref",
+        "title": "Gene Ontology annotation based on absence of key sequence residues.",
+        "comments": [
+            "This describes a method for supplying a NOT-qualified, IKR-evidenced GO annotation to a gene product, when general sequence homology considerations would suggest a function or location, or a role in a biological process, but where a curator has determined that the absence of key sequence residues, known to be required for an expected activity or location, indicating the gene product is unlikely to be able to carry out the implied activity, involvement in a process or cellular component location. This reference should only be used used when an IKR-evidenced annotation is made based on curator judgement from manually reviewing the sequence of the gene product and where no publication can be found to support the curators conclusion. It is preferable to cite a peer-reviewed publication (such as a PubMed identifier) for IKR-evidenced annotations whenever possible. Curators will have carefully reviewed the sequence of the annotated protein, and established that the key residues known to be required for an expected activity or location are not present. Inclusion of an identifier in the 'with/from' field, that highlights to the user the lacking residues(e.g. an alignment, domain or rule identifier) is absolutely required when annotating to IKR with this GO_REF. Documentation on the GOC website provides more details on the <a href = \"http://www.geneontology.org/GO.evidence.shtml#ikr\">correct use of the IKR evidence code</a>."
+        ]
+    },
+    {
+        "authors": "Alison Deckhut Augustine (1), Alan Collmer (2), Judith A. Blake (3, 4), Candace W. Collmer (2, 3), Shane C. Burgess (5), Lindsay Grey Cowell (6), Jennifer I. Clark (3, 7), Bernard de Bono (7), Russell T. Collins (8), Alexander D. Diehl (3, 4), Michelle Gwinn Giglio (3, 9), Jamie A. Lee (10), Linda Hannick (3, 9), Jane Lomax (3, 7), Midori A. Harris (3, 7), Christopher J. Mungall (3, 11), David P. Hill (3, 4), Richard H. Scheuermann (10), Amelia Ireland (3, 7), Alessandro Sette (12) (1. NIAID, 2. Cornell University, 3. The GO Consortium, 4. Mouse Genome Informatics, 5. Mississippi State University, 6. Duke University, 7. EMBL-EBI, 8. University of Cambridge, 9. The Institute for Genomic Research, 10. U.T. Southwestern Medical Center, 11. HHMI, 12. La Jolla Institute for Allergy and Immunology)",
+        "id": "GO_REF:0000022",
+        "year": 2005,
+        "layout": "goref",
+        "title": "Improving the representation of immunology in the biological process Ontology",
+        "comments": [
+            "GO terms describing processes, functions, and cellular components related to the immune system have existed in the GO from its beginning and been used extensively in the annotation of gene products. However, particularly in the biological process ontology, the initial set of terms relating to immunology failed to cover the breadth of known immunological processes, and in many cases diverged from current usage and understanding in their names, definitions, and ontological placement. As part of a larger effort to improve the representation of immunology in the GO, a GO Content Meeting was held November 15-16, 2005, at The Institute for Genomic Research, to discuss improvements to representation of immunology in the biological process ontology of the GO. As a result of the meeting, a number of high level terms for immunological processes were created, an overall structure for immunologically related terms was established, and certain existing terms were renamed or redefined as well to bring them in line with current usage."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000073",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of import of a chemical as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the import of a chemical entity (ChEBI) as a biological process. The underlying equivalence axiom template is \"GO:0006810 and 'imports' some X\", where X is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI has been described in the following publication: PMID:23895341."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000080",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of plant development as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the development of a plant structure as a biological process. The underlying equivalence axiom template is \"'anatomical structure development' and 'results in development of' some P\", where P is a plant anatomical entity (PO:0025131)."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000090",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Automatic creation of relationships between ontology branches in the Gene Ontology",
+        "comments": [
+            "We have created a rule-based approach to create relations between the branches of the Gene Ontology. The approach uses the equivalence axioms and a given pattern to create non-subClassOf relationships between the three different branches of the Gene Ontology (biological process, molecular function, cellular component). Currently, there are the following rules: \"'transporter activity' and 'transports_or_maintains_localization_of' some X' -part_of-&gt; \"transport and 'transports_or_maintains_localization_of' some X\"; \"'transmembrane transporter activity' and 'transports_or_maintains_localization_of' some X -part_of-&gt; 'transmembrane transport' and 'transports_or_maintains_localization_of' some X\""
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000063",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of processes regulated by other regulating processes in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing processes regulated by other regulating processes. The underlying equivalence axiom template is \"R and 'results_in' some P\", where R is a biological process and P is a regulation of biological process subclass."
+        ]
+    },
+    {
+        "authors": "Christopher J. Mungall, Tanya Z. Berardini, David P. Hill",
+        "id": "GO_REF:0000032",
+        "is_obsolete": true,
+        "url": "http://wiki.geneontology.org/index.php/GAF_Inference",
+        "layout": "goref",
+        "title": "OBSOLETE Inference of Biological Process annotations from inter-ontology links",
+        "comments": [
+            "We use the GOBO library to propagate annotations from Molecular Function to Biological Process. This results in both increased numbers of annotations, and increased consistency between curators.",
+            "Duplicate of GO_REF:0000108."
+        ]
+    },
+    {
+        "authors": "Mouse Genome Informatics scientific curators",
+        "citation": "PMID:11374909",
+        "external_accession": [
+            "MGI:2152097",
+            "J:72246"
+        ],
+        "id": "GO_REF:0000006",
+        "is_obsolete": true,
+        "year": 2001,
+        "layout": "goref",
+        "title": "OBSOLETE Gene Ontology annotation by the MGI curatorial staff, Mouse Locus Catalog",
+        "comments": [
+            "For annotations documented via this citation, curators used the information in the Mouse Locus Catalog in MGI to assign GO terms. The GO terms were assigned based on MLC textual descriptions of genes that could not be traced to the primary literature. Details of this strategy can be found in Hill et al, Genomics (2001) 74:121-128."
+        ]
+    },
+    {
+        "authors": "UniProt",
+        "id": "GO_REF:0000117",
+        "year": 2021,
+        "layout": "goref",
+        "title": "Electronic Gene Ontology annotations created by ARBA machine learning models",
+        "comments": [
+            "ARBA predicts Gene Ontology (GO) terms among other types of functional annotation such as Protein Description (DE), Keywords (KW), Enzyme Commission numbers (EC), sucellular LOcation (LO), etc. For all annotation types, reviewed UniProtKB/Swiss-Prot records having manual annotations as reference data are used to perform the machine learning phase and generate prediction models. For GO terms, ARBA has an additional feature to augment reference data using the relations between GO terms in the GO graph. The data augmentation is based on adding more general annotations into records containing manual GO terms, which will result in richer reference data. The predicted GO terms are then propagated to all unreviewed UniProtKB/TrEMBL proteins that meet the conditions of ARBA models. GO annotations using this technique receive the evidence code Inferred from Electronic Annotation (IEA; ECO:0000501). These annotations are updated regularly by UniProt and are available for download on both the GO and GOA EBI ftp sites."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000087",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of protein localization and establishment of protein localization as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the protein localization and establishment of protein localization to a cellular component as a biological process. The underlying equivalence axiom templates are \"GO:0008104 and 'has_target_end_location' some C\" (protein localization) and \"GO:0045184 and 'has_target_end_location' some C\" (establishment of protein localization), where C is cellular component."
+        ]
+    },
+    {
+        "authors": "Michelle Gwinn, TIGR curators",
+        "id": "GO_REF:0000025",
+        "year": 2007,
+        "layout": "goref",
+        "title": "Operon structure as IGC evidence",
+        "comments": [
+            "Genes in prokaryotic organisms are often arranged in operons. Genes in an operon are all transcribed into one mRNA. Generally the genes in the operons code for proteins that all have related functions. For example, they may be the steps in a biochemical pathway, or they may be the subunits of a protein complex. Often the genes in operons shared between organisms are syntenic; that is, the same genes are in the same order in the operon in different species. When assessing sequence-comparison-based evidence during the process of manual annotation of a genome, it is often the case that some of the genes in the operon will have strong sequence-based evidence while others will have weak evidence. If seen alone, not in the presence of an operon, the weak evidence in question may not be sufficient to make a functional annotation. However, in the presence of an operon in which there is strong evidence for some of the genes, the very presence of the gene in the operon is a strong indication that the gene shares in the process carried out by the operon. If the putative function is one expected to exist for the process in question and particularly if that function has been observed in the same operon in another species, then the annotation should be made. This type of evidence is inferred from the context of the gene in an operon, and therefore the evidence code is IGC \"inferred from genomic context.\""
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000074",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of export of a chemical as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the export of a chemical entity (ChEBI) as a biological process. The underlying equivalence axiom template is \"GO:0006810 and 'exports' some X\", where X is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI has been described in the following publication: PMID:23895341."
+        ]
+    },
+    {
+        "authors": "Ivan Erill, SEA-PHAGE biocurators",
+        "id": "GO_REF:0000100",
+        "is_obsolete": true,
+        "year": 2014,
+        "layout": "goref",
+        "title": "OBSOLETE Gene Ontology annotation by SEA-PHAGE biocurators",
+        "comments": [
+            "This GO reference describes the criteria used by biocurators of the SEA-PHAGE consortium for the annotation of predicted gene products from newly sequenced bacteriophage genomes in the SEA-PHAGE phagesdb.org and other databases and in the GenBank records periodically released to NCBI for these genomes. In particular, this GO reference describes the criteria used to assign evidence codes ISS, ISA, ISO, ISM, IGC and ND. To assign ISS, ISA, ISO and ISM evidence codes, SEA-PHAGE biocurators use a varied array of bioinformatics tools to establish homology and conservation of sequence and structure functional determinants with proteins from multiple organisms with published association to experimental GO terms and lacking NOT qualifiers. These proteins are referenced in the WITH field of the annotation using their xref database accession. The primary tools for homology search in ISS, ISA, ISO and ISM assignments are BLASTP and HHpred, using a maximum e-value of 10^-7 for BLASTP and a minimum probability of 0.9 for HHpred, and manual inspection of alignments in both cases. For ISS and ISA assignments, BLASTP alignments are required to have at least 75% coverage and 30% identity. For ISO assignments, orthology is further validated using reciprocal BLASTP with the identified hit. For HHpred results, ISS or ISM annotations are made only if the source for the original GO annotation explicitly defines a matched domain function, or if more than half of the domains of the query protein are identified in the matching protein. All ISS, ISA, ISO and ISM assignments entail the manual verification of the source for the GO term in the matching protein sequence and critical curator assessment of the likelihood of preservation of function, process or component in the context of bacteriophage biology. IGC codes are assigned on the basis of suggestive evidence for function based on synteny, as inferred from whole-genome comparative analyses of multiple bacteriophage genomes using primarily the Phamerator software platform, and with special emphasis on the bacteriophage virion structure and assembly genes. When extensive review of published literature on putative homologs reveals no experimental evidence of function, component or process for a particular gene product, it is assigned an ND evidence code and annotated to the root term for Cellular Component, Molecular Function and Biological Process. As part of the review process for assignment of ISS, ISA, ISO, IGC and ISM evidence codes, SEA-PHAGE curators are required to analyze the reference literature for identified matches and shall perform GO annotations with appropriate evidence codes if these were not available."
+        ]
+    },
+    {
+        "authors": "UniProt-GOA",
+        "id": "GO_REF:0000040",
+        "is_obsolete": true,
+        "year": 2011,
+        "layout": "goref",
+        "title": "OBSOLETE Gene Ontology annotation based on the automatic assignment of UniProtKB Subcellular Location terms in UniProtKB/TrEMBL entries.",
+        "comments": [
+            "Transitive assignment of GO terms based on the UniProtKB Subcellular Location vocabulary. UniProtKB Subcellular Location is a controlled vocabulary used to supply subcellular location information to UniProtKB entries in the SUBCELLULAR LOCATION lines. Terms from this vocabulary are applied automatically to UniProtKB/TrEMBL entries from the underlying nucleic acid databases and/or by the UniProt automatic annotation program. Further information on the UniProtKB automatic annotation program is available at http://www.uniprot.org/faq/45.<br>When a UniProtKB Subcellular Location term describes a concept that is within the scope of the Gene Ontology, it is investigated to determine whether it is appropriate to map the term to an equivalent term in GO. The mapping between UniProtKB Subcellular Location terms and GO terms is carried out manually. Definitions and hierarchies of the terms in the two resources are compared and the mapping generated will reflect the most correct correspondence. The translation table between GO terms and UniProtKB Subcellular Location terms is maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/spsl2go."
+        ]
+    },
+    {
+        "authors": "Michelle Gwinn, TIGR curators",
+        "id": "GO_REF:0000011",
+        "year": 2003,
+        "layout": "goref",
+        "title": "Hidden Markov Models (TIGR)",
+        "comments": [
+            "A Hidden Markov Model (HMM) is a statistical representation of patterns found in a data set. When using HMMs with proteins, the HMM is a statistical model of the patterns of the amino acids found in a multiple alignment of a set of proteins called the \"seed\". Seed proteins are chosen based on sequence similarity to each other. Seed members can be chosen with different levels of relationship to each other. They can be members of a superfamily (ex. ABC transporter, ATP-binding proteins), they can all share the same exact specific function (ex. biotin synthase) or they could share another type of relationship of intermediate specificity (ex. subfamily, domain). New proteins can be scored against the model generated from the seed according to how closely the patterns of amino acids in the new proteins match those in the seed. There are two scores assigned to the HMM which allow annotators to judge how well any new protein scores to the model. Proteins scoring above the \"trusted cutoff\" score can be assumed to be part of the group defined by the seed. Proteins scoring below the \"noise cutoff\" score can be assumed to NOT be a part of the group. Proteins scoring between the trusted and noise cutoffs may be part of the group but may not. One of the important features of HMMs is that they are built from a multiple alignment of protein sequences, not a pairwise alignment. This is significant, since shared similarity between many proteins is much more likely to indicate shared functional relationship than sequence similarity between just two proteins. The usefulness of an HMM is directly related to the amount of care that is taken in chosing the seed members, building a good multiple alignment of the seed members, assessing the level of specificity of the model, and choosing the cutoff scores correctly. In order to properly assess what functional relevance an above-trusted scoring HMM match has to a query, one must carefully determine what the functional scope of the HMM is. If the HMM models proteins that all share the same function then it is likely possible to assign a specific function to high-scoring match proteins based on the HMM. If the HMM models proteins that have a wide variety of functions, then it will not be possible to assign a specific function to the query based on the HMM match, however, depending on the nature of the HMM in question, it may be possible to assign a more general (family or subfamily level) function. In order to determine the functional scope of an HMM, one must carefully read the documentation associated with the HMM. The annotator must also consider whether the function attributed to the proteins in the HMM makes sense for the query based on what is known about the organism in which the query protein resides and in light of any other information that might be available about the query protein. After carefully considering all of these issues the annotator makes an annotation."
+        ]
+    },
+    {
+        "authors": "GO curators",
+        "id": "GO_REF:0000001",
+        "year": 1998,
+        "layout": "goref",
+        "title": "GO Consortium unpublished data",
+        "comments": [
+            "No abstract available.",
+            "This reference will normally be replaced upon publication of the data supporting the annotation. Formerly GOC:unpublished."
+        ]
+    },
+    {
+        "authors": "PomBase curators",
+        "external_accession": [
+            "FB:FBrf0231277"
+        ],
+        "id": "GO_REF:0000050",
+        "year": 2012,
+        "layout": "goref",
+        "title": "Manual transfer of GO annotation data to genes by curator judgment of sequence model",
+        "comments": [
+            "Transitive assignment of GO terms to a gene based on a curator's judgment of its match to a sequence model,such as a Pfam or InterPro entry, that has manually curated GO annotations, mappings to GO terms, or a description from which GO terms can be inferred. A statistical model of a sequence or group of sequences is used to make a prediction about the function of a protein or RNA. Annotations are created when a curator evaluates the results, using criteria that include excluding false positives and ensuring that the annotation is accurate for all matches. Statistical scores (such as e values and cutoff scores) and the functional specificity of the model may also be (but are not always) considered. Annotations resulting from the transfer of GO terms use the 'ISM' evidence code and include an accession for the model from which the annotation was projected in the 'with' field (column 8)."
+        ]
+    },
+    {
+        "authors": "FlyBase",
+        "external_accession": [
+            "FB:FBrf0159903"
+        ],
+        "id": "GO_REF:0000110",
+        "year": 2003,
+        "layout": "goref",
+        "title": "Gene Ontology annotation of Drosophila melanogaster nuclear genes encoding proteins targeted to the mitochondrion.",
+        "comments": [
+            "Gene Ontology annotation of Drosophila melanogaster nuclear genes encoding proteins targeted to the mitochondrion based on analysis by MitoDrome (http://mitodrome.ba.itb.cnr.it/) by comparison of human mitochondrial proteins available in SWISSPROT vs. the Drosophila genome, ESTs and cDNA sequences available in the FlyBase database (PMID:12520013)."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000064",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of cell components as part of other cell components in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing cell components as part of other cell components. The underlying equivalence axiom template is \"P and 'part_of' some W\", where P and W are cell components."
+        ]
+    },
+    {
+        "authors": "Ensembl, GRAMENE, GOA curators",
+        "id": "GO_REF:0000035",
+        "year": 2011,
+        "layout": "goref",
+        "title": "Automatic transfer of experimentally verified manual GO annotation data to plant orthologs using Ensembl Compara",
+        "comments": [
+            "GO terms from a source species are projected onto one or more target species based on gene orthology obtained from the Ensembl Compara system. One to one, one to many and many to many orthologies are used but annotations are only projected between orthologs that have at least a 40% peptide identity to each other. Only GO annotations with an evidence type of IDA, IEP, IGI, IMP or IPI are projected, no annotations with a 'NOT' qualifier are projected and annotations to the GO:0005515 protein binding term are not projected. Projected GO annotations using this technique will receive the evidence code Inferred from Electronic Annotation (IEA). The model organism database identifier of the annotation source will be indicated in the 'With' column of the GOA association file.",
+            "Duplicate of GO_REF:0000107."
+        ]
+    },
+    {
+        "authors": "FlyBase",
+        "id": "GO_REF:0000097",
+        "year": 2014,
+        "layout": "goref",
+        "title": "Gene Ontology annotation based on personal communication to FlyBase",
+        "comments": [
+            "FlyBase occasionally makes GO annotations based on information that has been sent to us directly by researchers as a personal communication to FlyBase. In each case, the full details of the communication including any associated data and analyses are recorded in a FlyBase publication (FBrf) available from our website (http://flybase.org)."
+        ]
+    },
+    {
+        "authors": "GO Curators",
+        "external_accession": [
+            "ECO:0000307",
+            "AspGD_REF:ASPL0000111607",
+            "CGD_REF:CAL0125086",
+            "dictyBase_REF:2",
+            "dictyBase_REF:9851",
+            "FB:FBrf0159398",
+            "MGI:MGI:2156816",
+            "RGD:1598407",
+            "SGD_REF:S000069584",
+            "TAIR:Communication:1345790",
+            "ZFIN:ZDB-PUB-031118-1",
+            "GO_REF:nd"
+        ],
+        "id": "GO_REF:0000015",
+        "year": 2002,
+        "layout": "goref",
+        "title": "Use of the ND evidence code for Gene Ontology (GO) terms.",
+        "comments": [
+            "Direct annotations to any of the three root terms 'molecular function; GO:0003674', 'biological process; GO:0008150' or 'cellular component; GO:0005575' indicate that curators have found no data supporting an annotation to a more specific term, either in the literature and/or by sequence similarity for this gene or protein as of the date of the annotation."
+        ]
+    },
+    {
+        "authors": "UniProt curators",
+        "external_accession": [
+            "ZFIN:ZDB-PUB-170525-1"
+        ],
+        "id": "GO_REF:0000104",
+        "year": 2015,
+        "layout": "goref",
+        "title": "Electronic Gene Ontology annotations created by transferring manual GO annotations between related proteins based on shared sequence features.",
+        "comments": [
+            "GO terms are manually assigned to each rule in UniRule. These rules are prepared manually by UniProt curators based on the annotations present in reviewed UniProtKB/Swiss-Prot records that share sequence features, sequence similarity and taxonomy. The assigned GO terms are then transferred to all unreviewed UniProtKB/TrEMBL proteins that meet the conditions given in the UniRule rule. GO annotations using this technique receive the evidence code Inferred from Electronic Annotation (IEA; ECO:0000501). These annotations are updated regularly by UniProt and are available for download on both the GO and GOA EBI ftp sites. To report an annotation error or inconsistency, or for further information, please contact the UniProt Automated Annotation team at automated_annotation@ebi.ac.uk. UniRule is a collaboration between the European Bioinformatics Institute (EMBL-EBI), the Swiss Institute of Bioinformatics (SIB), and the Protein Information Resource at Georgetown University (PIR). For further information, please see UniProt: a hub for protein information Nucleic Acids Res. 2015, 43, D204, doi: 10.1093/nar/gku989 or www.uniprot.org."
+        ]
+    },
+    {
+        "authors": "UniProt-GOA",
+        "id": "GO_REF:0000044",
+        "external_accession": [
+            "TAIR:AnalysisReference:501756971",
+            "TAIR:AnalysisReference:50175724"
+        ],
+        "year": 2012,
+        "layout": "goref",
+        "title": "Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt.",
+        "comments": [
+            "Transitive assignment of GO terms based on the UniProtKB/Swiss-Prot Subcellular Location vocabulary. UniProtKB Subcellular Location is a controlled vocabulary used to supply subcellular location information to UniProtKB entries in the SUBCELLULAR LOCATION lines. Terms from this vocabulary are annotated manually to UniProtKB/Swiss-Prot entries but are automatically assigned to UniProtKB/TrEMBL entries from the underlying nucleic acid databases and/or by the UniProt automatic annotation program.\nFurther information on these two different annotation methods is available https://www.uniprot.org/help/keywords. \nWhen a UniProtKB Subcellular Location term describes a concept that is within the scope of the Gene Ontology, a mapping is manually made to the corresponding GO term. The translation table between GO terms and UniProtKB Subcellular Location term is maintained by the EBI GOA team and available at http://www.geneontology.org/external2go/spsl2go."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000083",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of plant morphogenesis as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the morphogenesis of a plant structure as a biological process. The underlying equivalence axiom template is \"'anatomical structure morphogenesis' and 'results in morphogenesis of' some P\", where P is a plant anatomical entity (PO:0025131)."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000070",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of transmembrane transporter activity as molecular function in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the transmembrane transporter activity a chemical entity (ChEBI) as molecular function. This includes variants for secondary active transmembrane transporter activity (GO:0015291), uptake transmembrane transporter activity (GO:0015563), and ATPase activity, coupled to transmembrane movement of substances (GO:0042626). The underlying equivalence axiom template is \"G and 'transports or maintains localization of' some X\",  where the genus G is either GO:0022857 (transmembrane transporter activity), GO:0015291, GO:0015563, or GO:0042626 depending on the variant. The variable X is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI has been described in the following publication: PMID:23895341."
+        ]
+    },
+    {
+        "authors": "Judith Blake (1, 2), William Bug (3), Rex Chisholm (1, 4), Jennifer Clark (1, 5), Erika Feltrin (6), Jacqueline Finger (2), David Hill (1, 2), Midori Harris (1, 5), Terry Hayamizu (2), Doug Howe (9), Maryanne Martone (7), Kathleen Millen (8), Francis Sele (4) (1. The Gene Ontology Consortium, 2. Mouse Genome Informatics, Bar Harbor, ME, 3. Drexel University, Philadelphia, PA, 4. Northwestern University, Chicago, IL, 5. EMBL-EBI, Hinxton, Cambridgeshire, UK, 6. The University of Padua, Padua, Italy, 7. The University of California at San Diego, San Diego, CA, 8. The University of Chicago, Chicago, IL, 9. The Zebrafish Information Network, University of Oregon, Eugene, OR)",
+        "id": "GO_REF:0000021",
+        "year": 2006,
+        "layout": "goref",
+        "title": "Improving the representation of central nervous system development in the biological process ontology",
+        "comments": [
+            "Current genetic and molecular studies in many model organisms are aimed at understanding formation and development of the nervous system. Up until this point, the GO has had a very shallow representation of processes pertaining to the nervous system. In June 2006, curators from MGI and ZFIN met with researchers studying central nervous system development to improve the representation of these processes in GO. In particular, emphasis was placed on three areas that are being addressed actively in current research: forebrain development, hindbrain development and neural tube development. This collaboration resulted in the addition of over 500 terms that reflect the development of the forebrain, the hindbrain, and the neural tube from the perspective of biological process and anatomical structure."
+        ]
+    },
+    {
+        "authors": "Alexander D. Diehl, Alison Deckhut Augustine, Judith A. Blake, Lindsay G. Cowell, Elizabeth S. Gold, Timothy A. Gondre-Lewis, Anna Maria Masci, Terrence F. Meehan, Penelope A. Morel, Anastasia Nijnik, Bjoern Peters, Bali Pulendran, Richard H. Scheuermann, Q. Alison Yao, Martin S. Zand, Christopher J. Mungall",
+        "id": "GO_REF:0000031",
+        "url": "http://www.bioontology.org/wiki/index.php/NIAID_Cell_Ontology_Workshop_May_2008",
+        "year": 2008,
+        "is_obsolete": true,
+        "layout": "goref",
+        "title": "OBSOLETE NIAID Cell Ontology Workshop",
+        "comments": [
+            "The NIAID sponsored a Cell Ontology Workshop, May 13-14, 2008, in Bethesda, focusing on improving representation of immune cell types in the Cell Ontology. The participants in the workshop worked together to extend the current ontology in the area of immune cell types and to provide the necessary information for the upcoming restructuring of the Cell Ontology in single-inheritance form with genus-differentia definitions."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000060",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of processes involved in other process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing processes involved in other processes. The underlying equivalence axiom template is \"P and 'part_of' some W\", where P and W are biological processes."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000093",
+        "year": 2014,
+        "layout": "goref",
+        "title": "Representation for the degradation to or via a chemical as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the degradation of a chemical entity to or via an other chemical entity as biological processes. The underlying equivalence axiom templates are \"GO:0009056 and 'has input' some S and 'has output' some T\" (catabolism to) and \"GO:0009056 and 'has input' some S and 'has intermediate' some I\" (catabolism via), where S,T, and I are chemical entities (CHEBI:24431). The approach to combine GO and ChEBI has been described in the following publication: PMID:23895341."
+        ]
+    },
+    {
+        "authors": "LIFEdb",
+        "id": "GO_REF:0000054",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Gene Ontology annotation based on curation of intracellular localizations of expressed fusion proteins in living cells.",
+        "comments": [
+            "LIFEdb is a database that was created to manage the experimental data produced by the German Cancer Research Institute (DKFZ) and its collaborators, from work on cDNAs contained in the German cDNA Consortium collection. <br>A novel cloning technology was used to rapidly generate N- and C-terminal green fluorescent protein fusions of cDNAs to examine the intracellular localizations of expressed fusion proteins in living cells. GO Cellular Component terms are manually assigned by curators studying fluorescence microscope images of cells labelled with GFP-fused cDNAs. Protein coding regions of novel full length cDNAs are tagged with the coding sequence of the green fluorescent protein, the fusion proteins are then expressed and analyzed for their subcellular localization. <br>Prior to February 2013, all LIFEdb annotations were referenced by PMID: 11256614 (Simpson et al. 2000 EMBO Rep. 1:287-292), a paper describing the protein subcellular localization pilot study and methodology used by LIFEdb. However, it has been decided that these annotations are more correctly described by a GO reference. <br>Resource URL: http://www.dkfz.de/en/mga/Groups/LIFEdb-Database.html <br>Protein subcellular localization images can be viewed on the LIFEdb website, http://www.dkfz.de/gpcf/lifedb.php"
+        ]
+    },
+    {
+        "authors": "Birgit Meldal and Sandra Orchard (1). (1) European Bioinformatics Institute (EBI), Hinxton, Cambridgeshire, United Kingdom",
+        "id": "GO_REF:0000114",
+        "year": 2018,
+        "layout": "goref",
+        "title": "Manual transfer of experimentally-verified manual GO annotation data to homologous complexes by curator judgment of sequence, composition and function similarity",
+        "comments": [
+            "Method for transferring manual annotations to an entry based on a curator's judgment of its similarity to a putative homolog that has annotations that are supported with experimental evidence. Annotations are created when a curator judges that the sequence, composition and function of a complex shows high similarity to another complex that has annotation(s) supported by experimental evidence (and therefore display one of the evidence codes ECO:0000353 [IPI] or ECO:0005543). Annotations resulting from the transfer of GO terms display the ECO:0005610, ECO:0005544 or ECO:0005546 evidence codes and include an accession for the complex from which the annotation was projected in the 'with/from' field (column 8). This field MUST contain a Complex Portal accession identifier. Putative homologs are chosen using information combined from a variety of complementary sources. Potential homologs are initially identified using sequence similarity search programs such as BLAST. Homologous relationships are then verified manually using a combination of resources including sequence analysis tools, phylogenetic and comparative genomics databases such as Ensembl Compara, INPARANOID and OrthoMCL, as well as other specialised databases such as species-specific collections (e.g. HGNC's HCOP). In all cases curators check the alignments for each complex component and use their experience to assess whether similarity is considered to be strong enough to infer that the two proteins have a common function so that they can confidently project an annotation. While there is no fixed cut-off point in percentage sequence similarity, generally proteins which have greater than 70% identity that covers greater than 90% of the length of both proteins are examined further. Whilst we expect subunit composition to be conserved between closely related species, this is not an absolute rule and orthologous complexes may differ if a subunit cannot be traced in one species or is experimentally shown not to be present. When there is evidence of multiple paralogs for a single species, multiple variants of the complex can be inferred."
+        ]
+    },
+    {
+        "authors": "FlyBase",
+        "external_accession": [
+            "FB:FBrf0145624"
+        ],
+        "id": "GO_REF:0000105",
+        "year": 2016,
+        "layout": "goref",
+        "title": "Gene Ontology annotation of transfer RNAs based on tRNAscan-SE analysis of the Drosophila melanogaster genome (2002).",
+        "comments": [
+            "Gene Ontology annotation based on predicted cytoplasmic tRNAs using tRNAscan-SE analysis (doi: 10.1093/nar/25.5.0955) of the Drosophila melanogaster genome (2002). Annotations have been reviewed by FlyBase (2015) and found to be consistent when compared with the most recent tRNAscan-SE analysis of the genome (http://gtrnadb.ucsc.edu/genomes/eukaryota/Dmela6/)."
+        ]
+    },
+    {
+        "authors": "UniProt-GOA",
+        "id": "GO_REF:0000045",
+        "is_obsolete": true,
+        "year": 2012,
+        "layout": "goref",
+        "title": "OBSOLETE Gene Ontology annotation based on UniProtKB/TrEMBL entries keyword mapping, accompanied by conservative changes to GO terms applied by UniProt.",
+        "comments": [
+            "Transitive assignments using UniProtKB/TrEMBL keywords. The UniProtKB keyword controlled vocabulary has been created and used by the UniProt Knowledgebase (UniProtKB) to supply 10 different categories of information to UniProtKB/TrEMBL entries entries. Further information on the UniProtKB keyword resource can be found at http://www.uniprot.org/docs/keywlist.<br>UniProtKB keywords are assigned to UniProtKB/UniProtKB entries by UniProt curators as part of the UniProtKB manual curation process. In contrast however, UniProtKB keywords are automatically assigned to UniProtKB/TrEMBL entries from the underlying nucleic acid databases and/or by the UniProt automatic annotation program.<br>Further information on the two different UniProt annotation methods is available at http://www.uniprot.org/faq/45 and http://www.uniprot.org/program/automatic_annotation.<br>When a UniProtKB keyword describes a concept that is within the scope of the Gene Ontology, it is investigated to determine whether it is appropriate to map the keyword to an equivalent term in GO. The translation table between GO terms and UniProtKB keywords is maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/uniprotkb_kw2go.<br>Please note that the GO term in the annotation assigned with this GO reference has been changed from that originally applied by the UniProtKB keywords 2GO mapping. This change has been carried out by the UniProt group to ensure the GO annotation obeys the GO Consortium\u2019s ontology structure and taxonomic constraints. Further information on the rules used by UniProt to transform specific incorrect IEA annotations is available at http://www.ebi.ac.uk/QuickGO/AnnotationPostProcessing.html.",
+            "Duplicate of GO_REF:0000004."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000082",
+        "is_obsolete": true,
+        "year": 2013,
+        "layout": "goref",
+        "title": "OBSOLETE Representation of plant maturation as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the maturation of a plant structure as a biological process. The underlying equivalence axiom template is \"'developmental maturation' and 'results in developmental progression of' some P\", where P is a plant anatomical entity (PO:0025131)."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000071",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of response to and cellular response to a chemical as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the response to and cellular response to a chemical entity (ChEBI) as a biological process. The underlying equivalence axiom templates are \"GO:0050896 and 'has input' some X\" (response to) and \"GO:0070887 and 'has input' some X\" (cellular response to), where X is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI has been described in the following publication: PMID:23895341."
+        ]
+    },
+    {
+        "authors": "Swiss Institute of Bioinformatics (SIB) curators, GOA curators",
+        "id": "GO_REF:0000020",
+        "year": 2006,
+        "layout": "goref",
+        "title": "Electronic Gene Ontology annotations created by transferring manual GO annotations between orthologous microbial proteins",
+        "comments": [
+            "GO terms are manually assigned to each HAMAP family rule. High-quality Automated and Manual Annotation of microbial Proteins (HAMAP) family rules are a collection of orthologous microbial protein families, from bacteria, archaea and plastids, generated manually by expert curators. The assigned GO terms are then transferred to all the proteins that belong to each HAMAP family. Only GO terms from the molecular function and biological process ontologies are assigned. GO annotations using this technique will receive the evidence code Inferred from Electronic Annotation (IEA). These annotations are updated monthly by HAMAP and are available for download on both GO and GOA EBI ftp sites. To report an annotation error or inconsistency, or for further information, please contact the GO Consortium at gohelp@genome.stanford.edu or submit a comment the SourceForge Annotation Issues tracker (http://sourceforge.net/projects/geneontology/). HAMAP is a project based at the Swiss Institute of Bioinformatics (Gattiker et al. 2003, Comp. Biol and Chem. 27: 49-58). For further information, please see http://www.expasy.org/sprot/hamap/."
+        ]
+    },
+    {
+        "authors": "Daniel Haft, JCVI",
+        "id": "GO_REF:0000030",
+        "year": 2008,
+        "is_obsolete": true,
+        "layout": "goref",
+        "title": "OBSOLETE Portable Annotation Rules",
+        "comments": [
+            "The JCVI is developing a collection of mixed-evidence annotation rules, under the working name BrainGrab/RuleBase (BGRB). A rule has two parts. The first is the set of conditions that must be met for the rule to fire. The second is the set actions to be taken for rules that have fired. BGRB rules are designed to serve as proxies for the annotators that create them. They have very high fidelity but may have low coverage. Types of evidence used in combination include HMM hits and BLAST matches, hits to neighboring genes, pathway reconstruction reports from the Genome Properties system, and species taxonomy. BLAST matches are described by a number of separate parameters for raw score, percent sequence identity, and coverage of total sequence length by the match region. These parameters are customized for each protein family in order to achieve high fidelity in automated annotation systems. The flexible syntax makes it possible to use existing protein family classifiers, such as Pfam and TIGRFAMs HMMs, in new ways. It is especially useful in assigning GO terms to proteins such as SelD (selenide, water dikinase) that have different roles in different contexts."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000061",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of a molecular function involved in a biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing molecular function involved in other biological processes. The underlying equivalence axiom template is \"P and 'part_of' some W\", where P is a molecular function and W is a biological processes."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000092",
+        "year": 2014,
+        "layout": "goref",
+        "title": "Representation for the biosynthesis from or via a chemical as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the biosynthesis of a chemical entity from or via an other chemical entity as biological processes. The underlying equivalence axiom templates are \"GO:0009058 and 'has output' some T and 'has input' some F\" (biosynthesis from) and \"GO:0009058 and 'has output' some T and 'has intermediate' some I\" (biosynthesis via), where T,F, and I are chemical entities (CHEBI:24431). The approach to combine GO and ChEBI has been described in the following publication: PMID:23895341."
+        ]
+    },
+    {
+        "authors": "AgBase biocurators",
+        "id": "GO_REF:0000055",
+        "year": 2013,
+        "is_obsolete": true,
+        "layout": "goref",
+        "title": "OBSOLETE Gene Ontology Cellular Component annotation based on cellular fractionation.",
+        "comments": [
+            "Assignment of GO Cellular Component terms based on experimental evidence of cellular localization from Differential Detergent Fractionation (DDF). Cellular proteins are differentially fractionated and detected using mass spectrometry. Subcellular localization is based upon identification of proteins in different fractions and analysis of their predicted transmembrane domains. Proteins are assigned GO CC based upon a manually reviewed DDF2GO mapping file."
+        ]
+    },
+    {
+        "authors": "RNAcentral (1). (1) European Bioinformatics Institute (EMBL-EBI), Hinxton, Cambridgeshire, United Kingdom",
+        "id": "GO_REF:0000115",
+        "year": 2018,
+        "layout": "goref",
+        "title": "Automatic Gene Ontology annotation of non-coding RNA sequences through association of Rfam records with GO terms",
+        "comments": [
+            "Rfam (http://rfam.org, PMID:29112718) is a database of non-coding RNA families which are manually\nannotated with GO terms by Rfam curators. RNAcentral (http://rnacentral.org, PMID:27794554) maintains\na comprehensive collection of non-coding RNA sequences that are regularly annotated with Rfam families\nusing the Infernal software (PMID:24008419). When a non-coding RNA sequence is matched to one or more Rfam families\nby sequence similarity, the GO terms associated with the Rfam family are transitively assigned to the non-coding RNA sequence.\nAnnotations resulting from the transfer of GO terms are assigned the ECO:0000256 evidence code\n(match to sequence model evidence used in automatic assertion) and include RNAcentral and Rfam accessions. \nThe annotations are available on the GOA and EMBL-EBI FTP sites. \nThe mapping between Rfam families and GO terms is available at http://www.geneontology.org/external2go/rfam2go, \nand the Infernal software can be downloaded at http://eddylab.org/infernal. To report an annotation error or inconsistency, \nor for further information, please visit the RNAcentral website at http://rnacentral.org."
+        ]
+    },
+    {
+        "alt_id": [
+            "GO_REF:0000009",
+            "GO_REF:0000013"
+        ],
+        "authors": "GOA curators",
+        "external_accession": [
+            "MGI:1354194",
+            "J:60000",
+            "ZFIN:ZDB-PUB-020723-1",
+            "SGD_REF:S000124038"
+        ],
+        "id": "GO_REF:0000004",
+        "year": 2000,
+        "layout": "goref",
+        "title": "Gene Ontology annotation based on UniProtKB keyword mapping.",
+        "comments": [
+            "Transitive assignments using UniProtKB keywords. The UniProtKB keyword controlled vocabulary has been created and used by the UniProt Knowledgebase (UniProtKB) to supply 10 different categories of information to UniProtKB entries. Further information on the UniProtKB keyword resource can be found at http://www.uniprot.org/docs/keywlist. <br>Further information on the UniProt annotation methods is available at  https://www.uniprot.org/help/manual_curation and https://www.uniprot.org/help/automatic_annotation.\n<br>When a UniProtKB keyword describes a concept that is within the scope of the Gene Ontology, it is investigated to determine whether it is appropriate to map the keyword to an equivalent term in GO. The mapping between UniProtKB keywords and GO terms is carried out manually. Definitions and hierarchies of the terms in the two resources are compared and the mapping generated will reflect the most correct correspondence. The translation table between GO terms and UniProtKB keywords is maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/uniprotkb_kw2go.",
+            "Formerly GOA:spkw."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000086",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of cell differentiation as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the differentiation process for a cell type as a biological process. The underlying equivalence axiom template is \"GO:0030154 and 'results in acquisition of features of' some C\", where C is a native cell (CL:0000003)."
+        ]
+    },
+    {
+        "authors": "AgBase, BHF-UCL, Parkinson's UK-UCL, dictyBase, HGNC, Roslin Institute, FlyBase and UniProtKB curators.",
+        "external_accession": [
+            "dictyBase_REF:9",
+            "J:73065",
+            "J:104715",
+            "FB:FBrf0202953",
+            "FB:FBrf0212479",
+            "FB:FBrf0232278",
+            "FB:FBrf0232279"
+        ],
+        "id": "GO_REF:0000024",
+        "url": "http://www.ebi.ac.uk/GOA/ISS_method.html",
+        "year": 2011,
+        "layout": "goref",
+        "title": "Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity.",
+        "comments": [
+            "Method for transferring manual annotations to an entry based on a curator's judgment of its similarity to a putative ortholog that has annotations that are supported with experimental evidence. Annotations are created when a curator judges that the sequence of a protein shows high similarity to another protein that has annotation(s) supported by experimental evidence (and therefore display one of the evidence codes EXP, IDA, IGI, IMP, IPI or IEP). Annotations resulting from the transfer of GO terms display the 'ISS' evidence code and include an accession for the protein from which the annotation was projected in the 'with' field (column 8). This field can contain either a UniProtKB accession or an IPI (International Protein Index) identifier. Only annotations with an experimental evidence code and which do not have the 'NOT' qualifier are transferred. Putative orthologs are chosen using information combined from a variety of complementary sources. Potential orthologs are initially identified using sequence similarity search programs such as BLAST. Orthology relationships are then verified manually using a combination of resources including sequence analysis tools, phylogenetic and comparative genomics databases such as Ensembl Compara, INPARANOID and OrthoMCL, as well as other specialised databases such as species-specific collections (e.g. HGNC's HCOP). In all cases curators check each alignment and use their experience to assess whether similarity is considered to be strong enough to infer that the two proteins have a common function so that they can confidently project an annotation. While there is no fixed cut-off point in percentage sequence similarity, generally proteins which have greater than 30% identity that covers greater than 80% of the length of both proteins are examined further. For mammalian proteins this cut-off tends to be higher, with an average of 80% identity over 90% of the length of both proteins. Strict orthologs are desirable but not essential. In general, when there is evidence of multiple paralogs for a single species, annotations using less specific GO terms are transferred to the paralogs, however, annotations using more specific GO terms may be transferred to the most similar paralog in each species, this decision is taken on a case by case basis and may be influenced by statements by researchers in the field. Further detailed information on this procedure, including how ISS annotations are made to protein isoforms, can be found at: http://www.ebi.ac.uk/GOA/ISS_method.html."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000075",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of transport of a chemical into a cellular component as biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the transport of a chemical entity (ChEBI) into a cellular component as a biological process. The underlying equivalence axiom template is \"GO:0006810 and 'has_target_end_location' some T and 'imports' some S\", where T is a cellular component and S is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI has been described in the following publication: PMID:23895341."
+        ]
+    },
+    {
+        "authors": "Sascha Steinbiss, GeneDB curators",
+        "id": "GO_REF:0000101",
+        "year": 2015,
+        "layout": "goref",
+        "title": "Automated transfer of experimentally-verified GO annotation data to close orthologs",
+        "comments": [
+            "This reference is used to describe functional annotations transferred from one or more reference (\"source\") organisms to a newly annotated (\"target\") organism on the basis of ortholog cluster membership. In detail, predicted (e.g. by AUGUSTUS, see doi:10.1186/1471-2105-7-62) or transferred (e.g. via RATT, see doi:10:1093/nar/gkg1268) gene models in the target genome are translated and processed by OrthoMCL 1.4 together with reference protein sequences to produce clusters of gene products derived from orthologous genes. For each cluster, GO terms are automatically transferred from source products to the target gene products if they are experimentally verified (IDA (ECO:0000314), IMP (ECO:0000315), IPI (ECO:0000353), IGI (ECO:0000316), (EXP ECO:0000269). They are tagged with the ISO evidence code and the \"with/from\" is populated with the source feature references (e.g. \"GeneDB:LmjF.28.0960\"). OrthoMCL runs are done using the parameterization suggested in the OrthoMCL algorithm document (blastall -F 'm S' -e 1e-5)."
+        ]
+    },
+    {
+        "authors": "UniProt-GOA",
+        "external_accession": [
+            "ZFIN:ZDB-PUB-130131-1"
+        ],
+        "id": "GO_REF:0000041",
+        "year": 2012,
+        "layout": "goref",
+        "title": "Gene Ontology annotation based on UniPathway vocabulary mapping.",
+        "comments": [
+            "Transitive assignment of GO terms based on the UniPathway pathway vocabulary. UniPathway is a manually curated resource of enzyme-catalyzed and spontaneous chemical reactions. It provides a hierarchical representation of metabolic pathways. Descriptions of the pathway(s) that a particular protein is involved in are included in UniProtKB records.<br>UniPathway data are cross-linked to existing pathway resources such as KEGG and MetaCyc. Further information on the UniPathway resource is available at http://www.unipathway.org/obiwarehouse/unipathway.<br>When a UniPathway pathway describes a concept that is within the scope of the Gene Ontology, it is investigated to determine whether it is appropriate to map the term to an equivalent term in GO. The mapping between UniPathway terms and GO terms is carried out manually. Definitions and hierarchies of the terms in the two resources are compared and the mapping generated will reflect the most correct correspondence. The translation table between GO terms and UniPathway pathways is maintained by the UniPathway team and is available at http://www.grenoble.prabi.fr/dev/obiwarehouse/download/unipathway/public/unipathway2go.tsv."
+        ]
+    },
+    {
+        "authors": "Mouse Genome Informatics scientific curators",
+        "citation": "PMID:11374909",
+        "external_accession": [
+            "MGI:1347124",
+            "J:56000"
+        ],
+        "id": "GO_REF:0000010",
+        "is_obsolete": true,
+        "year": 1999,
+        "layout": "goref",
+        "title": "OBSOLETE Gene Ontology annotation by the MGI curatorial staff, mouse gene nomenclature",
+        "comments": [
+            "For annotations documented via this citation, curators designed queries based on their knowledge of mouse gene nomenclature to group genes that shared common molecular functions, biological processes or cellular components. GO annotations were assigned to these genes in groups. Details of this strategy can be found in Hill et al., Genomics (2001) 74:121-128."
+        ]
+    },
+    {
+        "authors": "PomBase curators",
+        "id": "GO_REF:0000051",
+        "year": 2012,
+        "layout": "goref",
+        "title": "S. pombe keyword mapping",
+        "comments": [
+            "Active 2006-2012.",
+            "Keywords derived from manually curated primary annotation, e.g. gene product descriptions, are mapped to GO terms. Annotations made by this method have the evidence code Non-traceable Author Statement (NAS), and are filtered from the PomBase annotation files wherever another annotation exists that is equally or more specific, and supported by experimental or manually evaluated comparative evidence (such as ISS and its subtypes). Formerly GOC:pombekw2GO."
+        ]
+    },
+    {
+        "authors": "TBD",
+        "external_accession": [
+            "FB:FBrf0233689"
+        ],
+        "id": "GO_REF:0000111",
+        "year": 2016,
+        "layout": "goref",
+        "title": "Gene Ontology annotations Inferred by Curator (IC) using at least one Inferred by Sequence Similarity (ISS) annotation to support the inference",
+        "comments": [
+            "The Gene Ontology Consortium uses the IC (Inferred by Curator; ECO:0000305) evidence code when assignment of a GO term cannot be supported by direct experimental or sequence-based evidence, but can, based on a curator\u2019s biological knowledge, be reasonably inferred from existing GO annotations to the same gene/gene product.  Use of the IC evidence code with GO_REF:0000111 indicates that a curator inferred the GO term based on at least one supporting annotation with an 'Inferred from Sequence Similarity' (ISS; ECO:0000250) evidence code.  Note that additional supporting annotations may be experimentally evidenced. When using GO_REF:0000111, the 'with/from' field must contain all GO identifiers used as supporting annotations."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000065",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of transport of a chemical entity as a biological process in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing transport of a chemical entity (ChEBI) as a biological process. The underlying equivalence axiom template is \"GO:0006810 and 'transports or maintains localization of' some X\", where X is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI has been described in the following publication: PMID:23895341."
+        ]
+    },
+    {
+        "authors": "Brian K. Hall (Dalhousie University), Matthew Vickaryous (Ontario Veterinary College, University of Guelph), David Blackburn, University of Kansas; Wasila Dahdul, University of South Dakota and NESCent; Alexander Diehl, Mouse Genome Informatics (MGI); Melissa Haendel, Oregon Health Sciences University; John G. Lundberg, Department of Ichthyology, Academy of Natural Sciences, Philadelphia; Paula Mabee, Department of Biology, University of South Dakota; Martin Ringwald, Mouse Genome Informatics (MGI); Erik Segerdell, Oregon Health Sciences University; Ceri Van Slyke, Zebrafish Information Network (ZFIN); Monte Westerfield, Zebrafish Information Network (ZFIN) and Institute of Neuroscience, University of Oregon.",
+        "id": "GO_REF:0000034",
+        "year": 2010,
+        "layout": "goref",
+        "title": "Phenoscape Skeletal Anatomy Jamboree",
+        "comments": [
+            "Skeletal cell terms and relationships were added and revised at the Skeletal Anatomy Jamboree held by Phenoscape (NSF grant BDI-0641025) and hosted by the National Evolutionary Synthesis Center (NESCent), April 9-10, 2010."
+        ]
+    },
+    {
+        "authors": "Mouse Genome Informatics scientific curators",
+        "external_accession": [
+            "J:164563",
+            "J:155856",
+            "RGD:1624291"
+        ],
+        "id": "GO_REF:0000096",
+        "year": 2014,
+        "layout": "goref",
+        "title": "Automated transfer of experimentally-verified manual GO annotation data to close orthologs.",
+        "comments": [
+            "Mouse Genome Database (MGD), The HUGO Gene Nomenclature Committee (HGNC), and Rat Genome Database (RGD) have extensive procedures in place, overseen by expert curation, to establish orthology relationships between their genes. The Experimentally based annotations annotated by each group (IDA, IMP IPI, IGI, and EXP) are used to provide annotations  to the respective mouse and rat orthologs, and given the ISO evidence code and an entry in the inferred_from field to indicate the orthologous entity. "
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000089",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of single-organism and multi-organism biological processes in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes describing the single-organism and multi-organism biological processes. The underlying equivalence axiom templates are \"P and 'bearer_of' some PATO:0002487\" (single-organism) and \"P and 'bearer_of' some PATO:0002486\" (multi-organism), where P is a biological process."
+        ]
+    },
+    {
+        "authors": "FlyBase",
+        "id": "GO_REF:0000099",
+        "is_obsolete": true,
+        "year": 2014,
+        "layout": "goref",
+        "title": "OBSOLETE Gene Ontology annotation based on DNA/RNA sequence records",
+        "comments": [
+            "Prior to 2005, FlyBase made GO annotations based on information in DNA/RNA sequence records in GenBank/EMBL/DDBJ. We no longer add GO annotations based on sequence records and gradually replacing these GO annotations as other sources of evidence become available."
+        ]
+    },
+    {
+        "authors": "GO ontology editors",
+        "id": "GO_REF:0000088",
+        "year": 2013,
+        "layout": "goref",
+        "title": "Representation of protein complex by molecular function in the Gene Ontology",
+        "comments": [
+            "We have created a standard template for classes defining a protein complex by a molecular function as a cellular component. The underlying equivalence axiom template is \"GO:0043234 and 'capable_of' some ?A\", where A is a molecular function."
+        ]
+    },
+    {
+        "authors": "FlyBase",
+        "id": "GO_REF:0000098",
+        "is_obsolete": true,
+        "year": 2014,
+        "layout": "goref",
+        "title": "OBSOLETE Gene Ontology annotation based on research conference abstracts",
+        "comments": [
+            "Prior to 2008, FlyBase made GO annotations based on information in abstracts for research conferences, primarily the Annual Drosophila Research Conference and the European Drosophila Research Conference. We no longer curate conference abstracts and we are gradually replacing all abstract-based GO annotation with annotation based on experimental data in primary research papers."
+        ]
+    }
+]

--- a/metadata/gorefs/gorefs.schema.json
+++ b/metadata/gorefs/gorefs.schema.json
@@ -1,36 +1,42 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "https://example.com/gorefs.schema.json",
-    "title": "object",
-    "properties": {
-        "authors": {
-            "type": "string",
-            "description": ""
-        },
-        "id": {
-            "type": "string",
-            "description": ""
-        },
-        "is_obsolete": {
-            "type":"boolean",
-            "description": ""
-        },
-        "year": {
-            "type": "integer",
-            "description": ""
-        },
-        "layout": {
-            "type": "string",
-            "description": ""
-        },
-        "title": {
-            "type": "string",
-            "description": ""
-        },
-        "comments": {
-            "type": "array",
-            "items": {
-                "type": "string"
+    "title": "JSON Schema for validating gorefs.yaml",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "authors": {
+                "type": "string",
+                "description": ""
+            },
+            "id": {
+                "type": "string",
+                "pattern": "GO_REF:\\d{7}",
+                "description": ""
+            },
+            "is_obsolete": {
+                "type":"boolean",
+                "description": ""
+            },
+            "year": {
+                "type": "integer",
+                "description": ""
+            },
+            "layout": {
+                "type": "string",
+                "description": ""
+            },
+            "title": {
+                "type": "string",
+                "description": ""
+            },
+            "comments": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "description": ""
             }
         }
     }

--- a/metadata/gorefs/gorefs.schema.json
+++ b/metadata/gorefs/gorefs.schema.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://example.com/gorefs.schema.json",
+    "title": "object",
+    "properties": {
+        "authors": {
+            "type": "string",
+            "description": ""
+        },
+        "id": {
+            "type": "string",
+            "description": ""
+        },
+        "is_obsolete": {
+            "type":"boolean",
+            "description": ""
+        },
+        "year": {
+            "type": "integer",
+            "description": ""
+        },
+        "layout": {
+            "type": "string",
+            "description": ""
+        },
+        "title": {
+            "type": "string",
+            "description": ""
+        },
+        "comments": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/metadata/gorefs/gorefs.yaml
+++ b/metadata/gorefs/gorefs.yaml
@@ -1,2045 +1,1969 @@
-authors: GOA-UniProt curators
-id: GO_REF:0000029
-is_obsolete: true
-year: 2007
-layout: goref
-title: OBSOLETE Gene Ontology annotation based on information extracted from curated
-  UniProtKB entries
-comments:
-- Active 2001-2007.
-- Method by which GO terms were manually assigned to UniProt KnowledgeBase accessions,
-  using either a NAS or TAS evidence code, by applying information extracted from
-  the corresponding publicly-available, manually curated UniProtKB entry. Such GO
-  annotations were submitted by the GOA-UniProt group from 2001, but this annotation
-  practice was discontinued in 2007.
----
-authors: GO ontology editors
-id: GO_REF:0000078
-year: 2013
-layout: goref
-title: Representation for the transport or vesicle-mediated transport of a chemical
-  from and/or to a cell component as biological process in the Gene Ontology
-comments:
-- 'We have created a standard template for classes describing the transport or vesicle-mediated
-  transport of a chemical entity (ChEBI) from and/or to a cellular component as a
-  biological process. The underlying equivalence axiom templates are "GO:0006810 and
-  ''transports or maintains localization of'' some X [ and ''has_target_start_location''
-  some F] [ and ''has_target_end_location'' some T]" (transport) and "GO:0016192 and
-  ''transports or maintains localization of'' some X [ and ''has_target_start_location''
-  some F] [ and ''has_target_end_location'' some T]" (vesicle-mediated transport),
-  where F and T are cellular components and X is a chemical entity (CHEBI:24431).
-  The approach to combine GO and ChEBI has been described in the following publication:
-  PMID:23895341.'
----
-authors: GO ontology editors
-id: GO_REF:0000068
-year: 2013
-layout: goref
-title: Representation of metabolic triad (metabolism, catabolism, biosynthesis) as
-  biological process in the Gene Ontology
-comments:
-- 'We have created a standard template for classes each describing the metabolism,
-  catabolism, or biosynthesis of a chemical entity (ChEBI) as a process. The underlying
-  equivalence axiom templates are "GO:0008152 and ''has participant'' some X" (metabolism),
-  "GO:0009056 and ''has input'' some X" (catabolism), "GO:0009058 and ''has output''
-  some X" and (biosynthesis),  where X is a chemical entity (CHEBI:24431). The approach
-  to combine GO and ChEBI has been described in the following publication: PMID:23895341.'
----
-authors: UniProt-GOA
-id: GO_REF:0000039
-year: 2011
-layout: goref
-title: OBSOLETE Gene Ontology annotation based on the manual assignment of UniProtKB
-  Subcellular Location terms in UniProtKB/Swiss-Prot entries.
-comments:
-- Transitive assignment of GO terms based on the UniProtKB Subcellular Location vocabulary.
-  UniProtKB Subcellular Location is a controlled vocabulary used to supply subcellular
-  location information to UniProtKB entries in the SUBCELLULAR LOCATION lines. Terms
-  from this vocabulary are annotated manually to UniProtKB/Swiss-Prot entries. Further
-  information on the UniProtKB manual annotation method is available at http://www.uniprot.org/faq/45.<br>When
-  a UniProtKB Subcellular Location term describes a concept that is within the scope
-  of the Gene Ontology, it is investigated to determine whether it is appropriate
-  to map the term to an equivalent term in GO. The mapping between UniProtKB Subcellular
-  Location terms and GO terms is carried out manually. Definitions and hierarchies
-  of the terms in the two resources are compared and the mapping generated will reflect
-  the most correct correspondence. The translation table between GO terms and UniProtKB
-  Subcellular Location terms is maintained by the UniProt-GOA team and available at
-  http://www.geneontology.org/external2go/spsl2go.
----
-authors: Ensembl curators, GOA curators
-id: GO_REF:0000019
-is_obsolete: true
-year: 2006
-layout: goref
-title: OBSOLETE Automatic transfer of experimentally verified manual GO annotation
-  data to orthologs using Ensembl Compara
-comments:
-- GO terms from a source species are projected on to one or more target species based
-  on gene orthology obtained from the Ensembl Compara system. Only one to one and
-  apparent one to one orthologies are used for a restricted range of species. Only
-  GO annotations with a manual experimental evidence type of IDA, IEP, IGI, IMP or
-  IPI are projected. Projected GO annotations using this technique will receive the
-  evidence code, inferred from electronic annotation, 'IEA'. The Ensembl protein identifier
-  of the annotation source is indicated in the 'With' column of the GOA association
-  file.
----
-authors: GOA curators
-id: GO_REF:0000108
-year: 2016
-layout: goref
-title: Automatic assignment of GO terms using logical inference, based on on inter-ontology
-  links.
-comments:
-- GO terms are automatically assigned based on inter-ontology links to generate inferred
-  annotations. Annotations from Molecular Function to Biological Process can be propagated,
-  as well as between Biological Process and Cellular Component. Annotations that are
-  created using this inference method receive either the evidence code ECO:0000366
-  (evidence based on logical inference from automatic annotation used in automatic
-  assertion) or ECO:0000364 (evidence based on logical inference from manual annotation
-  used in automatic assertion), depending on whether the source annotation has a manual
-  or automatic evidence code. Both of these codes map up to the GO Inferred from Electronic
-  Annotation (IEA) evidence code.
----
-authors: TIGR Arabidopsis annotation team
-external_accession:
-- TAIR:Communication:501714663
-id: GO_REF:0000048
-is_obsolete: true
-year: 2005
-layout: goref
-title: OBSOLETE TIGR's Eukaryotic Manual Gene Ontology Assignment Method
-comments:
-- This describes TIGR curators' interpretation of a combination of evidence. Our internal
-  software tools present us with a great deal of evidence based on domains, sequence
-  similarities, signal sequences, paralogous proteins, etc. The curator interprets
-  the body of evidence to make a decision about a GO assignment when an external reference
-  is not available. The curator places one or more accessions that informed the decision
-  in the "with" field.
----
-authors: GO ontology editors
-id: GO_REF:0000058
-year: 2013
-layout: goref
-title: Representation of regulation in the Gene Ontology (biological process)
-comments:
-- We have created a standard template for the definition of classes for the regulation
-  of a biological process. This includes the definitions for positive and negative
-  regulation. The equivalence axiom templates are "GO:0065007 and 'regulates' some
-  X" (regulation), "GO:0065007 and 'negatively_regulates' some X" (negative regulation),
-  and "GO:0065007 and 'positively_regulates' some X" (positive regulation), where
-  X is a biological process.
----
-authors: DictyBase curators
-external_accession:
-- dictyBase_REF:10158
-id: GO_REF:0000018
-is_obsolete: true
-year: 2005
-layout: goref
-title: OBSOLETE dictyBase 'Inferred from Electronic Annotation (BLAST method)'
-comments:
-- Gene Ontology (GO) annotations with the evidence code 'Inferred from Electronic
-  Annotation' (IEA) are assigned automatically to gene products in dictyBase. All
-  Dictyostelium protein sequences are analyzed by BLAST against GO gene association
-  sequence files, identifying proteins in other organisms that align with Dictyostelium
-  proteins with an E value less than or equal to e-50. GO annotations that have been
-  manually assigned to these proteins from other species are then imported and attached
-  to the corresponding gene product in dictyBase. The proteins from which the annotations
-  are derived are displayed in the 'Evidence' column on the Gene Ontology evidence
-  and references page.
----
-authors: TrypTag
-id: GO_REF:0000109
-year: 2016
-layout: goref
-title: Gene Ontology annotation based on curation of genome-wide subcellular localisation
-  of proteins using fluorescent protein tagging in Trypanosoma brucei
-comments:
-- 'Trypanosomes are exquisitely structured cells in which protein localisation can
-  be extremely informative for likely function. TrypTag is a project using expression
-  of N- and C-terminal mNeonGreen fusion proteins from the endogenous loci to determine
-  the subcellular localisation of every gene in the Trypanosoma brucei genome. GO
-  Cellular Component terms are manually assigned by curators studying fluorescence
-  microscope images of the resulting cells labelled with mNeonGreen fusion proteins.
-  As trypanosomes are a pathogenic basal eukaryote, this will indicate likely function
-  of both highly conserved eukaryote genes and parasite-specific genes. Resource URL:
-  http://www.tryptag.org Protein subcellular localisation images can be viewed on
-  the Tryptag website, e.g. http://www.tryptag.org?id=Tb927.8.1550'
----
-authors: Ensembl Genomes
-id: GO_REF:0000049
-is_obsolete: true
-year: 2012
-layout: goref
-title: OBSOLETE Automatic transfer of experimentally verified manual GO annotation
-  data to fungal orthologs using Ensembl Compara
-comments:
-- GO terms from a source species are projected onto one or more target species based
-  on gene orthology obtained from the Ensembl Compara system. One to one, one to many
-  and many to many orthologies are used but annotations are only projected between
-  orthologs that have at least a 40% peptide identity to each other. Only GO annotations
-  with an evidence type of IDA, IEP, IGI, IMP or IPI are projected, no annotations
-  with a 'NOT' qualifier are projected and annotations to the GO:0005515 protein binding
-  term are not projected. Projected GO annotations using this technique will receive
-  the evidence code Inferred from Electronic Annotation (IEA). The model organism
-  database identifier of the annotation source will be indicated in the 'With' column
-  of the GOA association file.
-- Duplicate of GO_REF:0000107.
----
-authors: GO ontology editors
-id: GO_REF:0000059
-year: 2013
-layout: goref
-title: Representation of regulation in the Gene Ontology (molecular function)
-comments:
-- We have created a standard template for the definition of classes for the regulation
-  of a molecular function. This includes the definitions for positive and negative
-  regulation. The equivalence axiom templates are "GO:0065007 and 'regulates' some
-  X" (regulation), "GO:0065007 and 'negatively_regulates' some X" (negative regulation),
-  and "GO:0065007 and 'positively_regulates' some X" (positive regulation), where
-  X is a molecular function.
----
-authors: Mouse Genome Informatics scientific curators
-external_accession:
-- MGI:2154458
-- J:73065
-id: GO_REF:0000008
-year: 2001
-layout: goref
-title: Gene Ontology annotation by the MGI curatorial staff, curated orthology
-comments:
-- The sequence conservation that permits the establishment of orthology between mouse
-  and rat or mouse and human genes is a strong predictor of the conservation of function
-  for the gene product across these species. Therefore, in instances where a mouse
-  gene product has not been functionally characterized, but its human or rat orthologs
-  have, Mouse Genome Informatics (MGI) curators append the GO terms associated with
-  the orthologous gene(s) to the mouse gene. Only those GO terms assigned by experimental
-  determination to the ortholog of the mouse gene will be adopted by MGI. GO terms
-  that are assigned to the ortholog of the mouse gene computationally (i.e. IEA),
-  will not be transferred to the mouse ortholog. The evidence code represented by
-  this citation is Inferred by Sequence Orthology (ISO).
----
-authors: PAMGO_MGG curators
-id: GO_REF:0000028
-year: 2008
-layout: goref
-title: Criteria for IDA, IEP, ISS, IGC, RCA, and IEA assignment in PAMGO_MGG
-comments:
-- This GO reference describes the criteria used in assigning the evidence codes of
-  IDA (ECO:0000314), IEP (ECO:0000270), ISS (ECO:0000250), IGC (ECO_0000317), RCA
-  (ECO:0000245) and IEA (ECO:0000501) to annotate gene products from PAMGO_MGG. Standard
-  BLASTP from NCBI was used (http://www.ncbi.nih.gov/blast) to iteratively search
-  reciprocal best hits and thus identify orthologs between predicted proteins of Magnaporthe
-  grisea and GO proteins from multiple organisms with published association to GO
-  terms. The alignments were manually reviewed for those hits with e-value equal to
-  zero and with 80% or better coverage of both query and subject sequences, and for
-  those hits with e&lt;=10^-20, pid &gt;=35 and sequence coverage &gt;=80%. Furthermore,
-  experimental or reviewed data from literature and other sources were incorporated
-  into the GO annotation. IDA was assigned to an annotation if normal function of
-  its gene was determined through transfections into a cell line and overexpression.
-  IEP was assigned to an annotation if according to microarray experiments, its gene
-  was upregulated in a biological process and the fold change was equal to or bigger
-  than 10, or if according to Massively Parallel Signature Sequencing (MPSS), its
-  gene was upregulated only in a certain biological process and the fold change was
-  equal to or bigger than 10. ISS was assigned to an annotation if the entry at the
-  With_column was experimentally characterized and the pairwise alignments were manually
-  reviewed. IGC was assigned to an annotation if it based on comparison and analysis
-  of gene location and structure, clustering of genes, and phylogenetic reconstruction
-  of these genes. RCA was assigned to an annotation if it based on integrated computational
-  analysis of whole genome microarray data, and matches to InterPro, pfam, and COG
-  etc. IEA was assigned to an annotation if its function assignment based on computational
-  work, and no manual review was done.
----
-authors: GO ontology editors
-id: GO_REF:0000079
-year: 2013
-layout: goref
-title: Representation of assembly or disassembly of a cell component as biological
-  process in the Gene Ontology
-comments:
-- We have created a standard template for classes describing the assembly or disassembly
-  of a cellular component as a biological process. The underlying equivalence axiom
-  templates are "GO:0022607 and 'results_in_assembly_of' some C" (assembly) and "GO:0022411
-  and 'results_in_disassembly_of' some C" (disassembly), where C is a cellular component.
----
-authors: GO ontology editors
-id: GO_REF:0000069
-year: 2013
-layout: goref
-title: Representation of transmembrane transport of a chemical as biological process
-  in the Gene Ontology
-comments:
-- 'We have created a standard template for classes describing the transmembrane transport
-  of a chemical entity (ChEBI) as a biological process. The underlying equivalence
-  axiom template is "GO:0055085 and ''transports or maintains localization of'' some
-  X", where X is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI
-  has been described in the following publication: PMID:23895341.'
----
-authors: UniProt-GOA
-id: GO_REF:0000038
-is_obsolete: true
-year: 2011
-layout: goref
-title: OBSOLETE Gene Ontology annotation based on automatic assignment of UniProtKB
-  keywords in UniProtKB/TrEMBL entries.
-comments:
-- 'Transitive assignments using UniProtKB keywords. The UniProtKB keyword controlled
-  vocabulary has been created and used by the UniProt Knowledgebase (UniProtKB) to
-  supply 10 different categories of information to UniProtKB entries. Further information
-  on the UniProtKB keyword resource can be found at http://www.uniprot.org/docs/keywlist.
-  UniProtKB keywords are automatically assigned to UniProtKB/TrEMBL entries from the
-  underlying nucleic acid databases and/or by the UniProt automatic annotation program.
-  Further information on the prediction systems applied by UniProt is available here:
-  http://www.uniprot.org/program/automatic_annotation.<br>When a UniProtKB keyword
-  describes a concept that is within the scope of the Gene Ontology, it is investigated
-  to determine whether it is appropriate to map the keyword to an equivalent term
-  in GO. The mapping between UniProtKB keywords and GO terms is carried out manually.
-  Definitions and hierarchies of the terms in the two resources are compared and the
-  mapping generated will reflect the most correct correspondence. The translation
-  table between GO terms and UniProtKB keywords is maintained by the UniProt-GOA team
-  and available at http://www.geneontology.org/external2go/uniprotkb_kw2go.'
-- Duplicate of GO_REF:0000043.
----
-authors: FlyBase
-id: GO_REF:0000106
-is_obsolete: true
-year: 2016
-layout: goref
-title: OBSOLETE Gene Ontology annotation based on protein sequence records.
-comments:
-- Between 1986 and 2005 GO annotations were made by FlyBase curators based on information
-  in UniProtKB/Swiss-Prot protein sequence records. We no longer add GO annotations
-  based on sequence records and are gradually replacing these GO annotations as other
-  sources of evidence become available.
----
-authors: UniProt-GOA
-id: GO_REF:0000046
-is_obsolete: true
-year: 2012
-layout: goref
-title: OBSOLETE Gene Ontology annotation based on UniProtKB/TrEMBL Subcellular Location
-  vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt.
-comments:
-- "Transitive assignment of GO terms based on the UniProtKB/TrEMBL Subcellular Location\
-  \ vocabulary. UniProtKB Subcellular Location is a controlled vocabulary used to\
-  \ supply subcellular location information to UniProtKB entries in the SUBCELLULAR\
-  \ LOCATION lines. Terms from this vocabulary are annotated manually to UniProtKB/Swiss-Prot\
-  \ entries but are automatically assigned to UniProtKB/TrEMBL entries from the underlying\
-  \ nucleic acid databases and/or by the UniProt automatic annotation program.<br>Further\
-  \ information on these two different annotation methods is available at http://www.uniprot.org/faq/45\
-  \ and http://www.uniprot.org/program/automatic_annotation.<br> The translation table\
-  \ between GO terms and UniProtKB Subcellular Location term is maintained by the\
-  \ UniProt-GOA team and available at http://www.geneontology.org/external2go/spsl2go.<br>Please\
-  \ note that the GO term in the annotation assigned with this GO reference has been\
-  \ changed from that originally applied by the UniProtKB Subcellular Location2GO\
-  \ mapping. This change has been carried out by the UniProt group to ensure the GO\
-  \ annotation obeys the GO Consortium\u2019s ontology structure and taxonomic constraints.\
-  \ Further information on the rules used by UniProt to transform specific incorrect\
-  \ IEA annotations is available at http://www.ebi.ac.uk/QuickGO/AnnotationPostProcessing.html."
-- Duplicate of GO_REF:0000023.
----
-authors: GOA curators, UniProt curators
-external_accession:
-- SGD_REF:S000125578
-id: GO_REF:0000023
-is_obsolete: true
-year: 2007
-layout: goref
-title: OBSOLETE Gene Ontology annotation based on UniProtKB Subcellular Location vocabulary
-  mapping.
-comments:
-- Transitive assignment of GO terms based on the UniProtKB Subcellular Location vocabulary.
-  UniProtKB Subcellular Location is a controlled vocabulary used to supply subcellular
-  location information to UniProtKB entries in the SUBCELLULAR LOCATION lines. Terms
-  from this vocabulary are annotated manually to UniProtKB/Swiss-Prot entries but  are
-  automatically assigned to UniProtKB/TrEMBL entries from the underlying nucleic acid
-  databases and/or by the UniProt automatic annotation program.<br>Further information
-  on these two different annotation methods is available at http://www.uniprot.org/faq/45
-  and http://www.uniprot.org/program/automatic_annotation .<br>When a UniProtKB Subcellular
-  Location term describes a concept that is within the scope of the Gene Ontology,
-  it is investigated to determine whether it is appropriate to map the term to an
-  equivalent term in GO. The mapping between UniProtKB Subcellular Location terms
-  and GO terms is carried out manually. Definitions and hierarchies of the terms in
-  the two resources are compared and the mapping generated will reflect the most correct
-  correspondence. The translation table between GO terms and UniProtKB Subcellular
-  Location term is maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/spsl2go
-  .
-- Duplicate of GO_REF:0000039.
----
-authors: GO ontology editors
-id: GO_REF:0000072
-year: 2013
-layout: goref
-title: Representation of chemical homeostasis and cellular chemical homeostasisl as
-  biological process in the Gene Ontology
-comments:
-- 'We have created a standard template for classes describing the homeostasis and
-  cellular homeostasis for a chemical entity (ChEBI) as a biological process. The
-  underlying equivalence axiom templates are "GO:0048878 and ''regulates level of''
-  some X" (homeostasis) and "GO:0055082 and ''regulates level of'' some X" (cellular
-  homeostasis), where X is a chemical entity (CHEBI:24431). The approach to combine
-  GO and ChEBI has been described in the following publication: PMID:23895341.'
----
-authors: GO ontology editors
-id: GO_REF:0000081
-year: 2013
-layout: goref
-title: Representation of plant formation as biological process in the Gene Ontology
-comments:
-- We have created a standard template for classes describing the formation of a plant
-  structure as a biological process. The underlying equivalence axiom template is
-  "'anatomical structure formation involved in morphogenesis' and 'results in formation
-  of' some P", where P is a plant anatomical entity (PO:0025131).
----
-authors: GO ontology editors
-id: GO_REF:0000091
-year: 2014
-layout: goref
-title: Representation of cell migration as biological processes in the Gene Ontology
-comments:
-- We have created a standard template for classes describing the cell migration process
-  for a cell type as a biological process. The underlying equivalence axiom template
-  is "'cell migration' and 'alters_location_of' some C", where C is a native cell
-  (CL:0000004).
----
-authors: GO ontology editors
-id: GO_REF:0000062
-year: 2013
-layout: goref
-title: Representation of processes occurring in parts of the cell in the Gene Ontology
-comments:
-- We have created a standard template for classes describing processes occurring in
-  parts of the cell. The underlying equivalence axiom template is "P and 'occurs in'
-  some C", where P is a biological process and C is a cellular component.
----
-authors: Pascale Gaudet, Michael Livstone, Paul Thomas, The Reference Genome Project
-external_accession:
-- SGD_REF:S000146947
-- TAIR:Communication:501741973
-- MGI:MGI:4459044
-- 'J:161428 '
-- ZFIN:ZDB-PUB-110330-1
-- FB:FBrf0232076
-id: GO_REF:0000033
-url: http://gocwiki.geneontology.org/index.php/PAINT
-year: 2010
-is_obsolete: true
-layout: goref
-title: OBSOLETE Annotation inferences using phylogenetic trees
-comments:
-- This GO_REF was originally used to support PAINT annotations. The SOP has changed,
-  and now phylogenetic annotations are supported using the identifier for the family
-  itself.
-- The goal of the GO Reference Genome Project, described in PMID 19578431, is to provide
-  accurate, complete and consistent GO annotations for all genes in twelve model organism
-  genomes.To this end, GO curators are annotating evolutionary trees from the PANTHER
-  database with GO terms describing molecular function, biological process and cellular
-  component. GO terms based on experimental data from the scientific literature are
-  used to annotate ancestral genes in the phylogenetic tree by sequence similarity
-  (ISS), and unannotated descendants of these ancestral genes are inferred to have
-  inherited these same GO annotations by descent. The annotations are done using a
-  tool called PAINT (Phylogenetic Annotation and INference Tool).
----
-authors: The GO Consortium
-id: GO_REF:0000056
-year: 2013
-is_obsolete: true
-layout: goref
-title: OBSOLETE Taxon constraints to detect inconsistencies in annotation and ontology
-  structure.
-comments:
-- 'GO is intended to cover the full range of species, therefore GO terms are defined
-  to be taxon neutral, avoiding reliance on taxon information for full definition
-  of the given process, function, or component. For certain terms, however, there
-  is obvious implicit taxon specificity, such that the term should only be used to
-  categorize gene products from particular species. Taxon specificity of GO terms
-  is captured using relationships such as "only_in_taxon" and "never_in_taxon". All
-  taxon constraints are inherited by sub-types and parts of the GO term they are applied
-  to. Taxon constraints are used to prevent inappropriate annotations from being made
-  by curators as well as to identify pre-existing annotations that violate the taxon
-  constraints. Errors in annotations are automatically detected by looking for inconsistencies
-  between the taxonomic origin of the annotated gene products and the implicit taxon
-  specificity of the GO terms. The inconsistencies are passed on to curators for correction,
-  in some cases the constraints need to be tightened or relaxed or the structure of
-  the ontology needs to be adjusted. The taxon constraints are further described in
-  this publication: Deegan, Dimmer and Mungall. BMC Bionformatics (2010) Formalization
-  of taxon-based constraints to detect inconsistencies in annotaiton and ontology
-  development. (PMID:20973947). '
----
-authors: GO Central curators, GOA curators, Rhea curators
-citation: PMID:30272209
-id: GO_REF:0000116
-year: 2020
-layout: goref
-title: Automatic Gene Ontology annotation based on Rhea mapping.
-comments:
-- 'Rhea (https://www.rhea-db.org/, PMID:30272209) is an expert-curated knowledgebase
-  of chemical and transport reactions of biological interest - and the standard for
-  enzyme and transporter annotation in UniProtKB (PMID:31688925). Rhea uses the chemical
-  dictionary ChEBI (Chemical Entities of Biological Interest) to describe reaction
-  participants and their chemical transformations in a computationally tractable manner.
-  GO terms corresponding to Rhea reactions are assigned a Rhea database cross-reference.
-  The corresponding GO term is automatically applied to all UniProt entries annotated
-  with a Rhea reaction. The mapping file is available at: http://current.geneontology.org/ontology/external2go/rhea2go.'
----
-authors: GO ontology editors
-id: GO_REF:0000076
-year: 2013
-layout: goref
-title: Representation of transport or vesicle-mediated transport from cell component
-  to cell component as biological process in the Gene Ontology
-comments:
-- We have created a standard template for classes describing the transport or vesicle-mediated
-  transport from cellular component to cellular component as a biological process.
-  The underlying equivalence axiom templates are "GO:0006810 and 'has_target_start_location'
-  some F and 'has_target_end_location' some T" (transport) and "GO:0016192 and 'has_target_start_location'
-  some F and 'has_target_end_location' some T" (vesicle-mediated transport), where
-  F and T are a cellular components.
----
-authors: PAMGO_GAT curators
-id: GO_REF:0000027
-year: 2007
-layout: goref
-title: BLAST search criteria for ISS assignment in PAMGO_GAT
-comments:
-- This GO reference describes the criteria used in assigning the evidence code of
-  ISS via BLAST searches to annotate gene products from PAMGO_GAT. Standard BLASTP
-  from NCBI was used (http://www.ncbi.nih.gov/blast) to query the non-redundant (NR)
-  database. Hits are considered to be significant if the E-value is at or less than
-  10^-4. All other parameters are default according to http://www.ncbi.nih.gov/blast.
----
-authors: GO ontology editors
-id: GO_REF:0000085
-year: 2013
-layout: goref
-title: Representation of cell apoptotic process as biological process in the Gene
-  Ontology
-comments:
-- We have created a standard template for classes describing the apoptotic process
-  for a cell type as a biological process. The underlying equivalence axiom template
-  is "'apoptotic process' and 'occurs in' some C", where C is a native cell (CL:0000003).
----
-authors: GO ontology editors
-id: GO_REF:0000102
-is_obsolete: true
-year: 2015
-layout: goref
-title: OBSOLETE Representation of cellular component binding as molecular functions
-  in the Gene Ontology
-comments:
-- We have created a standard template for classes cellular component binding as a
-  molecular function. The underlying equivalence axiom template is "'binding' and
-  'has input' some C", where C is a cellular component (GO:0005575).
----
-authors: UniProt-GOA
-id: GO_REF:0000042
-is_obsolete: true
-year: 2012
-layout: goref
-title: OBSOLETE Gene Ontology annotation through association of InterPro records with
-  GO terms, accompanied by conservative changes to GO terms applied by UniProt.
-comments:
-- "Transitive assignment of GO terms based on InterPro classification. For any database\
-  \ entry (representing a protein or protein-coding gene) that has been annotated\
-  \ with one or more InterPro domains, The corresponding GO terms are obtained from\
-  \ a translation table of InterPro entries to GO terms (interpro2go) generated manually\
-  \ by the InterPro team at EBI. The mapping file is available at http://www.geneontology.org/external2go/interpro2go.<br>Please\
-  \ note that the GO term in the annotation assigned with this GO reference has been\
-  \ changed from that originally applied by the InterPro2GO mapping. This change has\
-  \ been carried out by the UniProt group to ensure the GO annotation obeys the GO\
-  \ Consortium\u2019s ontology structure and taxonomic constraints. Further information\
-  \ on the rules used by UniProt to transform specific incorrect IEA annotations is\
-  \ available at http://www.ebi.ac.uk/QuickGO/AnnotationPostProcessing.html."
-- Duplicate of GO_REF:0000002.
----
-authors: Human Protein Atlas
-id: GO_REF:0000052
-year: 2013
-layout: goref
-title: Gene Ontology annotation based on curation of immunofluorescence data
-comments:
-- 'GO Cellular Component terms are manually assigned by curators studying high resolution
-  confocal microscopy images of immunohistochemically stained tissue. The methodology
-  uses antibody-based proteomics which combines high-throughput generation of affinity-purified
-  antibodies with protein profiling in a variety of cells and tissues. Further information
-  on the annotation methods can be found at http://www.proteinatlas.org/about/assays+annotation
-  <br>Annotations are only exported to the GO Consortium if the localizations are
-  supported by literature, according to the following validation grading:<br>Supportive
-  - Subcellular localization supported by literature.<br>1) One/multiple localizations
-  supported by literature.<br>2) Multiple localizations partly supported (at least
-  one) by literature.<br>3) One/multiple localizations in cytoplasm (i.e. Golgi, mitochondria,
-  ER etc) with literature supporting cytoplasmic localization. <br>Prior to February
-  2013, all Human Protein Atlas annotations were referenced by PMID:18029348 (Barbe
-  et al. 2008 Mol. Cell Proteomics. 7:499-508), a paper describing the protein localization
-  pilot study and methodology used by the Human Protein Atlas. However, it has been
-  decided that these annotations are more correctly described by a GO reference.<br>Resource
-  URL: http://www.proteinatlas.org <br>Protein subcellular localization images can
-  be viewed on the Human Protein Atlas website, e.g. http://www.proteinatlas.org/ENSG00000175899/summary#ifcelline'
----
-authors: Ivan Erill, James Hu, Community Assessment of Community Annotation with Ontologies
-id: GO_REF:0000112
-is_obsolete: true
-year: 2017
-layout: goref
-title: OBSOLETE Gene Ontology annotation by CACAO biocurators
-comments:
-- This GO reference describes the criteria used by biocurators participating in the
-  Community Assessment of Community Annotation with Ontologies (CACAO) to annotate
-  gene products from genomes of interest through the use of computational methods
-  to establish and manually validate function or homology to gene products. In particular,
-  this GO reference describes the criteria used to make annotations based on evidence
-  codes ISS, ISA, ISO, ISM and IGC. To perform ISS-, ISA-, and ISO-based annotations
-  on a gene product, CACAO biocurators use sequence- and structure-based search algorithms
-  (e.g. BLASTP, HHPred) to establish homology, conservation of sequence and structure
-  functional determinants between the target gene product and gene products from other
-  organisms with published GO annotations supported by experimental codes and lacking
-  NOT qualifiers. These gene products are referenced in the WITH field of the annotation
-  using their xref database accession. ISM-based annotations make use of published
-  computational methods (e.g. TMHMM, SignalP) to predict gene product structure, localization
-  or function. IGC-based annotations are made on the basis of suggestive evidence
-  for function based on synteny. Parameters and criteria for use of all computational
-  methods (e.g. e-value) are listed and versioned in the publicly available CACAO
-  documentation (http://gowiki.tamu.edu/). Annotations made by CACAO biocurators are
-  reviewed by CACAO team instructors before their release.
----
-alt_id:
-- GO_REF:0000005
-authors: GOA curators, MGI curators
-citation: PMID:11374909
-external_accession:
-- MGI:2152096
-- J:72245
-- ZFIN:ZDB-PUB-031118-3
-- SGD_REF:S000124037
-id: GO_REF:0000003
-year: 2001
-layout: goref
-title: Gene Ontology annotation based on Enzyme Commission mapping.
-comments:
-- Transitive assignment using Enzyme Commission identifiers. This method is used for
-  any database entry, such as a protein record in UniProtKB or TrEMBL, that has had
-  an Enzyme Commission number assigned. The corresponding GO term is determined using
-  the EC cross-references in the GO molecular function ontology. Also see Hill et
-  al., Genomics (2001) 74:121-128. The mapping file is available at http://www.geneontology.org/external2go/ec2go.
-- Formerly GOA:spec.
----
-authors: Mouse Genome Informatics scientific curators and FlyBase
-id: GO_REF:0000095
-year: 2014
-layout: goref
-title: Literature reference not indexed by PubMed
-comments:
-- This article is not referenced in PubMed. Please see contributing data resource
-  for details.
----
-authors: UniProt-GOA
-id: GO_REF:0000037
-is_obsolete: true
-year: 2011
-evidence_codes:
-- ECO:0000501
-layout: goref
-title: OBSOLETE Gene Ontology annotation based on manual assignment of UniProtKB keywords
-  in UniProtKB/Swiss-Prot entries.
-comments:
-- Transitive assignments using UniProtKB keywords. The UniProtKB keyword controlled
-  vocabulary has been created and used by the UniProt Knowledgebase (UniProtKB) to
-  supply 10 different categories of information to UniProtKB entries. Further information
-  on the UniProtKB keyword resource can be found at http://www.uniprot.org/docs/keywlist.
-  UniProtKB keywords are manually applied to UniProtKB/Swiss-Prot entries by UniProt
-  curators. Further information on the UniProtKB manual annotation process is available
-  at http://www.uniprot.org/faq/45.<br>When a UniProtKB keyword describes a concept
-  that is within the scope of the Gene Ontology, it is investigated to determine whether
-  it is appropriate to map the keyword to an equivalent term in GO. The mapping between
-  UniProtKB keywords and GO terms is carried out manually. Definitions and hierarchies
-  of the terms in the two resources are compared and the mapping generated will reflect
-  the most correct correspondence. The translation table between GO terms and UniProtKB
-  keywords is maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/uniprotkb_kw2go.
-- Duplicate of GO_REF:0000043.
----
-authors: GO ontology editors
-id: GO_REF:0000066
-year: 2013
-layout: goref
-title: Representation of transport of a chemical entity as molecular function in the
-  Gene Ontology
-comments:
-- 'We have created a standard template for classes describing the transport of a chemical
-  entity (ChEBI) as a molecular function. The underlying equivalence axiom template
-  is "GO:0005215 and ''transports or maintains localization of'' some X", where X
-  is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI has been
-  described in the following publication: PMID:23895341.'
----
-authors: GO ontology editors
-id: GO_REF:0000077
-year: 2013
-is_obsolete: true
-layout: goref
-title: OBSOLETE Representation of transport of a cellular component as biological
-  process in the Gene Ontology
-comments:
-- We have created a standard template for classes describing the transport or vesicle-mediated
-  transport of a cellular component as a biological process. The underlying equivalence
-  axiom templates are "GO:0006810 and 'transports or maintains localization of' some
-  C" (transport) and "GO:0016192 and 'transports or maintains localization of' some
-  C" (vesicle-mediated transport), where C is a cellular component.
----
-authors: Jennifer Deegan nee Clark (1, 5), Alexander D. Diehl (1,7), Elisabeth Ehler
-  (2), Georgine Faulkner (3), Erika Feltrin (4), Jennifer Fordham (2), Midori Harris
-  (1, 5), Ralph Knoell (6) David Hill (1, 7), Paolo Laveder (8), Alessandra Nori (8),
-  Carlo Reggiani (8), Vincenzo Sorrentino (9), Giorgio Valle (4), Pompeo Volpe (8)
-  (1. The Gene Ontology Consortium, 2. King's College, London, UK, 3. ICGEB, Trieste,
-  Italy, 4. CRIBI - University of Padua, Padua, Italy 5. EMBL-EBI, Hinxton, Cambridgeshire,
-  UK, 6. University of Goettingen, Goettingen, Germany 7. Mouse Genome Informatics,
-  Bar Harbor, ME, 8. University of Padua, Padua, Italy, 9. University of Siena, Siena,
-  Italy)
-citation: PMID:19178689
-id: GO_REF:0000026
-is_obsolete: true
-year: 2007
-layout: goref
-title: OBSOLETE Improving the representation of muscle biology in the biological process
-  and cellular component ontologies.
-comments:
-- 'A meeting focused on the biology of skeletal and smooth muscle has been held on
-  24-25 July 2007 at the University of Padua, Italy, as a collaboration with the GO
-  consortium and CRIBI Biotechnology Center. The aims of this effort were to provide
-  a comprehensive representation of muscle biology in the biological process and cellular
-  component ontologies and to improve the organization of muscle-specific terms to
-  better describe the current knowledge of biological mechanisms in muscle tissue.
-  Thus, the collaboration brought together experts in several areas of muscle biology
-  and physiology who carried out a thorough review of the existing GO muscle terms
-  as these terms were largely created by non-muscle experts using older definitions.
-  In particular, several areas are being addressed actively in current research: the
-  biological processes of muscle contraction, muscle plasticity, muscle development,
-  and muscle regeneration; and the sarcoplasmic reticulum and membrane delimited compartments.
-  This work resulted in the addition of 159 new terms and in the modification of 57
-  terms to bring them in line with current usage. Funding for the meeting was provided
-  by Italian Telethon Foundation.'
----
-authors: GO ontology editors
-id: GO_REF:0000084
-year: 2013
-layout: goref
-title: Representation of plant structural organization as biological process in the
-  Gene Ontology
-comments:
-- We have created a standard template for classes describing the structural organization
-  of a plant structure as a biological process. The underlying equivalence axiom template
-  is "'anatomical structure arrangement' and 'results in structural organization of'
-  some P", where P is a plant anatomical entity (PO:0025131).
----
-authors: Michelle Gwinn, TIGR curators
-id: GO_REF:0000012
-year: 2003
-layout: goref
-title: Pairwise alignment (TIGR)
-comments:
-- 'Pairwise alignments are generated by taking two sequences and aligning them so
-  that the maximum number of amino acids in each protein match, or are similar to,
-  each other. Tools such as BLAST work by comparing a protein-of-interest individually
-  with every protein in a database of known protein sequences and retaining only those
-  matches with a high probability of being significant. Basic BLAST generates local
-  alignments between proteins for regions of high similarity. Other pairwise alignment
-  tools attempt to generate global (full-length) protein alignments. A tool called
-  Blast_Extend_repraze (BER, http://ber.sourceforge.net) has some benefits over basic
-  BLAST. Input into the BER tool includes the underlying DNA sequence for each protein
-  as well as 300 nucleotides upstream and downstream of the predicted boundaries of
-  the protein coding sequence. This allows annotators to see the DNA sequence that
-  underlies the query protein as part of the alignment. In addition, the BER tool
-  is able to look for continuation of regions of similarity through frameshifts and
-  in-frame stop codons.  If such regions are found the alignment is continued. BER
-  searches are done in a two-step process: step one is a BLAST search against a non-redundant
-  protein database, significant BLAST hits are stored in a mini-database for each
-  query protein; step two is a modified Smith-Waterman alignment between the query
-  and the proteins in its mini-database. In order to assess whether a given BER alignment
-  is good enough to assert that the query shares the function of the match protein,
-  one must look at a several factors. First of all, the match protein must itself
-  be experimentally characterized in order to avoid transitive annotation errors.
-  In addition, any residues or secondary structures known to be important for function
-  in the match protein must be conserved in the query. The alignment should be visually
-  inspected to look for any areas of lesser quality that might indicate the two proteins
-  do not share the same function. Although it is impossible to set cutoff values for
-  percent identity and length of match that will apply for every alignment, there
-  are some guidelines. In general at least 40% identity that extends over the full
-  lengths of both proteins is required in order to even consider functional equivalence.
-  However, this percentage is highly dependent on the length and complexity of the
-  proteins. 40% identity between two proteins 500 amino acids long is much more significant
-  that 40% identity between two proteins that are only 100 amino acids long. Therefore,
-  the annotator''s experience and knowledge of what is considered significant for
-  the organism and protein family in question is very important. Some sets of proteins
-  are much more highly conserved than others and therefore tolerances for percent
-  identity may have to be adjusted. Finally, the alignment must be considered in the
-  context of what else is known about the query protein and the organism as a whole.'
----
-authors: GO ontology editors
-id: GO_REF:0000103
-is_obsolete: true
-year: 2015
-layout: goref
-title: OBSOLETE Representation of cellular component organization as biological process
-  in the Gene Ontology
-comments:
-- We have created a standard template for classes cellular component organization
-  as a biological process. The underlying equivalence axiom template is "'cellular
-  component organization' and 'results_in_organization_of' some C", where C is a cellular
-  component (GO:0005575).
----
-authors: UniProt-GOA
-id: GO_REF:0000043
-external_accession:
-- SGD_REF:S000148669
-- J:60000
-- TAIR:AnalysisReference:501756968
-- TAIR:AnalysisReference:501756970
-year: 2012
-layout: goref
-title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
-comments:
-- 'Transitive assignments using UniProtKB/Swiss-Prot keywords. The UniProtKB keyword
-  controlled vocabulary contains 10 different categories of information to UniProtKB
-  entries. Further information on the UniProtKB keyword resource can be found at https://www.uniprot.org/keywords/.
+- authors: GOA-UniProt curators
+  id: GO_REF:0000029
+  is_obsolete: true
+  year: 2007
+  layout: goref
+  title: OBSOLETE Gene Ontology annotation based on information extracted from curated
+    UniProtKB entries
+  comments:
+  - Active 2001-2007.
+  - Method by which GO terms were manually assigned to UniProt KnowledgeBase accessions,
+    using either a NAS or TAS evidence code, by applying information extracted from
+    the corresponding publicly-available, manually curated UniProtKB entry. Such GO
+    annotations were submitted by the GOA-UniProt group from 2001, but this annotation
+    practice was discontinued in 2007.
+- authors: GO ontology editors
+  id: GO_REF:0000078
+  year: 2013
+  layout: goref
+  title: Representation for the transport or vesicle-mediated transport of a chemical
+    from and/or to a cell component as biological process in the Gene Ontology
+  comments:
+  - 'We have created a standard template for classes describing the transport or vesicle-mediated
+    transport of a chemical entity (ChEBI) from and/or to a cellular component as
+    a biological process. The underlying equivalence axiom templates are "GO:0006810
+    and ''transports or maintains localization of'' some X [ and ''has_target_start_location''
+    some F] [ and ''has_target_end_location'' some T]" (transport) and "GO:0016192
+    and ''transports or maintains localization of'' some X [ and ''has_target_start_location''
+    some F] [ and ''has_target_end_location'' some T]" (vesicle-mediated transport),
+    where F and T are cellular components and X is a chemical entity (CHEBI:24431).
+    The approach to combine GO and ChEBI has been described in the following publication:
+    PMID:23895341.'
+- authors: GO ontology editors
+  id: GO_REF:0000068
+  year: 2013
+  layout: goref
+  title: Representation of metabolic triad (metabolism, catabolism, biosynthesis)
+    as biological process in the Gene Ontology
+  comments:
+  - 'We have created a standard template for classes each describing the metabolism,
+    catabolism, or biosynthesis of a chemical entity (ChEBI) as a process. The underlying
+    equivalence axiom templates are "GO:0008152 and ''has participant'' some X" (metabolism),
+    "GO:0009056 and ''has input'' some X" (catabolism), "GO:0009058 and ''has output''
+    some X" and (biosynthesis),  where X is a chemical entity (CHEBI:24431). The approach
+    to combine GO and ChEBI has been described in the following publication: PMID:23895341.'
+- authors: UniProt-GOA
+  id: GO_REF:0000039
+  year: 2011
+  layout: goref
+  title: OBSOLETE Gene Ontology annotation based on the manual assignment of UniProtKB
+    Subcellular Location terms in UniProtKB/Swiss-Prot entries.
+  comments:
+  - Transitive assignment of GO terms based on the UniProtKB Subcellular Location
+    vocabulary. UniProtKB Subcellular Location is a controlled vocabulary used to
+    supply subcellular location information to UniProtKB entries in the SUBCELLULAR
+    LOCATION lines. Terms from this vocabulary are annotated manually to UniProtKB/Swiss-Prot
+    entries. Further information on the UniProtKB manual annotation method is available
+    at http://www.uniprot.org/faq/45.<br>When a UniProtKB Subcellular Location term
+    describes a concept that is within the scope of the Gene Ontology, it is investigated
+    to determine whether it is appropriate to map the term to an equivalent term in
+    GO. The mapping between UniProtKB Subcellular Location terms and GO terms is carried
+    out manually. Definitions and hierarchies of the terms in the two resources are
+    compared and the mapping generated will reflect the most correct correspondence.
+    The translation table between GO terms and UniProtKB Subcellular Location terms
+    is maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/spsl2go.
+- authors: Ensembl curators, GOA curators
+  id: GO_REF:0000019
+  is_obsolete: true
+  year: 2006
+  layout: goref
+  title: OBSOLETE Automatic transfer of experimentally verified manual GO annotation
+    data to orthologs using Ensembl Compara
+  comments:
+  - GO terms from a source species are projected on to one or more target species
+    based on gene orthology obtained from the Ensembl Compara system. Only one to
+    one and apparent one to one orthologies are used for a restricted range of species.
+    Only GO annotations with a manual experimental evidence type of IDA, IEP, IGI,
+    IMP or IPI are projected. Projected GO annotations using this technique will receive
+    the evidence code, inferred from electronic annotation, 'IEA'. The Ensembl protein
+    identifier of the annotation source is indicated in the 'With' column of the GOA
+    association file.
+- authors: GOA curators
+  id: GO_REF:0000108
+  year: 2016
+  layout: goref
+  title: Automatic assignment of GO terms using logical inference, based on on inter-ontology
+    links.
+  comments:
+  - GO terms are automatically assigned based on inter-ontology links to generate
+    inferred annotations. Annotations from Molecular Function to Biological Process
+    can be propagated, as well as between Biological Process and Cellular Component.
+    Annotations that are created using this inference method receive either the evidence
+    code ECO:0000366 (evidence based on logical inference from automatic annotation
+    used in automatic assertion) or ECO:0000364 (evidence based on logical inference
+    from manual annotation used in automatic assertion), depending on whether the
+    source annotation has a manual or automatic evidence code. Both of these codes
+    map up to the GO Inferred from Electronic Annotation (IEA) evidence code.
+- authors: TIGR Arabidopsis annotation team
+  external_accession:
+  - TAIR:Communication:501714663
+  id: GO_REF:0000048
+  is_obsolete: true
+  year: 2005
+  layout: goref
+  title: OBSOLETE TIGR's Eukaryotic Manual Gene Ontology Assignment Method
+  comments:
+  - This describes TIGR curators' interpretation of a combination of evidence. Our
+    internal software tools present us with a great deal of evidence based on domains,
+    sequence similarities, signal sequences, paralogous proteins, etc. The curator
+    interprets the body of evidence to make a decision about a GO assignment when
+    an external reference is not available. The curator places one or more accessions
+    that informed the decision in the "with" field.
+- authors: GO ontology editors
+  id: GO_REF:0000058
+  year: 2013
+  layout: goref
+  title: Representation of regulation in the Gene Ontology (biological process)
+  comments:
+  - We have created a standard template for the definition of classes for the regulation
+    of a biological process. This includes the definitions for positive and negative
+    regulation. The equivalence axiom templates are "GO:0065007 and 'regulates' some
+    X" (regulation), "GO:0065007 and 'negatively_regulates' some X" (negative regulation),
+    and "GO:0065007 and 'positively_regulates' some X" (positive regulation), where
+    X is a biological process.
+- authors: DictyBase curators
+  external_accession:
+  - dictyBase_REF:10158
+  id: GO_REF:0000018
+  is_obsolete: true
+  year: 2005
+  layout: goref
+  title: OBSOLETE dictyBase 'Inferred from Electronic Annotation (BLAST method)'
+  comments:
+  - Gene Ontology (GO) annotations with the evidence code 'Inferred from Electronic
+    Annotation' (IEA) are assigned automatically to gene products in dictyBase. All
+    Dictyostelium protein sequences are analyzed by BLAST against GO gene association
+    sequence files, identifying proteins in other organisms that align with Dictyostelium
+    proteins with an E value less than or equal to e-50. GO annotations that have
+    been manually assigned to these proteins from other species are then imported
+    and attached to the corresponding gene product in dictyBase. The proteins from
+    which the annotations are derived are displayed in the 'Evidence' column on the
+    Gene Ontology evidence and references page.
+- authors: TrypTag
+  id: GO_REF:0000109
+  year: 2016
+  layout: goref
+  title: Gene Ontology annotation based on curation of genome-wide subcellular localisation
+    of proteins using fluorescent protein tagging in Trypanosoma brucei
+  comments:
+  - 'Trypanosomes are exquisitely structured cells in which protein localisation can
+    be extremely informative for likely function. TrypTag is a project using expression
+    of N- and C-terminal mNeonGreen fusion proteins from the endogenous loci to determine
+    the subcellular localisation of every gene in the Trypanosoma brucei genome. GO
+    Cellular Component terms are manually assigned by curators studying fluorescence
+    microscope images of the resulting cells labelled with mNeonGreen fusion proteins.
+    As trypanosomes are a pathogenic basal eukaryote, this will indicate likely function
+    of both highly conserved eukaryote genes and parasite-specific genes. Resource
+    URL: http://www.tryptag.org Protein subcellular localisation images can be viewed
+    on the Tryptag website, e.g. http://www.tryptag.org?id=Tb927.8.1550'
+- authors: Ensembl Genomes
+  id: GO_REF:0000049
+  is_obsolete: true
+  year: 2012
+  layout: goref
+  title: OBSOLETE Automatic transfer of experimentally verified manual GO annotation
+    data to fungal orthologs using Ensembl Compara
+  comments:
+  - GO terms from a source species are projected onto one or more target species based
+    on gene orthology obtained from the Ensembl Compara system. One to one, one to
+    many and many to many orthologies are used but annotations are only projected
+    between orthologs that have at least a 40% peptide identity to each other. Only
+    GO annotations with an evidence type of IDA, IEP, IGI, IMP or IPI are projected,
+    no annotations with a 'NOT' qualifier are projected and annotations to the GO:0005515
+    protein binding term are not projected. Projected GO annotations using this technique
+    will receive the evidence code Inferred from Electronic Annotation (IEA). The
+    model organism database identifier of the annotation source will be indicated
+    in the 'With' column of the GOA association file.
+  - Duplicate of GO_REF:0000107.
+- authors: GO ontology editors
+  id: GO_REF:0000059
+  year: 2013
+  layout: goref
+  title: Representation of regulation in the Gene Ontology (molecular function)
+  comments:
+  - We have created a standard template for the definition of classes for the regulation
+    of a molecular function. This includes the definitions for positive and negative
+    regulation. The equivalence axiom templates are "GO:0065007 and 'regulates' some
+    X" (regulation), "GO:0065007 and 'negatively_regulates' some X" (negative regulation),
+    and "GO:0065007 and 'positively_regulates' some X" (positive regulation), where
+    X is a molecular function.
+- authors: Mouse Genome Informatics scientific curators
+  external_accession:
+  - MGI:2154458
+  - J:73065
+  id: GO_REF:0000008
+  year: 2001
+  layout: goref
+  title: Gene Ontology annotation by the MGI curatorial staff, curated orthology
+  comments:
+  - The sequence conservation that permits the establishment of orthology between
+    mouse and rat or mouse and human genes is a strong predictor of the conservation
+    of function for the gene product across these species. Therefore, in instances
+    where a mouse gene product has not been functionally characterized, but its human
+    or rat orthologs have, Mouse Genome Informatics (MGI) curators append the GO terms
+    associated with the orthologous gene(s) to the mouse gene. Only those GO terms
+    assigned by experimental determination to the ortholog of the mouse gene will
+    be adopted by MGI. GO terms that are assigned to the ortholog of the mouse gene
+    computationally (i.e. IEA), will not be transferred to the mouse ortholog. The
+    evidence code represented by this citation is Inferred by Sequence Orthology (ISO).
+- authors: PAMGO_MGG curators
+  id: GO_REF:0000028
+  year: 2008
+  layout: goref
+  title: Criteria for IDA, IEP, ISS, IGC, RCA, and IEA assignment in PAMGO_MGG
+  comments:
+  - This GO reference describes the criteria used in assigning the evidence codes
+    of IDA (ECO:0000314), IEP (ECO:0000270), ISS (ECO:0000250), IGC (ECO_0000317),
+    RCA (ECO:0000245) and IEA (ECO:0000501) to annotate gene products from PAMGO_MGG.
+    Standard BLASTP from NCBI was used (http://www.ncbi.nih.gov/blast) to iteratively
+    search reciprocal best hits and thus identify orthologs between predicted proteins
+    of Magnaporthe grisea and GO proteins from multiple organisms with published association
+    to GO terms. The alignments were manually reviewed for those hits with e-value
+    equal to zero and with 80% or better coverage of both query and subject sequences,
+    and for those hits with e&lt;=10^-20, pid &gt;=35 and sequence coverage &gt;=80%.
+    Furthermore, experimental or reviewed data from literature and other sources were
+    incorporated into the GO annotation. IDA was assigned to an annotation if normal
+    function of its gene was determined through transfections into a cell line and
+    overexpression. IEP was assigned to an annotation if according to microarray experiments,
+    its gene was upregulated in a biological process and the fold change was equal
+    to or bigger than 10, or if according to Massively Parallel Signature Sequencing
+    (MPSS), its gene was upregulated only in a certain biological process and the
+    fold change was equal to or bigger than 10. ISS was assigned to an annotation
+    if the entry at the With_column was experimentally characterized and the pairwise
+    alignments were manually reviewed. IGC was assigned to an annotation if it based
+    on comparison and analysis of gene location and structure, clustering of genes,
+    and phylogenetic reconstruction of these genes. RCA was assigned to an annotation
+    if it based on integrated computational analysis of whole genome microarray data,
+    and matches to InterPro, pfam, and COG etc. IEA was assigned to an annotation
+    if its function assignment based on computational work, and no manual review was
+    done.
+- authors: GO ontology editors
+  id: GO_REF:0000079
+  year: 2013
+  layout: goref
+  title: Representation of assembly or disassembly of a cell component as biological
+    process in the Gene Ontology
+  comments:
+  - We have created a standard template for classes describing the assembly or disassembly
+    of a cellular component as a biological process. The underlying equivalence axiom
+    templates are "GO:0022607 and 'results_in_assembly_of' some C" (assembly) and
+    "GO:0022411 and 'results_in_disassembly_of' some C" (disassembly), where C is
+    a cellular component.
+- authors: GO ontology editors
+  id: GO_REF:0000069
+  year: 2013
+  layout: goref
+  title: Representation of transmembrane transport of a chemical as biological process
+    in the Gene Ontology
+  comments:
+  - 'We have created a standard template for classes describing the transmembrane
+    transport of a chemical entity (ChEBI) as a biological process. The underlying
+    equivalence axiom template is "GO:0055085 and ''transports or maintains localization
+    of'' some X", where X is a chemical entity (CHEBI:24431). The approach to combine
+    GO and ChEBI has been described in the following publication: PMID:23895341.'
+- authors: UniProt-GOA
+  id: GO_REF:0000038
+  is_obsolete: true
+  year: 2011
+  layout: goref
+  title: OBSOLETE Gene Ontology annotation based on automatic assignment of UniProtKB
+    keywords in UniProtKB/TrEMBL entries.
+  comments:
+  - 'Transitive assignments using UniProtKB keywords. The UniProtKB keyword controlled
+    vocabulary has been created and used by the UniProt Knowledgebase (UniProtKB)
+    to supply 10 different categories of information to UniProtKB entries. Further
+    information on the UniProtKB keyword resource can be found at http://www.uniprot.org/docs/keywlist.
+    UniProtKB keywords are automatically assigned to UniProtKB/TrEMBL entries from
+    the underlying nucleic acid databases and/or by the UniProt automatic annotation
+    program. Further information on the prediction systems applied by UniProt is available
+    here: http://www.uniprot.org/program/automatic_annotation.<br>When a UniProtKB
+    keyword describes a concept that is within the scope of the Gene Ontology, it
+    is investigated to determine whether it is appropriate to map the keyword to an
+    equivalent term in GO. The mapping between UniProtKB keywords and GO terms is
+    carried out manually. Definitions and hierarchies of the terms in the two resources
+    are compared and the mapping generated will reflect the most correct correspondence.
+    The translation table between GO terms and UniProtKB keywords is maintained by
+    the UniProt-GOA team and available at http://www.geneontology.org/external2go/uniprotkb_kw2go.'
+  - Duplicate of GO_REF:0000043.
+- authors: FlyBase
+  id: GO_REF:0000106
+  is_obsolete: true
+  year: 2016
+  layout: goref
+  title: OBSOLETE Gene Ontology annotation based on protein sequence records.
+  comments:
+  - Between 1986 and 2005 GO annotations were made by FlyBase curators based on information
+    in UniProtKB/Swiss-Prot protein sequence records. We no longer add GO annotations
+    based on sequence records and are gradually replacing these GO annotations as
+    other sources of evidence become available.
+- authors: UniProt-GOA
+  id: GO_REF:0000046
+  is_obsolete: true
+  year: 2012
+  layout: goref
+  title: OBSOLETE Gene Ontology annotation based on UniProtKB/TrEMBL Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt.
+  comments:
+  - "Transitive assignment of GO terms based on the UniProtKB/TrEMBL Subcellular Location\
+    \ vocabulary. UniProtKB Subcellular Location is a controlled vocabulary used to\
+    \ supply subcellular location information to UniProtKB entries in the SUBCELLULAR\
+    \ LOCATION lines. Terms from this vocabulary are annotated manually to UniProtKB/Swiss-Prot\
+    \ entries but are automatically assigned to UniProtKB/TrEMBL entries from the\
+    \ underlying nucleic acid databases and/or by the UniProt automatic annotation\
+    \ program.<br>Further information on these two different annotation methods is\
+    \ available at http://www.uniprot.org/faq/45 and http://www.uniprot.org/program/automatic_annotation.<br>\
+    \ The translation table between GO terms and UniProtKB Subcellular Location term\
+    \ is maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/spsl2go.<br>Please\
+    \ note that the GO term in the annotation assigned with this GO reference has\
+    \ been changed from that originally applied by the UniProtKB Subcellular Location2GO\
+    \ mapping. This change has been carried out by the UniProt group to ensure the\
+    \ GO annotation obeys the GO Consortium\u2019s ontology structure and taxonomic\
+    \ constraints. Further information on the rules used by UniProt to transform specific\
+    \ incorrect IEA annotations is available at http://www.ebi.ac.uk/QuickGO/AnnotationPostProcessing.html."
+  - Duplicate of GO_REF:0000023.
+- authors: GOA curators, UniProt curators
+  external_accession:
+  - SGD_REF:S000125578
+  id: GO_REF:0000023
+  is_obsolete: true
+  year: 2007
+  layout: goref
+  title: OBSOLETE Gene Ontology annotation based on UniProtKB Subcellular Location
+    vocabulary mapping.
+  comments:
+  - Transitive assignment of GO terms based on the UniProtKB Subcellular Location
+    vocabulary. UniProtKB Subcellular Location is a controlled vocabulary used to
+    supply subcellular location information to UniProtKB entries in the SUBCELLULAR
+    LOCATION lines. Terms from this vocabulary are annotated manually to UniProtKB/Swiss-Prot
+    entries but  are automatically assigned to UniProtKB/TrEMBL entries from the underlying
+    nucleic acid databases and/or by the UniProt automatic annotation program.<br>Further
+    information on these two different annotation methods is available at http://www.uniprot.org/faq/45
+    and http://www.uniprot.org/program/automatic_annotation .<br>When a UniProtKB
+    Subcellular Location term describes a concept that is within the scope of the
+    Gene Ontology, it is investigated to determine whether it is appropriate to map
+    the term to an equivalent term in GO. The mapping between UniProtKB Subcellular
+    Location terms and GO terms is carried out manually. Definitions and hierarchies
+    of the terms in the two resources are compared and the mapping generated will
+    reflect the most correct correspondence. The translation table between GO terms
+    and UniProtKB Subcellular Location term is maintained by the UniProt-GOA team
+    and available at http://www.geneontology.org/external2go/spsl2go .
+  - Duplicate of GO_REF:0000039.
+- authors: GO ontology editors
+  id: GO_REF:0000072
+  year: 2013
+  layout: goref
+  title: Representation of chemical homeostasis and cellular chemical homeostasisl
+    as biological process in the Gene Ontology
+  comments:
+  - 'We have created a standard template for classes describing the homeostasis and
+    cellular homeostasis for a chemical entity (ChEBI) as a biological process. The
+    underlying equivalence axiom templates are "GO:0048878 and ''regulates level of''
+    some X" (homeostasis) and "GO:0055082 and ''regulates level of'' some X" (cellular
+    homeostasis), where X is a chemical entity (CHEBI:24431). The approach to combine
+    GO and ChEBI has been described in the following publication: PMID:23895341.'
+- authors: GO ontology editors
+  id: GO_REF:0000081
+  year: 2013
+  layout: goref
+  title: Representation of plant formation as biological process in the Gene Ontology
+  comments:
+  - We have created a standard template for classes describing the formation of a
+    plant structure as a biological process. The underlying equivalence axiom template
+    is "'anatomical structure formation involved in morphogenesis' and 'results in
+    formation of' some P", where P is a plant anatomical entity (PO:0025131).
+- authors: GO ontology editors
+  id: GO_REF:0000091
+  year: 2014
+  layout: goref
+  title: Representation of cell migration as biological processes in the Gene Ontology
+  comments:
+  - We have created a standard template for classes describing the cell migration
+    process for a cell type as a biological process. The underlying equivalence axiom
+    template is "'cell migration' and 'alters_location_of' some C", where C is a native
+    cell (CL:0000004).
+- authors: GO ontology editors
+  id: GO_REF:0000062
+  year: 2013
+  layout: goref
+  title: Representation of processes occurring in parts of the cell in the Gene Ontology
+  comments:
+  - We have created a standard template for classes describing processes occurring
+    in parts of the cell. The underlying equivalence axiom template is "P and 'occurs
+    in' some C", where P is a biological process and C is a cellular component.
+- authors: Pascale Gaudet, Michael Livstone, Paul Thomas, The Reference Genome Project
+  external_accession:
+  - SGD_REF:S000146947
+  - TAIR:Communication:501741973
+  - MGI:MGI:4459044
+  - 'J:161428 '
+  - ZFIN:ZDB-PUB-110330-1
+  - FB:FBrf0232076
+  id: GO_REF:0000033
+  url: http://gocwiki.geneontology.org/index.php/PAINT
+  year: 2010
+  is_obsolete: true
+  layout: goref
+  title: OBSOLETE Annotation inferences using phylogenetic trees
+  comments:
+  - This GO_REF was originally used to support PAINT annotations. The SOP has changed,
+    and now phylogenetic annotations are supported using the identifier for the family
+    itself.
+  - The goal of the GO Reference Genome Project, described in PMID 19578431, is to
+    provide accurate, complete and consistent GO annotations for all genes in twelve
+    model organism genomes.To this end, GO curators are annotating evolutionary trees
+    from the PANTHER database with GO terms describing molecular function, biological
+    process and cellular component. GO terms based on experimental data from the scientific
+    literature are used to annotate ancestral genes in the phylogenetic tree by sequence
+    similarity (ISS), and unannotated descendants of these ancestral genes are inferred
+    to have inherited these same GO annotations by descent. The annotations are done
+    using a tool called PAINT (Phylogenetic Annotation and INference Tool).
+- authors: The GO Consortium
+  id: GO_REF:0000056
+  year: 2013
+  is_obsolete: true
+  layout: goref
+  title: OBSOLETE Taxon constraints to detect inconsistencies in annotation and ontology
+    structure.
+  comments:
+  - 'GO is intended to cover the full range of species, therefore GO terms are defined
+    to be taxon neutral, avoiding reliance on taxon information for full definition
+    of the given process, function, or component. For certain terms, however, there
+    is obvious implicit taxon specificity, such that the term should only be used
+    to categorize gene products from particular species. Taxon specificity of GO terms
+    is captured using relationships such as "only_in_taxon" and "never_in_taxon".
+    All taxon constraints are inherited by sub-types and parts of the GO term they
+    are applied to. Taxon constraints are used to prevent inappropriate annotations
+    from being made by curators as well as to identify pre-existing annotations that
+    violate the taxon constraints. Errors in annotations are automatically detected
+    by looking for inconsistencies between the taxonomic origin of the annotated gene
+    products and the implicit taxon specificity of the GO terms. The inconsistencies
+    are passed on to curators for correction, in some cases the constraints need to
+    be tightened or relaxed or the structure of the ontology needs to be adjusted.
+    The taxon constraints are further described in this publication: Deegan, Dimmer
+    and Mungall. BMC Bionformatics (2010) Formalization of taxon-based constraints
+    to detect inconsistencies in annotaiton and ontology development. (PMID:20973947). '
+- authors: GO Central curators, GOA curators, Rhea curators
+  citation: PMID:30272209
+  id: GO_REF:0000116
+  year: 2020
+  layout: goref
+  title: Automatic Gene Ontology annotation based on Rhea mapping.
+  comments:
+  - 'Rhea (https://www.rhea-db.org/, PMID:30272209) is an expert-curated knowledgebase
+    of chemical and transport reactions of biological interest - and the standard
+    for enzyme and transporter annotation in UniProtKB (PMID:31688925). Rhea uses
+    the chemical dictionary ChEBI (Chemical Entities of Biological Interest) to describe
+    reaction participants and their chemical transformations in a computationally
+    tractable manner. GO terms corresponding to Rhea reactions are assigned a Rhea
+    database cross-reference. The corresponding GO term is automatically applied to
+    all UniProt entries annotated with a Rhea reaction. The mapping file is available
+    at: http://current.geneontology.org/ontology/external2go/rhea2go.'
+- authors: GO ontology editors
+  id: GO_REF:0000076
+  year: 2013
+  layout: goref
+  title: Representation of transport or vesicle-mediated transport from cell component
+    to cell component as biological process in the Gene Ontology
+  comments:
+  - We have created a standard template for classes describing the transport or vesicle-mediated
+    transport from cellular component to cellular component as a biological process.
+    The underlying equivalence axiom templates are "GO:0006810 and 'has_target_start_location'
+    some F and 'has_target_end_location' some T" (transport) and "GO:0016192 and 'has_target_start_location'
+    some F and 'has_target_end_location' some T" (vesicle-mediated transport), where
+    F and T are a cellular components.
+- authors: PAMGO_GAT curators
+  id: GO_REF:0000027
+  year: 2007
+  layout: goref
+  title: BLAST search criteria for ISS assignment in PAMGO_GAT
+  comments:
+  - This GO reference describes the criteria used in assigning the evidence code of
+    ISS via BLAST searches to annotate gene products from PAMGO_GAT. Standard BLASTP
+    from NCBI was used (http://www.ncbi.nih.gov/blast) to query the non-redundant
+    (NR) database. Hits are considered to be significant if the E-value is at or less
+    than 10^-4. All other parameters are default according to http://www.ncbi.nih.gov/blast.
+- authors: GO ontology editors
+  id: GO_REF:0000085
+  year: 2013
+  layout: goref
+  title: Representation of cell apoptotic process as biological process in the Gene
+    Ontology
+  comments:
+  - We have created a standard template for classes describing the apoptotic process
+    for a cell type as a biological process. The underlying equivalence axiom template
+    is "'apoptotic process' and 'occurs in' some C", where C is a native cell (CL:0000003).
+- authors: GO ontology editors
+  id: GO_REF:0000102
+  is_obsolete: true
+  year: 2015
+  layout: goref
+  title: OBSOLETE Representation of cellular component binding as molecular functions
+    in the Gene Ontology
+  comments:
+  - We have created a standard template for classes cellular component binding as
+    a molecular function. The underlying equivalence axiom template is "'binding'
+    and 'has input' some C", where C is a cellular component (GO:0005575).
+- authors: UniProt-GOA
+  id: GO_REF:0000042
+  is_obsolete: true
+  year: 2012
+  layout: goref
+  title: OBSOLETE Gene Ontology annotation through association of InterPro records
+    with GO terms, accompanied by conservative changes to GO terms applied by UniProt.
+  comments:
+  - "Transitive assignment of GO terms based on InterPro classification. For any database\
+    \ entry (representing a protein or protein-coding gene) that has been annotated\
+    \ with one or more InterPro domains, The corresponding GO terms are obtained from\
+    \ a translation table of InterPro entries to GO terms (interpro2go) generated\
+    \ manually by the InterPro team at EBI. The mapping file is available at http://www.geneontology.org/external2go/interpro2go.<br>Please\
+    \ note that the GO term in the annotation assigned with this GO reference has\
+    \ been changed from that originally applied by the InterPro2GO mapping. This change\
+    \ has been carried out by the UniProt group to ensure the GO annotation obeys\
+    \ the GO Consortium\u2019s ontology structure and taxonomic constraints. Further\
+    \ information on the rules used by UniProt to transform specific incorrect IEA\
+    \ annotations is available at http://www.ebi.ac.uk/QuickGO/AnnotationPostProcessing.html."
+  - Duplicate of GO_REF:0000002.
+- authors: Human Protein Atlas
+  id: GO_REF:0000052
+  year: 2013
+  layout: goref
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  comments:
+  - 'GO Cellular Component terms are manually assigned by curators studying high resolution
+    confocal microscopy images of immunohistochemically stained tissue. The methodology
+    uses antibody-based proteomics which combines high-throughput generation of affinity-purified
+    antibodies with protein profiling in a variety of cells and tissues. Further information
+    on the annotation methods can be found at http://www.proteinatlas.org/about/assays+annotation
+    <br>Annotations are only exported to the GO Consortium if the localizations are
+    supported by literature, according to the following validation grading:<br>Supportive
+    - Subcellular localization supported by literature.<br>1) One/multiple localizations
+    supported by literature.<br>2) Multiple localizations partly supported (at least
+    one) by literature.<br>3) One/multiple localizations in cytoplasm (i.e. Golgi,
+    mitochondria, ER etc) with literature supporting cytoplasmic localization. <br>Prior
+    to February 2013, all Human Protein Atlas annotations were referenced by PMID:18029348
+    (Barbe et al. 2008 Mol. Cell Proteomics. 7:499-508), a paper describing the protein
+    localization pilot study and methodology used by the Human Protein Atlas. However,
+    it has been decided that these annotations are more correctly described by a GO
+    reference.<br>Resource URL: http://www.proteinatlas.org <br>Protein subcellular
+    localization images can be viewed on the Human Protein Atlas website, e.g. http://www.proteinatlas.org/ENSG00000175899/summary#ifcelline'
+- authors: Ivan Erill, James Hu, Community Assessment of Community Annotation with
+    Ontologies
+  id: GO_REF:0000112
+  is_obsolete: true
+  year: 2017
+  layout: goref
+  title: OBSOLETE Gene Ontology annotation by CACAO biocurators
+  comments:
+  - This GO reference describes the criteria used by biocurators participating in
+    the Community Assessment of Community Annotation with Ontologies (CACAO) to annotate
+    gene products from genomes of interest through the use of computational methods
+    to establish and manually validate function or homology to gene products. In particular,
+    this GO reference describes the criteria used to make annotations based on evidence
+    codes ISS, ISA, ISO, ISM and IGC. To perform ISS-, ISA-, and ISO-based annotations
+    on a gene product, CACAO biocurators use sequence- and structure-based search
+    algorithms (e.g. BLASTP, HHPred) to establish homology, conservation of sequence
+    and structure functional determinants between the target gene product and gene
+    products from other organisms with published GO annotations supported by experimental
+    codes and lacking NOT qualifiers. These gene products are referenced in the WITH
+    field of the annotation using their xref database accession. ISM-based annotations
+    make use of published computational methods (e.g. TMHMM, SignalP) to predict gene
+    product structure, localization or function. IGC-based annotations are made on
+    the basis of suggestive evidence for function based on synteny. Parameters and
+    criteria for use of all computational methods (e.g. e-value) are listed and versioned
+    in the publicly available CACAO documentation (http://gowiki.tamu.edu/). Annotations
+    made by CACAO biocurators are reviewed by CACAO team instructors before their
+    release.
+- alt_id:
+  - GO_REF:0000005
+  authors: GOA curators, MGI curators
+  citation: PMID:11374909
+  external_accession:
+  - MGI:2152096
+  - J:72245
+  - ZFIN:ZDB-PUB-031118-3
+  - SGD_REF:S000124037
+  id: GO_REF:0000003
+  year: 2001
+  layout: goref
+  title: Gene Ontology annotation based on Enzyme Commission mapping.
+  comments:
+  - Transitive assignment using Enzyme Commission identifiers. This method is used
+    for any database entry, such as a protein record in UniProtKB or TrEMBL, that
+    has had an Enzyme Commission number assigned. The corresponding GO term is determined
+    using the EC cross-references in the GO molecular function ontology. Also see
+    Hill et al., Genomics (2001) 74:121-128. The mapping file is available at http://www.geneontology.org/external2go/ec2go.
+  - Formerly GOA:spec.
+- authors: Mouse Genome Informatics scientific curators and FlyBase
+  id: GO_REF:0000095
+  year: 2014
+  layout: goref
+  title: Literature reference not indexed by PubMed
+  comments:
+  - This article is not referenced in PubMed. Please see contributing data resource
+    for details.
+- authors: UniProt-GOA
+  id: GO_REF:0000037
+  is_obsolete: true
+  year: 2011
+  evidence_codes:
+  - ECO:0000501
+  layout: goref
+  title: OBSOLETE Gene Ontology annotation based on manual assignment of UniProtKB
+    keywords in UniProtKB/Swiss-Prot entries.
+  comments:
+  - Transitive assignments using UniProtKB keywords. The UniProtKB keyword controlled
+    vocabulary has been created and used by the UniProt Knowledgebase (UniProtKB)
+    to supply 10 different categories of information to UniProtKB entries. Further
+    information on the UniProtKB keyword resource can be found at http://www.uniprot.org/docs/keywlist.
+    UniProtKB keywords are manually applied to UniProtKB/Swiss-Prot entries by UniProt
+    curators. Further information on the UniProtKB manual annotation process is available
+    at http://www.uniprot.org/faq/45.<br>When a UniProtKB keyword describes a concept
+    that is within the scope of the Gene Ontology, it is investigated to determine
+    whether it is appropriate to map the keyword to an equivalent term in GO. The
+    mapping between UniProtKB keywords and GO terms is carried out manually. Definitions
+    and hierarchies of the terms in the two resources are compared and the mapping
+    generated will reflect the most correct correspondence. The translation table
+    between GO terms and UniProtKB keywords is maintained by the UniProt-GOA team
+    and available at http://www.geneontology.org/external2go/uniprotkb_kw2go.
+  - Duplicate of GO_REF:0000043.
+- authors: GO ontology editors
+  id: GO_REF:0000066
+  year: 2013
+  layout: goref
+  title: Representation of transport of a chemical entity as molecular function in
+    the Gene Ontology
+  comments:
+  - 'We have created a standard template for classes describing the transport of a
+    chemical entity (ChEBI) as a molecular function. The underlying equivalence axiom
+    template is "GO:0005215 and ''transports or maintains localization of'' some X",
+    where X is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI
+    has been described in the following publication: PMID:23895341.'
+- authors: GO ontology editors
+  id: GO_REF:0000077
+  year: 2013
+  is_obsolete: true
+  layout: goref
+  title: OBSOLETE Representation of transport of a cellular component as biological
+    process in the Gene Ontology
+  comments:
+  - We have created a standard template for classes describing the transport or vesicle-mediated
+    transport of a cellular component as a biological process. The underlying equivalence
+    axiom templates are "GO:0006810 and 'transports or maintains localization of'
+    some C" (transport) and "GO:0016192 and 'transports or maintains localization
+    of' some C" (vesicle-mediated transport), where C is a cellular component.
+- authors: Jennifer Deegan nee Clark (1, 5), Alexander D. Diehl (1,7), Elisabeth Ehler
+    (2), Georgine Faulkner (3), Erika Feltrin (4), Jennifer Fordham (2), Midori Harris
+    (1, 5), Ralph Knoell (6) David Hill (1, 7), Paolo Laveder (8), Alessandra Nori
+    (8), Carlo Reggiani (8), Vincenzo Sorrentino (9), Giorgio Valle (4), Pompeo Volpe
+    (8) (1. The Gene Ontology Consortium, 2. King's College, London, UK, 3. ICGEB,
+    Trieste, Italy, 4. CRIBI - University of Padua, Padua, Italy 5. EMBL-EBI, Hinxton,
+    Cambridgeshire, UK, 6. University of Goettingen, Goettingen, Germany 7. Mouse
+    Genome Informatics, Bar Harbor, ME, 8. University of Padua, Padua, Italy, 9. University
+    of Siena, Siena, Italy)
+  citation: PMID:19178689
+  id: GO_REF:0000026
+  is_obsolete: true
+  year: 2007
+  layout: goref
+  title: OBSOLETE Improving the representation of muscle biology in the biological
+    process and cellular component ontologies.
+  comments:
+  - 'A meeting focused on the biology of skeletal and smooth muscle has been held
+    on 24-25 July 2007 at the University of Padua, Italy, as a collaboration with
+    the GO consortium and CRIBI Biotechnology Center. The aims of this effort were
+    to provide a comprehensive representation of muscle biology in the biological
+    process and cellular component ontologies and to improve the organization of muscle-specific
+    terms to better describe the current knowledge of biological mechanisms in muscle
+    tissue. Thus, the collaboration brought together experts in several areas of muscle
+    biology and physiology who carried out a thorough review of the existing GO muscle
+    terms as these terms were largely created by non-muscle experts using older definitions.
+    In particular, several areas are being addressed actively in current research:
+    the biological processes of muscle contraction, muscle plasticity, muscle development,
+    and muscle regeneration; and the sarcoplasmic reticulum and membrane delimited
+    compartments. This work resulted in the addition of 159 new terms and in the modification
+    of 57 terms to bring them in line with current usage. Funding for the meeting
+    was provided by Italian Telethon Foundation.'
+- authors: GO ontology editors
+  id: GO_REF:0000084
+  year: 2013
+  layout: goref
+  title: Representation of plant structural organization as biological process in
+    the Gene Ontology
+  comments:
+  - We have created a standard template for classes describing the structural organization
+    of a plant structure as a biological process. The underlying equivalence axiom
+    template is "'anatomical structure arrangement' and 'results in structural organization
+    of' some P", where P is a plant anatomical entity (PO:0025131).
+- authors: Michelle Gwinn, TIGR curators
+  id: GO_REF:0000012
+  year: 2003
+  layout: goref
+  title: Pairwise alignment (TIGR)
+  comments:
+  - 'Pairwise alignments are generated by taking two sequences and aligning them so
+    that the maximum number of amino acids in each protein match, or are similar to,
+    each other. Tools such as BLAST work by comparing a protein-of-interest individually
+    with every protein in a database of known protein sequences and retaining only
+    those matches with a high probability of being significant. Basic BLAST generates
+    local alignments between proteins for regions of high similarity. Other pairwise
+    alignment tools attempt to generate global (full-length) protein alignments. A
+    tool called Blast_Extend_repraze (BER, http://ber.sourceforge.net) has some benefits
+    over basic BLAST. Input into the BER tool includes the underlying DNA sequence
+    for each protein as well as 300 nucleotides upstream and downstream of the predicted
+    boundaries of the protein coding sequence. This allows annotators to see the DNA
+    sequence that underlies the query protein as part of the alignment. In addition,
+    the BER tool is able to look for continuation of regions of similarity through
+    frameshifts and in-frame stop codons.  If such regions are found the alignment
+    is continued. BER searches are done in a two-step process: step one is a BLAST
+    search against a non-redundant protein database, significant BLAST hits are stored
+    in a mini-database for each query protein; step two is a modified Smith-Waterman
+    alignment between the query and the proteins in its mini-database. In order to
+    assess whether a given BER alignment is good enough to assert that the query shares
+    the function of the match protein, one must look at a several factors. First of
+    all, the match protein must itself be experimentally characterized in order to
+    avoid transitive annotation errors. In addition, any residues or secondary structures
+    known to be important for function in the match protein must be conserved in the
+    query. The alignment should be visually inspected to look for any areas of lesser
+    quality that might indicate the two proteins do not share the same function. Although
+    it is impossible to set cutoff values for percent identity and length of match
+    that will apply for every alignment, there are some guidelines. In general at
+    least 40% identity that extends over the full lengths of both proteins is required
+    in order to even consider functional equivalence. However, this percentage is
+    highly dependent on the length and complexity of the proteins. 40% identity between
+    two proteins 500 amino acids long is much more significant that 40% identity between
+    two proteins that are only 100 amino acids long. Therefore, the annotator''s experience
+    and knowledge of what is considered significant for the organism and protein family
+    in question is very important. Some sets of proteins are much more highly conserved
+    than others and therefore tolerances for percent identity may have to be adjusted.
+    Finally, the alignment must be considered in the context of what else is known
+    about the query protein and the organism as a whole.'
+- authors: GO ontology editors
+  id: GO_REF:0000103
+  is_obsolete: true
+  year: 2015
+  layout: goref
+  title: OBSOLETE Representation of cellular component organization as biological
+    process in the Gene Ontology
+  comments:
+  - We have created a standard template for classes cellular component organization
+    as a biological process. The underlying equivalence axiom template is "'cellular
+    component organization' and 'results_in_organization_of' some C", where C is a
+    cellular component (GO:0005575).
+- authors: UniProt-GOA
+  id: GO_REF:0000043
+  external_accession:
+  - SGD_REF:S000148669
+  - J:60000
+  - TAIR:AnalysisReference:501756968
+  - TAIR:AnalysisReference:501756970
+  year: 2012
+  layout: goref
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
+  comments:
+  - 'Transitive assignments using UniProtKB/Swiss-Prot keywords. The UniProtKB keyword
+    controlled vocabulary contains 10 different categories of information to UniProtKB
+    entries. Further information on the UniProtKB keyword resource can be found at
+    https://www.uniprot.org/keywords/.
 
-  UniProtKB keywords are assigned to UniProtKB/Swiss-Prot entries by UniProt curators
-  as part of the UniProtKB manual curation process. UniProtKB keywords are also automatically
-  assigned to UniProtKB/TrEMBL entries from the underlying nucleic acid databases
-  and/or by the UniProt automatic annotation program.
+    UniProtKB keywords are assigned to UniProtKB/Swiss-Prot entries by UniProt curators
+    as part of the UniProtKB manual curation process. UniProtKB keywords are also
+    automatically assigned to UniProtKB/TrEMBL entries from the underlying nucleic
+    acid databases and/or by the UniProt automatic annotation program.
 
-  Further information on the two different UniProt annotation methods is available
-  at https://www.uniprot.org/help/keywords..
+    Further information on the two different UniProt annotation methods is available
+    at https://www.uniprot.org/help/keywords..
 
-  When a UniProtKB keyword describes a concept that is within the scope of the Gene
-  Ontology, a mapping is manually made to the corresponding GO term.The translation
-  table between GO terms and UniProtKB keywords is maintained by the EBI GOA team
-  and available at http://www.geneontology.org/external2go/uniprotkb_kw2go.'
----
-authors: 'GO ontology editors '
-id: GO_REF:0000053
-year: 2013
-is_obsolete: true
-layout: goref
-title: OBSOLETE Automatic classification of GO using the ELK reasoner
-comments:
-- We use the <a href="http://code.google.com/p/elk-reasoner/">ELK reasoner</a> as
-  part of an ontology development and release pipeline to automatically construct
-  and check a large portion of the GO graph. The editors version of the GO (gene_ontology_write.obo)
-  contains additional metadata, including provenance of graph links. Every week, the
-  GO pipeline executes a process which first removes all links tagged as "is_inferred".
-  The reasoner then generates a list of inferred links which are automatically added
-  to the ontology with the "is_inferred" tag set. The pipeline generates a report
-  describing which links have changed as a part of this process.
----
-authors: "Marcio Luis Acencio (1), George Georghiou (2), Sandra Orchard (2), Liv Thommensen\
-  \ (1), Martin Kuiper (1) and Astrid L\xE6greid (1). (1) Norwegian University of\
-  \ Science and Technology (NTNU), Trondheim, Norway; (2) European Bioinformatics\
-  \ Institute (EBI), Hinxton, Cambridgeshire, United Kingdom"
-id: GO_REF:0000113
-year: 2018
-layout: goref
-title: Gene Ontology annotation of human sequence-specific DNA binding transcription
-  factors (DbTFs) based on the TFClass database
-comments:
-- 'The TFClass (http://tfclass.bioinf.med.uni-goettingen.de/index.jsf) database provides
-  a comprehensive classification of mammalian DNA binding transcription factors (DbTFs)
-  based on their DNA binding domains (DBDs) (PMID:29087517). TFClass classifies mammalian
-  DbTFs by a five-level classification in which the four highest levels represent
-  groups defined by structural and sequence similarities (superclass, class, family,
-  subfamily, and genera) (more details at http://www.edgar-wingender.de/TFClass_schema.html).
-  This classification is based on the combination of background knowledge of the molecular
-  structural features of DBDs (PMID:9340487, PMID:23427989) and phylogenetic trees
-  constructed via multiple sequence alignment with hierarchical clustering of manually
-  validated DBDs and/or full-length protein sequences retrieved from UniProt (PMID:23427989,
-  PMID:23180794, PMID:23427989). '
-- 'The NTNU curation team has evaluated each family and assigned a molecular function
-  annotation, GO:0000981 (DNA-binding transcription factor activity, RNA polymerase
-  II-specific), and a cellular component annotation GO:0000790 (nuclear chromatin),
-  as appropriate. The superclass/class/family or subfamily ID is specified in the
-  "With/From" field. The annotations are supported by the evidence code ECO:0005556
-  (multiple sequence alignment evidence used in manual assertion). '
----
-alt_id:
-- GO_REF:0000007
-- GO_REF:0000014
-- GO_REF:0000016
-- GO_REF:0000017
-authors: DDB, FB, MGI, GOA, ZFIN curators
-external_accession:
-- MGI:2152098
-- J:72247
-- ZFIN:ZDB-PUB-020724-1
-- FB:FBrf0174215
-- dictyBase_REF:10157
-- SGD_REF:S000124036
-id: GO_REF:0000002
-year: 2001
-layout: goref
-title: Gene Ontology annotation through association of InterPro records with GO terms.
-comments:
-- Transitive assignment of GO terms based on InterPro classification. For any database
-  entry (representing a protein or protein-coding gene) that has been annotated with
-  one or more InterPro domains, The corresponding GO terms are obtained from a translation
-  table of InterPro entries to GO terms (interpro2go) generated manually by the InterPro
-  team at EBI. The mapping file is available at http://www.geneontology.org/external2go/interpro2go.
-- Formerly GOA:interpro. Note that GO annotations based on InterPro-to-GO transitive
-  assignment may undergo subsequent filtering, e.g. to remove annotations redundant
-  with manual curation; consult documentation from the annotation providers for further
-  information.
----
-authors: GO ontology editors
-id: GO_REF:0000094
-year: 2014
-layout: goref
-title: Representation of metazoan development as biological process in the Gene Ontology
-comments:
-- We have created a standard template for classes describing the development of a
-  metazoan structure as a biological process. The underlying equivalence axiom template
-  is "'anatomical structure development' and 'results in development of' some E",
-  where E is a anatomical entity (UBERON:0001062).
----
-authors: GO Annotation working group
-external_accession:
-- SGD_REF:S000147045
-id: GO_REF:0000036
-year: 2011
-layout: goref
-title: Manual annotations that require more than one source of functional data to
-  support the assignment of the associated GO term
-comments:
-- The Gene Ontology Consortium uses the IC (Inferred by Curator) evidence code when
-  an annotation cannot be supported by any direct evidence, but can be inferred by
-  GO annotations that have been annotated to the same gene/gene product identifier
-  in conjunction with the curator's knowledge of biology (supporting GO annotations
-  must not be IC-evidenced). In many cases an IC-evidenced annotation simply applies
-  the same reference that was used in the supporting GO annotation.  The use of IC
-  evidence code in an annotation with reference GO_REF:0000036 signifies a curator
-  inferred the GO term based on evidence from multiple sources of evidence/GO annotations.
-  The 'with/from' field in these annotations will therefore supply more than one GO
-  identifier, obtained from the set of supporting GO annotations assigned to the same
-  gene/gene product identifier which cite publicly-available references.
----
-authors: GO ontology editors
-id: GO_REF:0000067
-year: 2013
-layout: goref
-title: Representation of binding to a chemical entity as molecular function in the
-  Gene Ontology
-comments:
-- 'We have created a standard template for classes describing the binding to a chemical
-  entity (ChEBI) as a molecular function. The underlying equivalence axiom template
-  is "GO:0005488 and ''has input'' some X", where X is a chemical entity (CHEBI:24431).
-  The approach to combine GO and ChEBI has been described in the following publication:
-  PMID:23895341.'
----
-authors: GOA curators
-id: GO_REF:0000107
-year: 2016
-layout: goref
-title: Automatic transfer of experimentally verified manual GO annotation data to
-  orthologs using Ensembl Compara.
-comments:
-- GO terms from a source species are projected onto one or more target species based
-  on gene orthology obtained from Ensembl Compara. One-to-one, one-to-many and many-to-many
-  orthology relations and anntations are transferred between orthologs that have at
-  least a 40% peptide identity to each other. Only GO annotations with evidence codes
-  ECO:0000314 (IDA), ECO:0000270 (IEP), ECO:0000316 (IGI), ECO:0000315 (IMP), and
-  ECO:0000353 (IPI), or their descendants, are transferred; annotations with a 'NOT'
-  qualifier are not transferred, and neither are annotations to GO:0005515 (protein
-  binding). Annotations that are transferred using this method receive the evidence
-  code ECO:0000265 (sequence orthology evidence used in automatic assertion), which
-  maps up to the GO Inferred from Electronic Annotation (IEA) evidence code.  The
-  model organism database identifier of the annotation source will be indicated in
-  the 'With' column of the GOA association file.
----
-authors: GO curators
-id: GO_REF:0000047
-year: 2012
-layout: goref
-title: Gene Ontology annotation based on absence of key sequence residues.
-comments:
-- This describes a method for supplying a NOT-qualified, IKR-evidenced GO annotation
-  to a gene product, when general sequence homology considerations would suggest a
-  function or location, or a role in a biological process, but where a curator has
-  determined that the absence of key sequence residues, known to be required for an
-  expected activity or location, indicating the gene product is unlikely to be able
-  to carry out the implied activity, involvement in a process or cellular component
-  location. This reference should only be used used when an IKR-evidenced annotation
-  is made based on curator judgement from manually reviewing the sequence of the gene
-  product and where no publication can be found to support the curators conclusion.
-  It is preferable to cite a peer-reviewed publication (such as a PubMed identifier)
-  for IKR-evidenced annotations whenever possible. Curators will have carefully reviewed
-  the sequence of the annotated protein, and established that the key residues known
-  to be required for an expected activity or location are not present. Inclusion of
-  an identifier in the 'with/from' field, that highlights to the user the lacking
-  residues(e.g. an alignment, domain or rule identifier) is absolutely required when
-  annotating to IKR with this GO_REF. Documentation on the GOC website provides more
-  details on the <a href = "http://www.geneontology.org/GO.evidence.shtml#ikr">correct
-  use of the IKR evidence code</a>.
----
-authors: Alison Deckhut Augustine (1), Alan Collmer (2), Judith A. Blake (3, 4), Candace
-  W. Collmer (2, 3), Shane C. Burgess (5), Lindsay Grey Cowell (6), Jennifer I. Clark
-  (3, 7), Bernard de Bono (7), Russell T. Collins (8), Alexander D. Diehl (3, 4),
-  Michelle Gwinn Giglio (3, 9), Jamie A. Lee (10), Linda Hannick (3, 9), Jane Lomax
-  (3, 7), Midori A. Harris (3, 7), Christopher J. Mungall (3, 11), David P. Hill (3,
-  4), Richard H. Scheuermann (10), Amelia Ireland (3, 7), Alessandro Sette (12) (1.
-  NIAID, 2. Cornell University, 3. The GO Consortium, 4. Mouse Genome Informatics,
-  5. Mississippi State University, 6. Duke University, 7. EMBL-EBI, 8. University
-  of Cambridge, 9. The Institute for Genomic Research, 10. U.T. Southwestern Medical
-  Center, 11. HHMI, 12. La Jolla Institute for Allergy and Immunology)
-id: GO_REF:0000022
-year: 2005
-layout: goref
-title: Improving the representation of immunology in the biological process Ontology
-comments:
-- GO terms describing processes, functions, and cellular components related to the
-  immune system have existed in the GO from its beginning and been used extensively
-  in the annotation of gene products. However, particularly in the biological process
-  ontology, the initial set of terms relating to immunology failed to cover the breadth
-  of known immunological processes, and in many cases diverged from current usage
-  and understanding in their names, definitions, and ontological placement. As part
-  of a larger effort to improve the representation of immunology in the GO, a GO Content
-  Meeting was held November 15-16, 2005, at The Institute for Genomic Research, to
-  discuss improvements to representation of immunology in the biological process ontology
-  of the GO. As a result of the meeting, a number of high level terms for immunological
-  processes were created, an overall structure for immunologically related terms was
-  established, and certain existing terms were renamed or redefined as well to bring
-  them in line with current usage.
----
-authors: GO ontology editors
-id: GO_REF:0000073
-year: 2013
-layout: goref
-title: Representation of import of a chemical as biological process in the Gene Ontology
-comments:
-- 'We have created a standard template for classes describing the import of a chemical
-  entity (ChEBI) as a biological process. The underlying equivalence axiom template
-  is "GO:0006810 and ''imports'' some X", where X is a chemical entity (CHEBI:24431).
-  The approach to combine GO and ChEBI has been described in the following publication:
-  PMID:23895341.'
----
-authors: GO ontology editors
-id: GO_REF:0000080
-year: 2013
-layout: goref
-title: Representation of plant development as biological process in the Gene Ontology
-comments:
-- We have created a standard template for classes describing the development of a
-  plant structure as a biological process. The underlying equivalence axiom template
-  is "'anatomical structure development' and 'results in development of' some P",
-  where P is a plant anatomical entity (PO:0025131).
----
-authors: GO ontology editors
-id: GO_REF:0000090
-year: 2013
-layout: goref
-title: Automatic creation of relationships between ontology branches in the Gene Ontology
-comments:
-- 'We have created a rule-based approach to create relations between the branches
-  of the Gene Ontology. The approach uses the equivalence axioms and a given pattern
-  to create non-subClassOf relationships between the three different branches of the
-  Gene Ontology (biological process, molecular function, cellular component). Currently,
-  there are the following rules: "''transporter activity'' and ''transports_or_maintains_localization_of''
-  some X'' -part_of-&gt; "transport and ''transports_or_maintains_localization_of''
-  some X"; "''transmembrane transporter activity'' and ''transports_or_maintains_localization_of''
-  some X -part_of-&gt; ''transmembrane transport'' and ''transports_or_maintains_localization_of''
-  some X"'
----
-authors: GO ontology editors
-id: GO_REF:0000063
-year: 2013
-layout: goref
-title: Representation of processes regulated by other regulating processes in the
-  Gene Ontology
-comments:
-- We have created a standard template for classes describing processes regulated by
-  other regulating processes. The underlying equivalence axiom template is "R and
-  'results_in' some P", where R is a biological process and P is a regulation of biological
-  process subclass.
----
-authors: Christopher J. Mungall, Tanya Z. Berardini, David P. Hill
-id: GO_REF:0000032
-is_obsolete: true
-url: http://wiki.geneontology.org/index.php/GAF_Inference
-layout: goref
-title: OBSOLETE Inference of Biological Process annotations from inter-ontology links
-comments:
-- We use the GOBO library to propagate annotations from Molecular Function to Biological
-  Process. This results in both increased numbers of annotations, and increased consistency
-  between curators.
-- Duplicate of GO_REF:0000108.
----
-authors: Mouse Genome Informatics scientific curators
-citation: PMID:11374909
-external_accession:
-- MGI:2152097
-- J:72246
-id: GO_REF:0000006
-is_obsolete: true
-year: 2001
-layout: goref
-title: OBSOLETE Gene Ontology annotation by the MGI curatorial staff, Mouse Locus
-  Catalog
-comments:
-- For annotations documented via this citation, curators used the information in the
-  Mouse Locus Catalog in MGI to assign GO terms. The GO terms were assigned based
-  on MLC textual descriptions of genes that could not be traced to the primary literature.
-  Details of this strategy can be found in Hill et al, Genomics (2001) 74:121-128.
----
-authors: UniProt
-id: GO_REF:0000117
-year: 2021
-layout: goref
-title: Electronic Gene Ontology annotations created by ARBA machine learning models
-comments:
-- ARBA predicts Gene Ontology (GO) terms among other types of functional annotation
-  such as Protein Description (DE), Keywords (KW), Enzyme Commission numbers (EC),
-  sucellular LOcation (LO), etc. For all annotation types, reviewed UniProtKB/Swiss-Prot
-  records having manual annotations as reference data are used to perform the machine
-  learning phase and generate prediction models. For GO terms, ARBA has an additional
-  feature to augment reference data using the relations between GO terms in the GO
-  graph. The data augmentation is based on adding more general annotations into records
-  containing manual GO terms, which will result in richer reference data. The predicted
-  GO terms are then propagated to all unreviewed UniProtKB/TrEMBL proteins that meet
-  the conditions of ARBA models. GO annotations using this technique receive the evidence
-  code Inferred from Electronic Annotation (IEA; ECO:0000501). These annotations are
-  updated regularly by UniProt and are available for download on both the GO and GOA
-  EBI ftp sites.
----
-authors: GO ontology editors
-id: GO_REF:0000087
-year: 2013
-layout: goref
-title: Representation of protein localization and establishment of protein localization
-  as biological process in the Gene Ontology
-comments:
-- We have created a standard template for classes describing the protein localization
-  and establishment of protein localization to a cellular component as a biological
-  process. The underlying equivalence axiom templates are "GO:0008104 and 'has_target_end_location'
-  some C" (protein localization) and "GO:0045184 and 'has_target_end_location' some
-  C" (establishment of protein localization), where C is cellular component.
----
-authors: Michelle Gwinn, TIGR curators
-id: GO_REF:0000025
-year: 2007
-layout: goref
-title: Operon structure as IGC evidence
-comments:
-- Genes in prokaryotic organisms are often arranged in operons. Genes in an operon
-  are all transcribed into one mRNA. Generally the genes in the operons code for proteins
-  that all have related functions. For example, they may be the steps in a biochemical
-  pathway, or they may be the subunits of a protein complex. Often the genes in operons
-  shared between organisms are syntenic; that is, the same genes are in the same order
-  in the operon in different species. When assessing sequence-comparison-based evidence
-  during the process of manual annotation of a genome, it is often the case that some
-  of the genes in the operon will have strong sequence-based evidence while others
-  will have weak evidence. If seen alone, not in the presence of an operon, the weak
-  evidence in question may not be sufficient to make a functional annotation. However,
-  in the presence of an operon in which there is strong evidence for some of the genes,
-  the very presence of the gene in the operon is a strong indication that the gene
-  shares in the process carried out by the operon. If the putative function is one
-  expected to exist for the process in question and particularly if that function
-  has been observed in the same operon in another species, then the annotation should
-  be made. This type of evidence is inferred from the context of the gene in an operon,
-  and therefore the evidence code is IGC "inferred from genomic context."
----
-authors: GO ontology editors
-id: GO_REF:0000074
-year: 2013
-layout: goref
-title: Representation of export of a chemical as biological process in the Gene Ontology
-comments:
-- 'We have created a standard template for classes describing the export of a chemical
-  entity (ChEBI) as a biological process. The underlying equivalence axiom template
-  is "GO:0006810 and ''exports'' some X", where X is a chemical entity (CHEBI:24431).
-  The approach to combine GO and ChEBI has been described in the following publication:
-  PMID:23895341.'
----
-authors: Ivan Erill, SEA-PHAGE biocurators
-id: GO_REF:0000100
-is_obsolete: true
-year: 2014
-layout: goref
-title: OBSOLETE Gene Ontology annotation by SEA-PHAGE biocurators
-comments:
-- This GO reference describes the criteria used by biocurators of the SEA-PHAGE consortium
-  for the annotation of predicted gene products from newly sequenced bacteriophage
-  genomes in the SEA-PHAGE phagesdb.org and other databases and in the GenBank records
-  periodically released to NCBI for these genomes. In particular, this GO reference
-  describes the criteria used to assign evidence codes ISS, ISA, ISO, ISM, IGC and
-  ND. To assign ISS, ISA, ISO and ISM evidence codes, SEA-PHAGE biocurators use a
-  varied array of bioinformatics tools to establish homology and conservation of sequence
-  and structure functional determinants with proteins from multiple organisms with
-  published association to experimental GO terms and lacking NOT qualifiers. These
-  proteins are referenced in the WITH field of the annotation using their xref database
-  accession. The primary tools for homology search in ISS, ISA, ISO and ISM assignments
-  are BLASTP and HHpred, using a maximum e-value of 10^-7 for BLASTP and a minimum
-  probability of 0.9 for HHpred, and manual inspection of alignments in both cases.
-  For ISS and ISA assignments, BLASTP alignments are required to have at least 75%
-  coverage and 30% identity. For ISO assignments, orthology is further validated using
-  reciprocal BLASTP with the identified hit. For HHpred results, ISS or ISM annotations
-  are made only if the source for the original GO annotation explicitly defines a
-  matched domain function, or if more than half of the domains of the query protein
-  are identified in the matching protein. All ISS, ISA, ISO and ISM assignments entail
-  the manual verification of the source for the GO term in the matching protein sequence
-  and critical curator assessment of the likelihood of preservation of function, process
-  or component in the context of bacteriophage biology. IGC codes are assigned on
-  the basis of suggestive evidence for function based on synteny, as inferred from
-  whole-genome comparative analyses of multiple bacteriophage genomes using primarily
-  the Phamerator software platform, and with special emphasis on the bacteriophage
-  virion structure and assembly genes. When extensive review of published literature
-  on putative homologs reveals no experimental evidence of function, component or
-  process for a particular gene product, it is assigned an ND evidence code and annotated
-  to the root term for Cellular Component, Molecular Function and Biological Process.
-  As part of the review process for assignment of ISS, ISA, ISO, IGC and ISM evidence
-  codes, SEA-PHAGE curators are required to analyze the reference literature for identified
-  matches and shall perform GO annotations with appropriate evidence codes if these
-  were not available.
----
-authors: UniProt-GOA
-id: GO_REF:0000040
-is_obsolete: true
-year: 2011
-layout: goref
-title: OBSOLETE Gene Ontology annotation based on the automatic assignment of UniProtKB
-  Subcellular Location terms in UniProtKB/TrEMBL entries.
-comments:
-- Transitive assignment of GO terms based on the UniProtKB Subcellular Location vocabulary.
-  UniProtKB Subcellular Location is a controlled vocabulary used to supply subcellular
-  location information to UniProtKB entries in the SUBCELLULAR LOCATION lines. Terms
-  from this vocabulary are applied automatically to UniProtKB/TrEMBL entries from
-  the underlying nucleic acid databases and/or by the UniProt automatic annotation
-  program. Further information on the UniProtKB automatic annotation program is available
-  at http://www.uniprot.org/faq/45.<br>When a UniProtKB Subcellular Location term
-  describes a concept that is within the scope of the Gene Ontology, it is investigated
-  to determine whether it is appropriate to map the term to an equivalent term in
-  GO. The mapping between UniProtKB Subcellular Location terms and GO terms is carried
-  out manually. Definitions and hierarchies of the terms in the two resources are
-  compared and the mapping generated will reflect the most correct correspondence.
-  The translation table between GO terms and UniProtKB Subcellular Location terms
-  is maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/spsl2go.
----
-authors: Michelle Gwinn, TIGR curators
-id: GO_REF:0000011
-year: 2003
-layout: goref
-title: Hidden Markov Models (TIGR)
-comments:
-- A Hidden Markov Model (HMM) is a statistical representation of patterns found in
-  a data set. When using HMMs with proteins, the HMM is a statistical model of the
-  patterns of the amino acids found in a multiple alignment of a set of proteins called
-  the "seed". Seed proteins are chosen based on sequence similarity to each other.
-  Seed members can be chosen with different levels of relationship to each other.
-  They can be members of a superfamily (ex. ABC transporter, ATP-binding proteins),
-  they can all share the same exact specific function (ex. biotin synthase) or they
-  could share another type of relationship of intermediate specificity (ex. subfamily,
-  domain). New proteins can be scored against the model generated from the seed according
-  to how closely the patterns of amino acids in the new proteins match those in the
-  seed. There are two scores assigned to the HMM which allow annotators to judge how
-  well any new protein scores to the model. Proteins scoring above the "trusted cutoff"
-  score can be assumed to be part of the group defined by the seed. Proteins scoring
-  below the "noise cutoff" score can be assumed to NOT be a part of the group. Proteins
-  scoring between the trusted and noise cutoffs may be part of the group but may not.
-  One of the important features of HMMs is that they are built from a multiple alignment
-  of protein sequences, not a pairwise alignment. This is significant, since shared
-  similarity between many proteins is much more likely to indicate shared functional
-  relationship than sequence similarity between just two proteins. The usefulness
-  of an HMM is directly related to the amount of care that is taken in chosing the
-  seed members, building a good multiple alignment of the seed members, assessing
-  the level of specificity of the model, and choosing the cutoff scores correctly.
-  In order to properly assess what functional relevance an above-trusted scoring HMM
-  match has to a query, one must carefully determine what the functional scope of
-  the HMM is. If the HMM models proteins that all share the same function then it
-  is likely possible to assign a specific function to high-scoring match proteins
-  based on the HMM. If the HMM models proteins that have a wide variety of functions,
-  then it will not be possible to assign a specific function to the query based on
-  the HMM match, however, depending on the nature of the HMM in question, it may be
-  possible to assign a more general (family or subfamily level) function. In order
-  to determine the functional scope of an HMM, one must carefully read the documentation
-  associated with the HMM. The annotator must also consider whether the function attributed
-  to the proteins in the HMM makes sense for the query based on what is known about
-  the organism in which the query protein resides and in light of any other information
-  that might be available about the query protein. After carefully considering all
-  of these issues the annotator makes an annotation.
----
-authors: GO curators
-id: GO_REF:0000001
-year: 1998
-layout: goref
-title: GO Consortium unpublished data
-comments:
-- No abstract available.
-- This reference will normally be replaced upon publication of the data supporting
-  the annotation. Formerly GOC:unpublished.
----
-authors: PomBase curators
-external_accession:
-- FB:FBrf0231277
-id: GO_REF:0000050
-year: 2012
-layout: goref
-title: Manual transfer of GO annotation data to genes by curator judgment of sequence
-  model
-comments:
-- Transitive assignment of GO terms to a gene based on a curator's judgment of its
-  match to a sequence model,such as a Pfam or InterPro entry, that has manually curated
-  GO annotations, mappings to GO terms, or a description from which GO terms can be
-  inferred. A statistical model of a sequence or group of sequences is used to make
-  a prediction about the function of a protein or RNA. Annotations are created when
-  a curator evaluates the results, using criteria that include excluding false positives
-  and ensuring that the annotation is accurate for all matches. Statistical scores
-  (such as e values and cutoff scores) and the functional specificity of the model
-  may also be (but are not always) considered. Annotations resulting from the transfer
-  of GO terms use the 'ISM' evidence code and include an accession for the model from
-  which the annotation was projected in the 'with' field (column 8).
----
-authors: FlyBase
-external_accession:
-- FB:FBrf0159903
-id: GO_REF:0000110
-year: 2003
-layout: goref
-title: Gene Ontology annotation of Drosophila melanogaster nuclear genes encoding
-  proteins targeted to the mitochondrion.
-comments:
-- Gene Ontology annotation of Drosophila melanogaster nuclear genes encoding proteins
-  targeted to the mitochondrion based on analysis by MitoDrome (http://mitodrome.ba.itb.cnr.it/)
-  by comparison of human mitochondrial proteins available in SWISSPROT vs. the Drosophila
-  genome, ESTs and cDNA sequences available in the FlyBase database (PMID:12520013).
----
-authors: GO ontology editors
-id: GO_REF:0000064
-year: 2013
-layout: goref
-title: Representation of cell components as part of other cell components in the Gene
-  Ontology
-comments:
-- We have created a standard template for classes describing cell components as part
-  of other cell components. The underlying equivalence axiom template is "P and 'part_of'
-  some W", where P and W are cell components.
----
-authors: Ensembl, GRAMENE, GOA curators
-id: GO_REF:0000035
-year: 2011
-layout: goref
-title: Automatic transfer of experimentally verified manual GO annotation data to
-  plant orthologs using Ensembl Compara
-comments:
-- GO terms from a source species are projected onto one or more target species based
-  on gene orthology obtained from the Ensembl Compara system. One to one, one to many
-  and many to many orthologies are used but annotations are only projected between
-  orthologs that have at least a 40% peptide identity to each other. Only GO annotations
-  with an evidence type of IDA, IEP, IGI, IMP or IPI are projected, no annotations
-  with a 'NOT' qualifier are projected and annotations to the GO:0005515 protein binding
-  term are not projected. Projected GO annotations using this technique will receive
-  the evidence code Inferred from Electronic Annotation (IEA). The model organism
-  database identifier of the annotation source will be indicated in the 'With' column
-  of the GOA association file.
-- Duplicate of GO_REF:0000107.
----
-authors: FlyBase
-id: GO_REF:0000097
-year: 2014
-layout: goref
-title: Gene Ontology annotation based on personal communication to FlyBase
-comments:
-- FlyBase occasionally makes GO annotations based on information that has been sent
-  to us directly by researchers as a personal communication to FlyBase. In each case,
-  the full details of the communication including any associated data and analyses
-  are recorded in a FlyBase publication (FBrf) available from our website (http://flybase.org).
----
-authors: GO Curators
-external_accession:
-- ECO:0000307
-- AspGD_REF:ASPL0000111607
-- CGD_REF:CAL0125086
-- dictyBase_REF:2
-- dictyBase_REF:9851
-- FB:FBrf0159398
-- MGI:MGI:2156816
-- RGD:1598407
-- SGD_REF:S000069584
-- TAIR:Communication:1345790
-- ZFIN:ZDB-PUB-031118-1
-- GO_REF:nd
-id: GO_REF:0000015
-year: 2002
-layout: goref
-title: Use of the ND evidence code for Gene Ontology (GO) terms.
-comments:
-- Direct annotations to any of the three root terms 'molecular function; GO:0003674',
-  'biological process; GO:0008150' or 'cellular component; GO:0005575' indicate that
-  curators have found no data supporting an annotation to a more specific term, either
-  in the literature and/or by sequence similarity for this gene or protein as of the
-  date of the annotation.
----
-authors: UniProt curators
-external_accession:
-- ZFIN:ZDB-PUB-170525-1
-id: GO_REF:0000104
-year: 2015
-layout: goref
-title: Electronic Gene Ontology annotations created by transferring manual GO annotations
-  between related proteins based on shared sequence features.
-comments:
-- 'GO terms are manually assigned to each rule in UniRule. These rules are prepared
-  manually by UniProt curators based on the annotations present in reviewed UniProtKB/Swiss-Prot
-  records that share sequence features, sequence similarity and taxonomy. The assigned
-  GO terms are then transferred to all unreviewed UniProtKB/TrEMBL proteins that meet
-  the conditions given in the UniRule rule. GO annotations using this technique receive
-  the evidence code Inferred from Electronic Annotation (IEA; ECO:0000501). These
-  annotations are updated regularly by UniProt and are available for download on both
-  the GO and GOA EBI ftp sites. To report an annotation error or inconsistency, or
-  for further information, please contact the UniProt Automated Annotation team at
-  automated_annotation@ebi.ac.uk. UniRule is a collaboration between the European
-  Bioinformatics Institute (EMBL-EBI), the Swiss Institute of Bioinformatics (SIB),
-  and the Protein Information Resource at Georgetown University (PIR). For further
-  information, please see UniProt: a hub for protein information Nucleic Acids Res.
-  2015, 43, D204, doi: 10.1093/nar/gku989 or www.uniprot.org.'
----
-authors: UniProt-GOA
-id: GO_REF:0000044
-external_accession:
-- TAIR:AnalysisReference:501756971
-- TAIR:AnalysisReference:50175724
-year: 2012
-layout: goref
-title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
-  vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt.
-comments:
-- "Transitive assignment of GO terms based on the UniProtKB/Swiss-Prot Subcellular\
-  \ Location vocabulary. UniProtKB Subcellular Location is a controlled vocabulary\
-  \ used to supply subcellular location information to UniProtKB entries in the SUBCELLULAR\
-  \ LOCATION lines. Terms from this vocabulary are annotated manually to UniProtKB/Swiss-Prot\
-  \ entries but are automatically assigned to UniProtKB/TrEMBL entries from the underlying\
-  \ nucleic acid databases and/or by the UniProt automatic annotation program.\nFurther\
-  \ information on these two different annotation methods is available https://www.uniprot.org/help/keywords.\
-  \ \nWhen a UniProtKB Subcellular Location term describes a concept that is within\
-  \ the scope of the Gene Ontology, a mapping is manually made to the corresponding\
-  \ GO term. The translation table between GO terms and UniProtKB Subcellular Location\
-  \ term is maintained by the EBI GOA team and available at http://www.geneontology.org/external2go/spsl2go."
----
-authors: GO ontology editors
-id: GO_REF:0000083
-year: 2013
-layout: goref
-title: Representation of plant morphogenesis as biological process in the Gene Ontology
-comments:
-- We have created a standard template for classes describing the morphogenesis of
-  a plant structure as a biological process. The underlying equivalence axiom template
-  is "'anatomical structure morphogenesis' and 'results in morphogenesis of' some
-  P", where P is a plant anatomical entity (PO:0025131).
----
-authors: GO ontology editors
-id: GO_REF:0000070
-year: 2013
-layout: goref
-title: Representation of transmembrane transporter activity as molecular function
-  in the Gene Ontology
-comments:
-- 'We have created a standard template for classes describing the transmembrane transporter
-  activity a chemical entity (ChEBI) as molecular function. This includes variants
-  for secondary active transmembrane transporter activity (GO:0015291), uptake transmembrane
-  transporter activity (GO:0015563), and ATPase activity, coupled to transmembrane
-  movement of substances (GO:0042626). The underlying equivalence axiom template is
-  "G and ''transports or maintains localization of'' some X",  where the genus G is
-  either GO:0022857 (transmembrane transporter activity), GO:0015291, GO:0015563,
-  or GO:0042626 depending on the variant. The variable X is a chemical entity (CHEBI:24431).
-  The approach to combine GO and ChEBI has been described in the following publication:
-  PMID:23895341.'
----
-authors: Judith Blake (1, 2), William Bug (3), Rex Chisholm (1, 4), Jennifer Clark
-  (1, 5), Erika Feltrin (6), Jacqueline Finger (2), David Hill (1, 2), Midori Harris
-  (1, 5), Terry Hayamizu (2), Doug Howe (9), Maryanne Martone (7), Kathleen Millen
-  (8), Francis Sele (4) (1. The Gene Ontology Consortium, 2. Mouse Genome Informatics,
-  Bar Harbor, ME, 3. Drexel University, Philadelphia, PA, 4. Northwestern University,
-  Chicago, IL, 5. EMBL-EBI, Hinxton, Cambridgeshire, UK, 6. The University of Padua,
-  Padua, Italy, 7. The University of California at San Diego, San Diego, CA, 8. The
-  University of Chicago, Chicago, IL, 9. The Zebrafish Information Network, University
-  of Oregon, Eugene, OR)
-id: GO_REF:0000021
-year: 2006
-layout: goref
-title: Improving the representation of central nervous system development in the biological
-  process ontology
-comments:
-- 'Current genetic and molecular studies in many model organisms are aimed at understanding
-  formation and development of the nervous system. Up until this point, the GO has
-  had a very shallow representation of processes pertaining to the nervous system.
-  In June 2006, curators from MGI and ZFIN met with researchers studying central nervous
-  system development to improve the representation of these processes in GO. In particular,
-  emphasis was placed on three areas that are being addressed actively in current
-  research: forebrain development, hindbrain development and neural tube development.
-  This collaboration resulted in the addition of over 500 terms that reflect the development
-  of the forebrain, the hindbrain, and the neural tube from the perspective of biological
-  process and anatomical structure.'
----
-authors: Alexander D. Diehl, Alison Deckhut Augustine, Judith A. Blake, Lindsay G.
-  Cowell, Elizabeth S. Gold, Timothy A. Gondre-Lewis, Anna Maria Masci, Terrence F.
-  Meehan, Penelope A. Morel, Anastasia Nijnik, Bjoern Peters, Bali Pulendran, Richard
-  H. Scheuermann, Q. Alison Yao, Martin S. Zand, Christopher J. Mungall
-id: GO_REF:0000031
-url: http://www.bioontology.org/wiki/index.php/NIAID_Cell_Ontology_Workshop_May_2008
-year: 2008
-is_obsolete: true
-layout: goref
-title: OBSOLETE NIAID Cell Ontology Workshop
-comments:
-- The NIAID sponsored a Cell Ontology Workshop, May 13-14, 2008, in Bethesda, focusing
-  on improving representation of immune cell types in the Cell Ontology. The participants
-  in the workshop worked together to extend the current ontology in the area of immune
-  cell types and to provide the necessary information for the upcoming restructuring
-  of the Cell Ontology in single-inheritance form with genus-differentia definitions.
----
-authors: GO ontology editors
-id: GO_REF:0000060
-year: 2013
-layout: goref
-title: Representation of processes involved in other process in the Gene Ontology
-comments:
-- We have created a standard template for classes describing processes involved in
-  other processes. The underlying equivalence axiom template is "P and 'part_of' some
-  W", where P and W are biological processes.
----
-authors: GO ontology editors
-id: GO_REF:0000093
-year: 2014
-layout: goref
-title: Representation for the degradation to or via a chemical as biological process
-  in the Gene Ontology
-comments:
-- 'We have created a standard template for classes describing the degradation of a
-  chemical entity to or via an other chemical entity as biological processes. The
-  underlying equivalence axiom templates are "GO:0009056 and ''has input'' some S
-  and ''has output'' some T" (catabolism to) and "GO:0009056 and ''has input'' some
-  S and ''has intermediate'' some I" (catabolism via), where S,T, and I are chemical
-  entities (CHEBI:24431). The approach to combine GO and ChEBI has been described
-  in the following publication: PMID:23895341.'
----
-authors: LIFEdb
-id: GO_REF:0000054
-year: 2013
-layout: goref
-title: Gene Ontology annotation based on curation of intracellular localizations of
-  expressed fusion proteins in living cells.
-comments:
-- 'LIFEdb is a database that was created to manage the experimental data produced
-  by the German Cancer Research Institute (DKFZ) and its collaborators, from work
-  on cDNAs contained in the German cDNA Consortium collection. <br>A novel cloning
-  technology was used to rapidly generate N- and C-terminal green fluorescent protein
-  fusions of cDNAs to examine the intracellular localizations of expressed fusion
-  proteins in living cells. GO Cellular Component terms are manually assigned by curators
-  studying fluorescence microscope images of cells labelled with GFP-fused cDNAs.
-  Protein coding regions of novel full length cDNAs are tagged with the coding sequence
-  of the green fluorescent protein, the fusion proteins are then expressed and analyzed
-  for their subcellular localization. <br>Prior to February 2013, all LIFEdb annotations
-  were referenced by PMID: 11256614 (Simpson et al. 2000 EMBO Rep. 1:287-292), a paper
-  describing the protein subcellular localization pilot study and methodology used
-  by LIFEdb. However, it has been decided that these annotations are more correctly
-  described by a GO reference. <br>Resource URL: http://www.dkfz.de/en/mga/Groups/LIFEdb-Database.html
-  <br>Protein subcellular localization images can be viewed on the LIFEdb website,
-  http://www.dkfz.de/gpcf/lifedb.php'
----
-authors: Birgit Meldal and Sandra Orchard (1). (1) European Bioinformatics Institute
-  (EBI), Hinxton, Cambridgeshire, United Kingdom
-id: GO_REF:0000114
-year: 2018
-layout: goref
-title: Manual transfer of experimentally-verified manual GO annotation data to homologous
-  complexes by curator judgment of sequence, composition and function similarity
-comments:
-- Method for transferring manual annotations to an entry based on a curator's judgment
-  of its similarity to a putative homolog that has annotations that are supported
-  with experimental evidence. Annotations are created when a curator judges that the
-  sequence, composition and function of a complex shows high similarity to another
-  complex that has annotation(s) supported by experimental evidence (and therefore
-  display one of the evidence codes ECO:0000353 [IPI] or ECO:0005543). Annotations
-  resulting from the transfer of GO terms display the ECO:0005610, ECO:0005544 or
-  ECO:0005546 evidence codes and include an accession for the complex from which the
-  annotation was projected in the 'with/from' field (column 8). This field MUST contain
-  a Complex Portal accession identifier. Putative homologs are chosen using information
-  combined from a variety of complementary sources. Potential homologs are initially
-  identified using sequence similarity search programs such as BLAST. Homologous relationships
-  are then verified manually using a combination of resources including sequence analysis
-  tools, phylogenetic and comparative genomics databases such as Ensembl Compara,
-  INPARANOID and OrthoMCL, as well as other specialised databases such as species-specific
-  collections (e.g. HGNC's HCOP). In all cases curators check the alignments for each
-  complex component and use their experience to assess whether similarity is considered
-  to be strong enough to infer that the two proteins have a common function so that
-  they can confidently project an annotation. While there is no fixed cut-off point
-  in percentage sequence similarity, generally proteins which have greater than 70%
-  identity that covers greater than 90% of the length of both proteins are examined
-  further. Whilst we expect subunit composition to be conserved between closely related
-  species, this is not an absolute rule and orthologous complexes may differ if a
-  subunit cannot be traced in one species or is experimentally shown not to be present.
-  When there is evidence of multiple paralogs for a single species, multiple variants
-  of the complex can be inferred.
----
-authors: FlyBase
-external_accession:
-- FB:FBrf0145624
-id: GO_REF:0000105
-year: 2016
-layout: goref
-title: Gene Ontology annotation of transfer RNAs based on tRNAscan-SE analysis of
-  the Drosophila melanogaster genome (2002).
-comments:
-- 'Gene Ontology annotation based on predicted cytoplasmic tRNAs using tRNAscan-SE
-  analysis (doi: 10.1093/nar/25.5.0955) of the Drosophila melanogaster genome (2002).
-  Annotations have been reviewed by FlyBase (2015) and found to be consistent when
-  compared with the most recent tRNAscan-SE analysis of the genome (http://gtrnadb.ucsc.edu/genomes/eukaryota/Dmela6/).'
----
-authors: UniProt-GOA
-id: GO_REF:0000045
-is_obsolete: true
-year: 2012
-layout: goref
-title: OBSOLETE Gene Ontology annotation based on UniProtKB/TrEMBL entries keyword
-  mapping, accompanied by conservative changes to GO terms applied by UniProt.
-comments:
-- "Transitive assignments using UniProtKB/TrEMBL keywords. The UniProtKB keyword controlled\
-  \ vocabulary has been created and used by the UniProt Knowledgebase (UniProtKB)\
-  \ to supply 10 different categories of information to UniProtKB/TrEMBL entries entries.\
-  \ Further information on the UniProtKB keyword resource can be found at http://www.uniprot.org/docs/keywlist.<br>UniProtKB\
-  \ keywords are assigned to UniProtKB/UniProtKB entries by UniProt curators as part\
-  \ of the UniProtKB manual curation process. In contrast however, UniProtKB keywords\
-  \ are automatically assigned to UniProtKB/TrEMBL entries from the underlying nucleic\
-  \ acid databases and/or by the UniProt automatic annotation program.<br>Further\
-  \ information on the two different UniProt annotation methods is available at http://www.uniprot.org/faq/45\
-  \ and http://www.uniprot.org/program/automatic_annotation.<br>When a UniProtKB keyword\
-  \ describes a concept that is within the scope of the Gene Ontology, it is investigated\
-  \ to determine whether it is appropriate to map the keyword to an equivalent term\
-  \ in GO. The translation table between GO terms and UniProtKB keywords is maintained\
-  \ by the UniProt-GOA team and available at http://www.geneontology.org/external2go/uniprotkb_kw2go.<br>Please\
-  \ note that the GO term in the annotation assigned with this GO reference has been\
-  \ changed from that originally applied by the UniProtKB keywords 2GO mapping. This\
-  \ change has been carried out by the UniProt group to ensure the GO annotation obeys\
-  \ the GO Consortium\u2019s ontology structure and taxonomic constraints. Further\
-  \ information on the rules used by UniProt to transform specific incorrect IEA annotations\
-  \ is available at http://www.ebi.ac.uk/QuickGO/AnnotationPostProcessing.html."
-- Duplicate of GO_REF:0000004.
----
-authors: GO ontology editors
-id: GO_REF:0000082
-is_obsolete: true
-year: 2013
-layout: goref
-title: OBSOLETE Representation of plant maturation as biological process in the Gene
-  Ontology
-comments:
-- We have created a standard template for classes describing the maturation of a plant
-  structure as a biological process. The underlying equivalence axiom template is
-  "'developmental maturation' and 'results in developmental progression of' some P",
-  where P is a plant anatomical entity (PO:0025131).
----
-authors: GO ontology editors
-id: GO_REF:0000071
-year: 2013
-layout: goref
-title: Representation of response to and cellular response to a chemical as biological
-  process in the Gene Ontology
-comments:
-- 'We have created a standard template for classes describing the response to and
-  cellular response to a chemical entity (ChEBI) as a biological process. The underlying
-  equivalence axiom templates are "GO:0050896 and ''has input'' some X" (response
-  to) and "GO:0070887 and ''has input'' some X" (cellular response to), where X is
-  a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI has been described
-  in the following publication: PMID:23895341.'
----
-authors: Swiss Institute of Bioinformatics (SIB) curators, GOA curators
-id: GO_REF:0000020
-year: 2006
-layout: goref
-title: Electronic Gene Ontology annotations created by transferring manual GO annotations
-  between orthologous microbial proteins
-comments:
-- 'GO terms are manually assigned to each HAMAP family rule. High-quality Automated
-  and Manual Annotation of microbial Proteins (HAMAP) family rules are a collection
-  of orthologous microbial protein families, from bacteria, archaea and plastids,
-  generated manually by expert curators. The assigned GO terms are then transferred
-  to all the proteins that belong to each HAMAP family. Only GO terms from the molecular
-  function and biological process ontologies are assigned. GO annotations using this
-  technique will receive the evidence code Inferred from Electronic Annotation (IEA).
-  These annotations are updated monthly by HAMAP and are available for download on
-  both GO and GOA EBI ftp sites. To report an annotation error or inconsistency, or
-  for further information, please contact the GO Consortium at gohelp@genome.stanford.edu
-  or submit a comment the SourceForge Annotation Issues tracker (http://sourceforge.net/projects/geneontology/).
-  HAMAP is a project based at the Swiss Institute of Bioinformatics (Gattiker et al.
-  2003, Comp. Biol and Chem. 27: 49-58). For further information, please see http://www.expasy.org/sprot/hamap/.'
----
-authors: Daniel Haft, JCVI
-id: GO_REF:0000030
-year: 2008
-is_obsolete: true
-layout: goref
-title: OBSOLETE Portable Annotation Rules
-comments:
-- The JCVI is developing a collection of mixed-evidence annotation rules, under the
-  working name BrainGrab/RuleBase (BGRB). A rule has two parts. The first is the set
-  of conditions that must be met for the rule to fire. The second is the set actions
-  to be taken for rules that have fired. BGRB rules are designed to serve as proxies
-  for the annotators that create them. They have very high fidelity but may have low
-  coverage. Types of evidence used in combination include HMM hits and BLAST matches,
-  hits to neighboring genes, pathway reconstruction reports from the Genome Properties
-  system, and species taxonomy. BLAST matches are described by a number of separate
-  parameters for raw score, percent sequence identity, and coverage of total sequence
-  length by the match region. These parameters are customized for each protein family
-  in order to achieve high fidelity in automated annotation systems. The flexible
-  syntax makes it possible to use existing protein family classifiers, such as Pfam
-  and TIGRFAMs HMMs, in new ways. It is especially useful in assigning GO terms to
-  proteins such as SelD (selenide, water dikinase) that have different roles in different
-  contexts.
----
-authors: GO ontology editors
-id: GO_REF:0000061
-year: 2013
-layout: goref
-title: Representation of a molecular function involved in a biological process in
-  the Gene Ontology
-comments:
-- We have created a standard template for classes describing molecular function involved
-  in other biological processes. The underlying equivalence axiom template is "P and
-  'part_of' some W", where P is a molecular function and W is a biological processes.
----
-authors: GO ontology editors
-id: GO_REF:0000092
-year: 2014
-layout: goref
-title: Representation for the biosynthesis from or via a chemical as biological process
-  in the Gene Ontology
-comments:
-- 'We have created a standard template for classes describing the biosynthesis of
-  a chemical entity from or via an other chemical entity as biological processes.
-  The underlying equivalence axiom templates are "GO:0009058 and ''has output'' some
-  T and ''has input'' some F" (biosynthesis from) and "GO:0009058 and ''has output''
-  some T and ''has intermediate'' some I" (biosynthesis via), where T,F, and I are
-  chemical entities (CHEBI:24431). The approach to combine GO and ChEBI has been described
-  in the following publication: PMID:23895341.'
----
-authors: AgBase biocurators
-id: GO_REF:0000055
-year: 2013
-is_obsolete: true
-layout: goref
-title: OBSOLETE Gene Ontology Cellular Component annotation based on cellular fractionation.
-comments:
-- Assignment of GO Cellular Component terms based on experimental evidence of cellular
-  localization from Differential Detergent Fractionation (DDF). Cellular proteins
-  are differentially fractionated and detected using mass spectrometry. Subcellular
-  localization is based upon identification of proteins in different fractions and
-  analysis of their predicted transmembrane domains. Proteins are assigned GO CC based
-  upon a manually reviewed DDF2GO mapping file.
----
-authors: RNAcentral (1). (1) European Bioinformatics Institute (EMBL-EBI), Hinxton,
-  Cambridgeshire, United Kingdom
-id: GO_REF:0000115
-year: 2018
-layout: goref
-title: Automatic Gene Ontology annotation of non-coding RNA sequences through association
-  of Rfam records with GO terms
-comments:
-- "Rfam (http://rfam.org, PMID:29112718) is a database of non-coding RNA families\
-  \ which are manually\nannotated with GO terms by Rfam curators. RNAcentral (http://rnacentral.org,\
-  \ PMID:27794554) maintains\na comprehensive collection of non-coding RNA sequences\
-  \ that are regularly annotated with Rfam families\nusing the Infernal software (PMID:24008419).\
-  \ When a non-coding RNA sequence is matched to one or more Rfam families\nby sequence\
-  \ similarity, the GO terms associated with the Rfam family are transitively assigned\
-  \ to the non-coding RNA sequence.\nAnnotations resulting from the transfer of GO\
-  \ terms are assigned the ECO:0000256 evidence code\n(match to sequence model evidence\
-  \ used in automatic assertion) and include RNAcentral and Rfam accessions. \nThe\
-  \ annotations are available on the GOA and EMBL-EBI FTP sites. \nThe mapping between\
-  \ Rfam families and GO terms is available at http://www.geneontology.org/external2go/rfam2go,\
-  \ \nand the Infernal software can be downloaded at http://eddylab.org/infernal.\
-  \ To report an annotation error or inconsistency, \nor for further information,\
-  \ please visit the RNAcentral website at http://rnacentral.org."
----
-alt_id:
-- GO_REF:0000009
-- GO_REF:0000013
-authors: GOA curators
-external_accession:
-- MGI:1354194
-- J:60000
-- ZFIN:ZDB-PUB-020723-1
-- SGD_REF:S000124038
-id: GO_REF:0000004
-year: 2000
-layout: goref
-title: Gene Ontology annotation based on UniProtKB keyword mapping.
-comments:
-- 'Transitive assignments using UniProtKB keywords. The UniProtKB keyword controlled
-  vocabulary has been created and used by the UniProt Knowledgebase (UniProtKB) to
-  supply 10 different categories of information to UniProtKB entries. Further information
-  on the UniProtKB keyword resource can be found at http://www.uniprot.org/docs/keywlist.
-  <br>Further information on the UniProt annotation methods is available at  https://www.uniprot.org/help/manual_curation
-  and https://www.uniprot.org/help/automatic_annotation.
+    When a UniProtKB keyword describes a concept that is within the scope of the Gene
+    Ontology, a mapping is manually made to the corresponding GO term.The translation
+    table between GO terms and UniProtKB keywords is maintained by the EBI GOA team
+    and available at http://www.geneontology.org/external2go/uniprotkb_kw2go.'
+- authors: 'GO ontology editors '
+  id: GO_REF:0000053
+  year: 2013
+  is_obsolete: true
+  layout: goref
+  title: OBSOLETE Automatic classification of GO using the ELK reasoner
+  comments:
+  - We use the <a href="http://code.google.com/p/elk-reasoner/">ELK reasoner</a> as
+    part of an ontology development and release pipeline to automatically construct
+    and check a large portion of the GO graph. The editors version of the GO (gene_ontology_write.obo)
+    contains additional metadata, including provenance of graph links. Every week,
+    the GO pipeline executes a process which first removes all links tagged as "is_inferred".
+    The reasoner then generates a list of inferred links which are automatically added
+    to the ontology with the "is_inferred" tag set. The pipeline generates a report
+    describing which links have changed as a part of this process.
+- authors: "Marcio Luis Acencio (1), George Georghiou (2), Sandra Orchard (2), Liv\
+    \ Thommensen (1), Martin Kuiper (1) and Astrid L\xE6greid (1). (1) Norwegian University\
+    \ of Science and Technology (NTNU), Trondheim, Norway; (2) European Bioinformatics\
+    \ Institute (EBI), Hinxton, Cambridgeshire, United Kingdom"
+  id: GO_REF:0000113
+  year: 2018
+  layout: goref
+  title: Gene Ontology annotation of human sequence-specific DNA binding transcription
+    factors (DbTFs) based on the TFClass database
+  comments:
+  - 'The TFClass (http://tfclass.bioinf.med.uni-goettingen.de/index.jsf) database
+    provides a comprehensive classification of mammalian DNA binding transcription
+    factors (DbTFs) based on their DNA binding domains (DBDs) (PMID:29087517). TFClass
+    classifies mammalian DbTFs by a five-level classification in which the four highest
+    levels represent groups defined by structural and sequence similarities (superclass,
+    class, family, subfamily, and genera) (more details at http://www.edgar-wingender.de/TFClass_schema.html).
+    This classification is based on the combination of background knowledge of the
+    molecular structural features of DBDs (PMID:9340487, PMID:23427989) and phylogenetic
+    trees constructed via multiple sequence alignment with hierarchical clustering
+    of manually validated DBDs and/or full-length protein sequences retrieved from
+    UniProt (PMID:23427989, PMID:23180794, PMID:23427989). '
+  - 'The NTNU curation team has evaluated each family and assigned a molecular function
+    annotation, GO:0000981 (DNA-binding transcription factor activity, RNA polymerase
+    II-specific), and a cellular component annotation GO:0000790 (nuclear chromatin),
+    as appropriate. The superclass/class/family or subfamily ID is specified in the
+    "With/From" field. The annotations are supported by the evidence code ECO:0005556
+    (multiple sequence alignment evidence used in manual assertion). '
+- alt_id:
+  - GO_REF:0000007
+  - GO_REF:0000014
+  - GO_REF:0000016
+  - GO_REF:0000017
+  authors: DDB, FB, MGI, GOA, ZFIN curators
+  external_accession:
+  - MGI:2152098
+  - J:72247
+  - ZFIN:ZDB-PUB-020724-1
+  - FB:FBrf0174215
+  - dictyBase_REF:10157
+  - SGD_REF:S000124036
+  id: GO_REF:0000002
+  year: 2001
+  layout: goref
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms.
+  comments:
+  - Transitive assignment of GO terms based on InterPro classification. For any database
+    entry (representing a protein or protein-coding gene) that has been annotated
+    with one or more InterPro domains, The corresponding GO terms are obtained from
+    a translation table of InterPro entries to GO terms (interpro2go) generated manually
+    by the InterPro team at EBI. The mapping file is available at http://www.geneontology.org/external2go/interpro2go.
+  - Formerly GOA:interpro. Note that GO annotations based on InterPro-to-GO transitive
+    assignment may undergo subsequent filtering, e.g. to remove annotations redundant
+    with manual curation; consult documentation from the annotation providers for
+    further information.
+- authors: GO ontology editors
+  id: GO_REF:0000094
+  year: 2014
+  layout: goref
+  title: Representation of metazoan development as biological process in the Gene
+    Ontology
+  comments:
+  - We have created a standard template for classes describing the development of
+    a metazoan structure as a biological process. The underlying equivalence axiom
+    template is "'anatomical structure development' and 'results in development of'
+    some E", where E is a anatomical entity (UBERON:0001062).
+- authors: GO Annotation working group
+  external_accession:
+  - SGD_REF:S000147045
+  id: GO_REF:0000036
+  year: 2011
+  layout: goref
+  title: Manual annotations that require more than one source of functional data to
+    support the assignment of the associated GO term
+  comments:
+  - The Gene Ontology Consortium uses the IC (Inferred by Curator) evidence code when
+    an annotation cannot be supported by any direct evidence, but can be inferred
+    by GO annotations that have been annotated to the same gene/gene product identifier
+    in conjunction with the curator's knowledge of biology (supporting GO annotations
+    must not be IC-evidenced). In many cases an IC-evidenced annotation simply applies
+    the same reference that was used in the supporting GO annotation.  The use of
+    IC evidence code in an annotation with reference GO_REF:0000036 signifies a curator
+    inferred the GO term based on evidence from multiple sources of evidence/GO annotations.
+    The 'with/from' field in these annotations will therefore supply more than one
+    GO identifier, obtained from the set of supporting GO annotations assigned to
+    the same gene/gene product identifier which cite publicly-available references.
+- authors: GO ontology editors
+  id: GO_REF:0000067
+  year: 2013
+  layout: goref
+  title: Representation of binding to a chemical entity as molecular function in the
+    Gene Ontology
+  comments:
+  - 'We have created a standard template for classes describing the binding to a chemical
+    entity (ChEBI) as a molecular function. The underlying equivalence axiom template
+    is "GO:0005488 and ''has input'' some X", where X is a chemical entity (CHEBI:24431).
+    The approach to combine GO and ChEBI has been described in the following publication:
+    PMID:23895341.'
+- authors: GOA curators
+  id: GO_REF:0000107
+  year: 2016
+  layout: goref
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara.
+  comments:
+  - GO terms from a source species are projected onto one or more target species based
+    on gene orthology obtained from Ensembl Compara. One-to-one, one-to-many and many-to-many
+    orthology relations and anntations are transferred between orthologs that have
+    at least a 40% peptide identity to each other. Only GO annotations with evidence
+    codes ECO:0000314 (IDA), ECO:0000270 (IEP), ECO:0000316 (IGI), ECO:0000315 (IMP),
+    and ECO:0000353 (IPI), or their descendants, are transferred; annotations with
+    a 'NOT' qualifier are not transferred, and neither are annotations to GO:0005515
+    (protein binding). Annotations that are transferred using this method receive
+    the evidence code ECO:0000265 (sequence orthology evidence used in automatic assertion),
+    which maps up to the GO Inferred from Electronic Annotation (IEA) evidence code.  The
+    model organism database identifier of the annotation source will be indicated
+    in the 'With' column of the GOA association file.
+- authors: GO curators
+  id: GO_REF:0000047
+  year: 2012
+  layout: goref
+  title: Gene Ontology annotation based on absence of key sequence residues.
+  comments:
+  - This describes a method for supplying a NOT-qualified, IKR-evidenced GO annotation
+    to a gene product, when general sequence homology considerations would suggest
+    a function or location, or a role in a biological process, but where a curator
+    has determined that the absence of key sequence residues, known to be required
+    for an expected activity or location, indicating the gene product is unlikely
+    to be able to carry out the implied activity, involvement in a process or cellular
+    component location. This reference should only be used used when an IKR-evidenced
+    annotation is made based on curator judgement from manually reviewing the sequence
+    of the gene product and where no publication can be found to support the curators
+    conclusion. It is preferable to cite a peer-reviewed publication (such as a PubMed
+    identifier) for IKR-evidenced annotations whenever possible. Curators will have
+    carefully reviewed the sequence of the annotated protein, and established that
+    the key residues known to be required for an expected activity or location are
+    not present. Inclusion of an identifier in the 'with/from' field, that highlights
+    to the user the lacking residues(e.g. an alignment, domain or rule identifier)
+    is absolutely required when annotating to IKR with this GO_REF. Documentation
+    on the GOC website provides more details on the <a href = "http://www.geneontology.org/GO.evidence.shtml#ikr">correct
+    use of the IKR evidence code</a>.
+- authors: Alison Deckhut Augustine (1), Alan Collmer (2), Judith A. Blake (3, 4),
+    Candace W. Collmer (2, 3), Shane C. Burgess (5), Lindsay Grey Cowell (6), Jennifer
+    I. Clark (3, 7), Bernard de Bono (7), Russell T. Collins (8), Alexander D. Diehl
+    (3, 4), Michelle Gwinn Giglio (3, 9), Jamie A. Lee (10), Linda Hannick (3, 9),
+    Jane Lomax (3, 7), Midori A. Harris (3, 7), Christopher J. Mungall (3, 11), David
+    P. Hill (3, 4), Richard H. Scheuermann (10), Amelia Ireland (3, 7), Alessandro
+    Sette (12) (1. NIAID, 2. Cornell University, 3. The GO Consortium, 4. Mouse Genome
+    Informatics, 5. Mississippi State University, 6. Duke University, 7. EMBL-EBI,
+    8. University of Cambridge, 9. The Institute for Genomic Research, 10. U.T. Southwestern
+    Medical Center, 11. HHMI, 12. La Jolla Institute for Allergy and Immunology)
+  id: GO_REF:0000022
+  year: 2005
+  layout: goref
+  title: Improving the representation of immunology in the biological process Ontology
+  comments:
+  - GO terms describing processes, functions, and cellular components related to the
+    immune system have existed in the GO from its beginning and been used extensively
+    in the annotation of gene products. However, particularly in the biological process
+    ontology, the initial set of terms relating to immunology failed to cover the
+    breadth of known immunological processes, and in many cases diverged from current
+    usage and understanding in their names, definitions, and ontological placement.
+    As part of a larger effort to improve the representation of immunology in the
+    GO, a GO Content Meeting was held November 15-16, 2005, at The Institute for Genomic
+    Research, to discuss improvements to representation of immunology in the biological
+    process ontology of the GO. As a result of the meeting, a number of high level
+    terms for immunological processes were created, an overall structure for immunologically
+    related terms was established, and certain existing terms were renamed or redefined
+    as well to bring them in line with current usage.
+- authors: GO ontology editors
+  id: GO_REF:0000073
+  year: 2013
+  layout: goref
+  title: Representation of import of a chemical as biological process in the Gene
+    Ontology
+  comments:
+  - 'We have created a standard template for classes describing the import of a chemical
+    entity (ChEBI) as a biological process. The underlying equivalence axiom template
+    is "GO:0006810 and ''imports'' some X", where X is a chemical entity (CHEBI:24431).
+    The approach to combine GO and ChEBI has been described in the following publication:
+    PMID:23895341.'
+- authors: GO ontology editors
+  id: GO_REF:0000080
+  year: 2013
+  layout: goref
+  title: Representation of plant development as biological process in the Gene Ontology
+  comments:
+  - We have created a standard template for classes describing the development of
+    a plant structure as a biological process. The underlying equivalence axiom template
+    is "'anatomical structure development' and 'results in development of' some P",
+    where P is a plant anatomical entity (PO:0025131).
+- authors: GO ontology editors
+  id: GO_REF:0000090
+  year: 2013
+  layout: goref
+  title: Automatic creation of relationships between ontology branches in the Gene
+    Ontology
+  comments:
+  - 'We have created a rule-based approach to create relations between the branches
+    of the Gene Ontology. The approach uses the equivalence axioms and a given pattern
+    to create non-subClassOf relationships between the three different branches of
+    the Gene Ontology (biological process, molecular function, cellular component).
+    Currently, there are the following rules: "''transporter activity'' and ''transports_or_maintains_localization_of''
+    some X'' -part_of-&gt; "transport and ''transports_or_maintains_localization_of''
+    some X"; "''transmembrane transporter activity'' and ''transports_or_maintains_localization_of''
+    some X -part_of-&gt; ''transmembrane transport'' and ''transports_or_maintains_localization_of''
+    some X"'
+- authors: GO ontology editors
+  id: GO_REF:0000063
+  year: 2013
+  layout: goref
+  title: Representation of processes regulated by other regulating processes in the
+    Gene Ontology
+  comments:
+  - We have created a standard template for classes describing processes regulated
+    by other regulating processes. The underlying equivalence axiom template is "R
+    and 'results_in' some P", where R is a biological process and P is a regulation
+    of biological process subclass.
+- authors: Christopher J. Mungall, Tanya Z. Berardini, David P. Hill
+  id: GO_REF:0000032
+  is_obsolete: true
+  url: http://wiki.geneontology.org/index.php/GAF_Inference
+  layout: goref
+  title: OBSOLETE Inference of Biological Process annotations from inter-ontology
+    links
+  comments:
+  - We use the GOBO library to propagate annotations from Molecular Function to Biological
+    Process. This results in both increased numbers of annotations, and increased
+    consistency between curators.
+  - Duplicate of GO_REF:0000108.
+- authors: Mouse Genome Informatics scientific curators
+  citation: PMID:11374909
+  external_accession:
+  - MGI:2152097
+  - J:72246
+  id: GO_REF:0000006
+  is_obsolete: true
+  year: 2001
+  layout: goref
+  title: OBSOLETE Gene Ontology annotation by the MGI curatorial staff, Mouse Locus
+    Catalog
+  comments:
+  - For annotations documented via this citation, curators used the information in
+    the Mouse Locus Catalog in MGI to assign GO terms. The GO terms were assigned
+    based on MLC textual descriptions of genes that could not be traced to the primary
+    literature. Details of this strategy can be found in Hill et al, Genomics (2001)
+    74:121-128.
+- authors: UniProt
+  id: GO_REF:0000117
+  year: 2021
+  layout: goref
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  comments:
+  - ARBA predicts Gene Ontology (GO) terms among other types of functional annotation
+    such as Protein Description (DE), Keywords (KW), Enzyme Commission numbers (EC),
+    sucellular LOcation (LO), etc. For all annotation types, reviewed UniProtKB/Swiss-Prot
+    records having manual annotations as reference data are used to perform the machine
+    learning phase and generate prediction models. For GO terms, ARBA has an additional
+    feature to augment reference data using the relations between GO terms in the
+    GO graph. The data augmentation is based on adding more general annotations into
+    records containing manual GO terms, which will result in richer reference data.
+    The predicted GO terms are then propagated to all unreviewed UniProtKB/TrEMBL
+    proteins that meet the conditions of ARBA models. GO annotations using this technique
+    receive the evidence code Inferred from Electronic Annotation (IEA; ECO:0000501).
+    These annotations are updated regularly by UniProt and are available for download
+    on both the GO and GOA EBI ftp sites.
+- authors: GO ontology editors
+  id: GO_REF:0000087
+  year: 2013
+  layout: goref
+  title: Representation of protein localization and establishment of protein localization
+    as biological process in the Gene Ontology
+  comments:
+  - We have created a standard template for classes describing the protein localization
+    and establishment of protein localization to a cellular component as a biological
+    process. The underlying equivalence axiom templates are "GO:0008104 and 'has_target_end_location'
+    some C" (protein localization) and "GO:0045184 and 'has_target_end_location' some
+    C" (establishment of protein localization), where C is cellular component.
+- authors: Michelle Gwinn, TIGR curators
+  id: GO_REF:0000025
+  year: 2007
+  layout: goref
+  title: Operon structure as IGC evidence
+  comments:
+  - Genes in prokaryotic organisms are often arranged in operons. Genes in an operon
+    are all transcribed into one mRNA. Generally the genes in the operons code for
+    proteins that all have related functions. For example, they may be the steps in
+    a biochemical pathway, or they may be the subunits of a protein complex. Often
+    the genes in operons shared between organisms are syntenic; that is, the same
+    genes are in the same order in the operon in different species. When assessing
+    sequence-comparison-based evidence during the process of manual annotation of
+    a genome, it is often the case that some of the genes in the operon will have
+    strong sequence-based evidence while others will have weak evidence. If seen alone,
+    not in the presence of an operon, the weak evidence in question may not be sufficient
+    to make a functional annotation. However, in the presence of an operon in which
+    there is strong evidence for some of the genes, the very presence of the gene
+    in the operon is a strong indication that the gene shares in the process carried
+    out by the operon. If the putative function is one expected to exist for the process
+    in question and particularly if that function has been observed in the same operon
+    in another species, then the annotation should be made. This type of evidence
+    is inferred from the context of the gene in an operon, and therefore the evidence
+    code is IGC "inferred from genomic context."
+- authors: GO ontology editors
+  id: GO_REF:0000074
+  year: 2013
+  layout: goref
+  title: Representation of export of a chemical as biological process in the Gene
+    Ontology
+  comments:
+  - 'We have created a standard template for classes describing the export of a chemical
+    entity (ChEBI) as a biological process. The underlying equivalence axiom template
+    is "GO:0006810 and ''exports'' some X", where X is a chemical entity (CHEBI:24431).
+    The approach to combine GO and ChEBI has been described in the following publication:
+    PMID:23895341.'
+- authors: Ivan Erill, SEA-PHAGE biocurators
+  id: GO_REF:0000100
+  is_obsolete: true
+  year: 2014
+  layout: goref
+  title: OBSOLETE Gene Ontology annotation by SEA-PHAGE biocurators
+  comments:
+  - This GO reference describes the criteria used by biocurators of the SEA-PHAGE
+    consortium for the annotation of predicted gene products from newly sequenced
+    bacteriophage genomes in the SEA-PHAGE phagesdb.org and other databases and in
+    the GenBank records periodically released to NCBI for these genomes. In particular,
+    this GO reference describes the criteria used to assign evidence codes ISS, ISA,
+    ISO, ISM, IGC and ND. To assign ISS, ISA, ISO and ISM evidence codes, SEA-PHAGE
+    biocurators use a varied array of bioinformatics tools to establish homology and
+    conservation of sequence and structure functional determinants with proteins from
+    multiple organisms with published association to experimental GO terms and lacking
+    NOT qualifiers. These proteins are referenced in the WITH field of the annotation
+    using their xref database accession. The primary tools for homology search in
+    ISS, ISA, ISO and ISM assignments are BLASTP and HHpred, using a maximum e-value
+    of 10^-7 for BLASTP and a minimum probability of 0.9 for HHpred, and manual inspection
+    of alignments in both cases. For ISS and ISA assignments, BLASTP alignments are
+    required to have at least 75% coverage and 30% identity. For ISO assignments,
+    orthology is further validated using reciprocal BLASTP with the identified hit.
+    For HHpred results, ISS or ISM annotations are made only if the source for the
+    original GO annotation explicitly defines a matched domain function, or if more
+    than half of the domains of the query protein are identified in the matching protein.
+    All ISS, ISA, ISO and ISM assignments entail the manual verification of the source
+    for the GO term in the matching protein sequence and critical curator assessment
+    of the likelihood of preservation of function, process or component in the context
+    of bacteriophage biology. IGC codes are assigned on the basis of suggestive evidence
+    for function based on synteny, as inferred from whole-genome comparative analyses
+    of multiple bacteriophage genomes using primarily the Phamerator software platform,
+    and with special emphasis on the bacteriophage virion structure and assembly genes.
+    When extensive review of published literature on putative homologs reveals no
+    experimental evidence of function, component or process for a particular gene
+    product, it is assigned an ND evidence code and annotated to the root term for
+    Cellular Component, Molecular Function and Biological Process. As part of the
+    review process for assignment of ISS, ISA, ISO, IGC and ISM evidence codes, SEA-PHAGE
+    curators are required to analyze the reference literature for identified matches
+    and shall perform GO annotations with appropriate evidence codes if these were
+    not available.
+- authors: UniProt-GOA
+  id: GO_REF:0000040
+  is_obsolete: true
+  year: 2011
+  layout: goref
+  title: OBSOLETE Gene Ontology annotation based on the automatic assignment of UniProtKB
+    Subcellular Location terms in UniProtKB/TrEMBL entries.
+  comments:
+  - Transitive assignment of GO terms based on the UniProtKB Subcellular Location
+    vocabulary. UniProtKB Subcellular Location is a controlled vocabulary used to
+    supply subcellular location information to UniProtKB entries in the SUBCELLULAR
+    LOCATION lines. Terms from this vocabulary are applied automatically to UniProtKB/TrEMBL
+    entries from the underlying nucleic acid databases and/or by the UniProt automatic
+    annotation program. Further information on the UniProtKB automatic annotation
+    program is available at http://www.uniprot.org/faq/45.<br>When a UniProtKB Subcellular
+    Location term describes a concept that is within the scope of the Gene Ontology,
+    it is investigated to determine whether it is appropriate to map the term to an
+    equivalent term in GO. The mapping between UniProtKB Subcellular Location terms
+    and GO terms is carried out manually. Definitions and hierarchies of the terms
+    in the two resources are compared and the mapping generated will reflect the most
+    correct correspondence. The translation table between GO terms and UniProtKB Subcellular
+    Location terms is maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/spsl2go.
+- authors: Michelle Gwinn, TIGR curators
+  id: GO_REF:0000011
+  year: 2003
+  layout: goref
+  title: Hidden Markov Models (TIGR)
+  comments:
+  - A Hidden Markov Model (HMM) is a statistical representation of patterns found
+    in a data set. When using HMMs with proteins, the HMM is a statistical model of
+    the patterns of the amino acids found in a multiple alignment of a set of proteins
+    called the "seed". Seed proteins are chosen based on sequence similarity to each
+    other. Seed members can be chosen with different levels of relationship to each
+    other. They can be members of a superfamily (ex. ABC transporter, ATP-binding
+    proteins), they can all share the same exact specific function (ex. biotin synthase)
+    or they could share another type of relationship of intermediate specificity (ex.
+    subfamily, domain). New proteins can be scored against the model generated from
+    the seed according to how closely the patterns of amino acids in the new proteins
+    match those in the seed. There are two scores assigned to the HMM which allow
+    annotators to judge how well any new protein scores to the model. Proteins scoring
+    above the "trusted cutoff" score can be assumed to be part of the group defined
+    by the seed. Proteins scoring below the "noise cutoff" score can be assumed to
+    NOT be a part of the group. Proteins scoring between the trusted and noise cutoffs
+    may be part of the group but may not. One of the important features of HMMs is
+    that they are built from a multiple alignment of protein sequences, not a pairwise
+    alignment. This is significant, since shared similarity between many proteins
+    is much more likely to indicate shared functional relationship than sequence similarity
+    between just two proteins. The usefulness of an HMM is directly related to the
+    amount of care that is taken in chosing the seed members, building a good multiple
+    alignment of the seed members, assessing the level of specificity of the model,
+    and choosing the cutoff scores correctly. In order to properly assess what functional
+    relevance an above-trusted scoring HMM match has to a query, one must carefully
+    determine what the functional scope of the HMM is. If the HMM models proteins
+    that all share the same function then it is likely possible to assign a specific
+    function to high-scoring match proteins based on the HMM. If the HMM models proteins
+    that have a wide variety of functions, then it will not be possible to assign
+    a specific function to the query based on the HMM match, however, depending on
+    the nature of the HMM in question, it may be possible to assign a more general
+    (family or subfamily level) function. In order to determine the functional scope
+    of an HMM, one must carefully read the documentation associated with the HMM.
+    The annotator must also consider whether the function attributed to the proteins
+    in the HMM makes sense for the query based on what is known about the organism
+    in which the query protein resides and in light of any other information that
+    might be available about the query protein. After carefully considering all of
+    these issues the annotator makes an annotation.
+- authors: GO curators
+  id: GO_REF:0000001
+  year: 1998
+  layout: goref
+  title: GO Consortium unpublished data
+  comments:
+  - No abstract available.
+  - This reference will normally be replaced upon publication of the data supporting
+    the annotation. Formerly GOC:unpublished.
+- authors: PomBase curators
+  external_accession:
+  - FB:FBrf0231277
+  id: GO_REF:0000050
+  year: 2012
+  layout: goref
+  title: Manual transfer of GO annotation data to genes by curator judgment of sequence
+    model
+  comments:
+  - Transitive assignment of GO terms to a gene based on a curator's judgment of its
+    match to a sequence model,such as a Pfam or InterPro entry, that has manually
+    curated GO annotations, mappings to GO terms, or a description from which GO terms
+    can be inferred. A statistical model of a sequence or group of sequences is used
+    to make a prediction about the function of a protein or RNA. Annotations are created
+    when a curator evaluates the results, using criteria that include excluding false
+    positives and ensuring that the annotation is accurate for all matches. Statistical
+    scores (such as e values and cutoff scores) and the functional specificity of
+    the model may also be (but are not always) considered. Annotations resulting from
+    the transfer of GO terms use the 'ISM' evidence code and include an accession
+    for the model from which the annotation was projected in the 'with' field (column
+    8).
+- authors: FlyBase
+  external_accession:
+  - FB:FBrf0159903
+  id: GO_REF:0000110
+  year: 2003
+  layout: goref
+  title: Gene Ontology annotation of Drosophila melanogaster nuclear genes encoding
+    proteins targeted to the mitochondrion.
+  comments:
+  - Gene Ontology annotation of Drosophila melanogaster nuclear genes encoding proteins
+    targeted to the mitochondrion based on analysis by MitoDrome (http://mitodrome.ba.itb.cnr.it/)
+    by comparison of human mitochondrial proteins available in SWISSPROT vs. the Drosophila
+    genome, ESTs and cDNA sequences available in the FlyBase database (PMID:12520013).
+- authors: GO ontology editors
+  id: GO_REF:0000064
+  year: 2013
+  layout: goref
+  title: Representation of cell components as part of other cell components in the
+    Gene Ontology
+  comments:
+  - We have created a standard template for classes describing cell components as
+    part of other cell components. The underlying equivalence axiom template is "P
+    and 'part_of' some W", where P and W are cell components.
+- authors: Ensembl, GRAMENE, GOA curators
+  id: GO_REF:0000035
+  year: 2011
+  layout: goref
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    plant orthologs using Ensembl Compara
+  comments:
+  - GO terms from a source species are projected onto one or more target species based
+    on gene orthology obtained from the Ensembl Compara system. One to one, one to
+    many and many to many orthologies are used but annotations are only projected
+    between orthologs that have at least a 40% peptide identity to each other. Only
+    GO annotations with an evidence type of IDA, IEP, IGI, IMP or IPI are projected,
+    no annotations with a 'NOT' qualifier are projected and annotations to the GO:0005515
+    protein binding term are not projected. Projected GO annotations using this technique
+    will receive the evidence code Inferred from Electronic Annotation (IEA). The
+    model organism database identifier of the annotation source will be indicated
+    in the 'With' column of the GOA association file.
+  - Duplicate of GO_REF:0000107.
+- authors: FlyBase
+  id: GO_REF:0000097
+  year: 2014
+  layout: goref
+  title: Gene Ontology annotation based on personal communication to FlyBase
+  comments:
+  - FlyBase occasionally makes GO annotations based on information that has been sent
+    to us directly by researchers as a personal communication to FlyBase. In each
+    case, the full details of the communication including any associated data and
+    analyses are recorded in a FlyBase publication (FBrf) available from our website
+    (http://flybase.org).
+- authors: GO Curators
+  external_accession:
+  - ECO:0000307
+  - AspGD_REF:ASPL0000111607
+  - CGD_REF:CAL0125086
+  - dictyBase_REF:2
+  - dictyBase_REF:9851
+  - FB:FBrf0159398
+  - MGI:MGI:2156816
+  - RGD:1598407
+  - SGD_REF:S000069584
+  - TAIR:Communication:1345790
+  - ZFIN:ZDB-PUB-031118-1
+  - GO_REF:nd
+  id: GO_REF:0000015
+  year: 2002
+  layout: goref
+  title: Use of the ND evidence code for Gene Ontology (GO) terms.
+  comments:
+  - Direct annotations to any of the three root terms 'molecular function; GO:0003674',
+    'biological process; GO:0008150' or 'cellular component; GO:0005575' indicate
+    that curators have found no data supporting an annotation to a more specific term,
+    either in the literature and/or by sequence similarity for this gene or protein
+    as of the date of the annotation.
+- authors: UniProt curators
+  external_accession:
+  - ZFIN:ZDB-PUB-170525-1
+  id: GO_REF:0000104
+  year: 2015
+  layout: goref
+  title: Electronic Gene Ontology annotations created by transferring manual GO annotations
+    between related proteins based on shared sequence features.
+  comments:
+  - 'GO terms are manually assigned to each rule in UniRule. These rules are prepared
+    manually by UniProt curators based on the annotations present in reviewed UniProtKB/Swiss-Prot
+    records that share sequence features, sequence similarity and taxonomy. The assigned
+    GO terms are then transferred to all unreviewed UniProtKB/TrEMBL proteins that
+    meet the conditions given in the UniRule rule. GO annotations using this technique
+    receive the evidence code Inferred from Electronic Annotation (IEA; ECO:0000501).
+    These annotations are updated regularly by UniProt and are available for download
+    on both the GO and GOA EBI ftp sites. To report an annotation error or inconsistency,
+    or for further information, please contact the UniProt Automated Annotation team
+    at automated_annotation@ebi.ac.uk. UniRule is a collaboration between the European
+    Bioinformatics Institute (EMBL-EBI), the Swiss Institute of Bioinformatics (SIB),
+    and the Protein Information Resource at Georgetown University (PIR). For further
+    information, please see UniProt: a hub for protein information Nucleic Acids Res.
+    2015, 43, D204, doi: 10.1093/nar/gku989 or www.uniprot.org.'
+- authors: UniProt-GOA
+  id: GO_REF:0000044
+  external_accession:
+  - TAIR:AnalysisReference:501756971
+  - TAIR:AnalysisReference:50175724
+  year: 2012
+  layout: goref
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt.
+  comments:
+  - "Transitive assignment of GO terms based on the UniProtKB/Swiss-Prot Subcellular\
+    \ Location vocabulary. UniProtKB Subcellular Location is a controlled vocabulary\
+    \ used to supply subcellular location information to UniProtKB entries in the\
+    \ SUBCELLULAR LOCATION lines. Terms from this vocabulary are annotated manually\
+    \ to UniProtKB/Swiss-Prot entries but are automatically assigned to UniProtKB/TrEMBL\
+    \ entries from the underlying nucleic acid databases and/or by the UniProt automatic\
+    \ annotation program.\nFurther information on these two different annotation methods\
+    \ is available https://www.uniprot.org/help/keywords. \nWhen a UniProtKB Subcellular\
+    \ Location term describes a concept that is within the scope of the Gene Ontology,\
+    \ a mapping is manually made to the corresponding GO term. The translation table\
+    \ between GO terms and UniProtKB Subcellular Location term is maintained by the\
+    \ EBI GOA team and available at http://www.geneontology.org/external2go/spsl2go."
+- authors: GO ontology editors
+  id: GO_REF:0000083
+  year: 2013
+  layout: goref
+  title: Representation of plant morphogenesis as biological process in the Gene Ontology
+  comments:
+  - We have created a standard template for classes describing the morphogenesis of
+    a plant structure as a biological process. The underlying equivalence axiom template
+    is "'anatomical structure morphogenesis' and 'results in morphogenesis of' some
+    P", where P is a plant anatomical entity (PO:0025131).
+- authors: GO ontology editors
+  id: GO_REF:0000070
+  year: 2013
+  layout: goref
+  title: Representation of transmembrane transporter activity as molecular function
+    in the Gene Ontology
+  comments:
+  - 'We have created a standard template for classes describing the transmembrane
+    transporter activity a chemical entity (ChEBI) as molecular function. This includes
+    variants for secondary active transmembrane transporter activity (GO:0015291),
+    uptake transmembrane transporter activity (GO:0015563), and ATPase activity, coupled
+    to transmembrane movement of substances (GO:0042626). The underlying equivalence
+    axiom template is "G and ''transports or maintains localization of'' some X",  where
+    the genus G is either GO:0022857 (transmembrane transporter activity), GO:0015291,
+    GO:0015563, or GO:0042626 depending on the variant. The variable X is a chemical
+    entity (CHEBI:24431). The approach to combine GO and ChEBI has been described
+    in the following publication: PMID:23895341.'
+- authors: Judith Blake (1, 2), William Bug (3), Rex Chisholm (1, 4), Jennifer Clark
+    (1, 5), Erika Feltrin (6), Jacqueline Finger (2), David Hill (1, 2), Midori Harris
+    (1, 5), Terry Hayamizu (2), Doug Howe (9), Maryanne Martone (7), Kathleen Millen
+    (8), Francis Sele (4) (1. The Gene Ontology Consortium, 2. Mouse Genome Informatics,
+    Bar Harbor, ME, 3. Drexel University, Philadelphia, PA, 4. Northwestern University,
+    Chicago, IL, 5. EMBL-EBI, Hinxton, Cambridgeshire, UK, 6. The University of Padua,
+    Padua, Italy, 7. The University of California at San Diego, San Diego, CA, 8.
+    The University of Chicago, Chicago, IL, 9. The Zebrafish Information Network,
+    University of Oregon, Eugene, OR)
+  id: GO_REF:0000021
+  year: 2006
+  layout: goref
+  title: Improving the representation of central nervous system development in the
+    biological process ontology
+  comments:
+  - 'Current genetic and molecular studies in many model organisms are aimed at understanding
+    formation and development of the nervous system. Up until this point, the GO has
+    had a very shallow representation of processes pertaining to the nervous system.
+    In June 2006, curators from MGI and ZFIN met with researchers studying central
+    nervous system development to improve the representation of these processes in
+    GO. In particular, emphasis was placed on three areas that are being addressed
+    actively in current research: forebrain development, hindbrain development and
+    neural tube development. This collaboration resulted in the addition of over 500
+    terms that reflect the development of the forebrain, the hindbrain, and the neural
+    tube from the perspective of biological process and anatomical structure.'
+- authors: Alexander D. Diehl, Alison Deckhut Augustine, Judith A. Blake, Lindsay
+    G. Cowell, Elizabeth S. Gold, Timothy A. Gondre-Lewis, Anna Maria Masci, Terrence
+    F. Meehan, Penelope A. Morel, Anastasia Nijnik, Bjoern Peters, Bali Pulendran,
+    Richard H. Scheuermann, Q. Alison Yao, Martin S. Zand, Christopher J. Mungall
+  id: GO_REF:0000031
+  url: http://www.bioontology.org/wiki/index.php/NIAID_Cell_Ontology_Workshop_May_2008
+  year: 2008
+  is_obsolete: true
+  layout: goref
+  title: OBSOLETE NIAID Cell Ontology Workshop
+  comments:
+  - The NIAID sponsored a Cell Ontology Workshop, May 13-14, 2008, in Bethesda, focusing
+    on improving representation of immune cell types in the Cell Ontology. The participants
+    in the workshop worked together to extend the current ontology in the area of
+    immune cell types and to provide the necessary information for the upcoming restructuring
+    of the Cell Ontology in single-inheritance form with genus-differentia definitions.
+- authors: GO ontology editors
+  id: GO_REF:0000060
+  year: 2013
+  layout: goref
+  title: Representation of processes involved in other process in the Gene Ontology
+  comments:
+  - We have created a standard template for classes describing processes involved
+    in other processes. The underlying equivalence axiom template is "P and 'part_of'
+    some W", where P and W are biological processes.
+- authors: GO ontology editors
+  id: GO_REF:0000093
+  year: 2014
+  layout: goref
+  title: Representation for the degradation to or via a chemical as biological process
+    in the Gene Ontology
+  comments:
+  - 'We have created a standard template for classes describing the degradation of
+    a chemical entity to or via an other chemical entity as biological processes.
+    The underlying equivalence axiom templates are "GO:0009056 and ''has input'' some
+    S and ''has output'' some T" (catabolism to) and "GO:0009056 and ''has input''
+    some S and ''has intermediate'' some I" (catabolism via), where S,T, and I are
+    chemical entities (CHEBI:24431). The approach to combine GO and ChEBI has been
+    described in the following publication: PMID:23895341.'
+- authors: LIFEdb
+  id: GO_REF:0000054
+  year: 2013
+  layout: goref
+  title: Gene Ontology annotation based on curation of intracellular localizations
+    of expressed fusion proteins in living cells.
+  comments:
+  - 'LIFEdb is a database that was created to manage the experimental data produced
+    by the German Cancer Research Institute (DKFZ) and its collaborators, from work
+    on cDNAs contained in the German cDNA Consortium collection. <br>A novel cloning
+    technology was used to rapidly generate N- and C-terminal green fluorescent protein
+    fusions of cDNAs to examine the intracellular localizations of expressed fusion
+    proteins in living cells. GO Cellular Component terms are manually assigned by
+    curators studying fluorescence microscope images of cells labelled with GFP-fused
+    cDNAs. Protein coding regions of novel full length cDNAs are tagged with the coding
+    sequence of the green fluorescent protein, the fusion proteins are then expressed
+    and analyzed for their subcellular localization. <br>Prior to February 2013, all
+    LIFEdb annotations were referenced by PMID: 11256614 (Simpson et al. 2000 EMBO
+    Rep. 1:287-292), a paper describing the protein subcellular localization pilot
+    study and methodology used by LIFEdb. However, it has been decided that these
+    annotations are more correctly described by a GO reference. <br>Resource URL:
+    http://www.dkfz.de/en/mga/Groups/LIFEdb-Database.html <br>Protein subcellular
+    localization images can be viewed on the LIFEdb website, http://www.dkfz.de/gpcf/lifedb.php'
+- authors: Birgit Meldal and Sandra Orchard (1). (1) European Bioinformatics Institute
+    (EBI), Hinxton, Cambridgeshire, United Kingdom
+  id: GO_REF:0000114
+  year: 2018
+  layout: goref
+  title: Manual transfer of experimentally-verified manual GO annotation data to homologous
+    complexes by curator judgment of sequence, composition and function similarity
+  comments:
+  - Method for transferring manual annotations to an entry based on a curator's judgment
+    of its similarity to a putative homolog that has annotations that are supported
+    with experimental evidence. Annotations are created when a curator judges that
+    the sequence, composition and function of a complex shows high similarity to another
+    complex that has annotation(s) supported by experimental evidence (and therefore
+    display one of the evidence codes ECO:0000353 [IPI] or ECO:0005543). Annotations
+    resulting from the transfer of GO terms display the ECO:0005610, ECO:0005544 or
+    ECO:0005546 evidence codes and include an accession for the complex from which
+    the annotation was projected in the 'with/from' field (column 8). This field MUST
+    contain a Complex Portal accession identifier. Putative homologs are chosen using
+    information combined from a variety of complementary sources. Potential homologs
+    are initially identified using sequence similarity search programs such as BLAST.
+    Homologous relationships are then verified manually using a combination of resources
+    including sequence analysis tools, phylogenetic and comparative genomics databases
+    such as Ensembl Compara, INPARANOID and OrthoMCL, as well as other specialised
+    databases such as species-specific collections (e.g. HGNC's HCOP). In all cases
+    curators check the alignments for each complex component and use their experience
+    to assess whether similarity is considered to be strong enough to infer that the
+    two proteins have a common function so that they can confidently project an annotation.
+    While there is no fixed cut-off point in percentage sequence similarity, generally
+    proteins which have greater than 70% identity that covers greater than 90% of
+    the length of both proteins are examined further. Whilst we expect subunit composition
+    to be conserved between closely related species, this is not an absolute rule
+    and orthologous complexes may differ if a subunit cannot be traced in one species
+    or is experimentally shown not to be present. When there is evidence of multiple
+    paralogs for a single species, multiple variants of the complex can be inferred.
+- authors: FlyBase
+  external_accession:
+  - FB:FBrf0145624
+  id: GO_REF:0000105
+  year: 2016
+  layout: goref
+  title: Gene Ontology annotation of transfer RNAs based on tRNAscan-SE analysis of
+    the Drosophila melanogaster genome (2002).
+  comments:
+  - 'Gene Ontology annotation based on predicted cytoplasmic tRNAs using tRNAscan-SE
+    analysis (doi: 10.1093/nar/25.5.0955) of the Drosophila melanogaster genome (2002).
+    Annotations have been reviewed by FlyBase (2015) and found to be consistent when
+    compared with the most recent tRNAscan-SE analysis of the genome (http://gtrnadb.ucsc.edu/genomes/eukaryota/Dmela6/).'
+- authors: UniProt-GOA
+  id: GO_REF:0000045
+  is_obsolete: true
+  year: 2012
+  layout: goref
+  title: OBSOLETE Gene Ontology annotation based on UniProtKB/TrEMBL entries keyword
+    mapping, accompanied by conservative changes to GO terms applied by UniProt.
+  comments:
+  - "Transitive assignments using UniProtKB/TrEMBL keywords. The UniProtKB keyword\
+    \ controlled vocabulary has been created and used by the UniProt Knowledgebase\
+    \ (UniProtKB) to supply 10 different categories of information to UniProtKB/TrEMBL\
+    \ entries entries. Further information on the UniProtKB keyword resource can be\
+    \ found at http://www.uniprot.org/docs/keywlist.<br>UniProtKB keywords are assigned\
+    \ to UniProtKB/UniProtKB entries by UniProt curators as part of the UniProtKB\
+    \ manual curation process. In contrast however, UniProtKB keywords are automatically\
+    \ assigned to UniProtKB/TrEMBL entries from the underlying nucleic acid databases\
+    \ and/or by the UniProt automatic annotation program.<br>Further information on\
+    \ the two different UniProt annotation methods is available at http://www.uniprot.org/faq/45\
+    \ and http://www.uniprot.org/program/automatic_annotation.<br>When a UniProtKB\
+    \ keyword describes a concept that is within the scope of the Gene Ontology, it\
+    \ is investigated to determine whether it is appropriate to map the keyword to\
+    \ an equivalent term in GO. The translation table between GO terms and UniProtKB\
+    \ keywords is maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/uniprotkb_kw2go.<br>Please\
+    \ note that the GO term in the annotation assigned with this GO reference has\
+    \ been changed from that originally applied by the UniProtKB keywords 2GO mapping.\
+    \ This change has been carried out by the UniProt group to ensure the GO annotation\
+    \ obeys the GO Consortium\u2019s ontology structure and taxonomic constraints.\
+    \ Further information on the rules used by UniProt to transform specific incorrect\
+    \ IEA annotations is available at http://www.ebi.ac.uk/QuickGO/AnnotationPostProcessing.html."
+  - Duplicate of GO_REF:0000004.
+- authors: GO ontology editors
+  id: GO_REF:0000082
+  is_obsolete: true
+  year: 2013
+  layout: goref
+  title: OBSOLETE Representation of plant maturation as biological process in the
+    Gene Ontology
+  comments:
+  - We have created a standard template for classes describing the maturation of a
+    plant structure as a biological process. The underlying equivalence axiom template
+    is "'developmental maturation' and 'results in developmental progression of' some
+    P", where P is a plant anatomical entity (PO:0025131).
+- authors: GO ontology editors
+  id: GO_REF:0000071
+  year: 2013
+  layout: goref
+  title: Representation of response to and cellular response to a chemical as biological
+    process in the Gene Ontology
+  comments:
+  - 'We have created a standard template for classes describing the response to and
+    cellular response to a chemical entity (ChEBI) as a biological process. The underlying
+    equivalence axiom templates are "GO:0050896 and ''has input'' some X" (response
+    to) and "GO:0070887 and ''has input'' some X" (cellular response to), where X
+    is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI has been
+    described in the following publication: PMID:23895341.'
+- authors: Swiss Institute of Bioinformatics (SIB) curators, GOA curators
+  id: GO_REF:0000020
+  year: 2006
+  layout: goref
+  title: Electronic Gene Ontology annotations created by transferring manual GO annotations
+    between orthologous microbial proteins
+  comments:
+  - 'GO terms are manually assigned to each HAMAP family rule. High-quality Automated
+    and Manual Annotation of microbial Proteins (HAMAP) family rules are a collection
+    of orthologous microbial protein families, from bacteria, archaea and plastids,
+    generated manually by expert curators. The assigned GO terms are then transferred
+    to all the proteins that belong to each HAMAP family. Only GO terms from the molecular
+    function and biological process ontologies are assigned. GO annotations using
+    this technique will receive the evidence code Inferred from Electronic Annotation
+    (IEA). These annotations are updated monthly by HAMAP and are available for download
+    on both GO and GOA EBI ftp sites. To report an annotation error or inconsistency,
+    or for further information, please contact the GO Consortium at gohelp@genome.stanford.edu
+    or submit a comment the SourceForge Annotation Issues tracker (http://sourceforge.net/projects/geneontology/).
+    HAMAP is a project based at the Swiss Institute of Bioinformatics (Gattiker et
+    al. 2003, Comp. Biol and Chem. 27: 49-58). For further information, please see
+    http://www.expasy.org/sprot/hamap/.'
+- authors: Daniel Haft, JCVI
+  id: GO_REF:0000030
+  year: 2008
+  is_obsolete: true
+  layout: goref
+  title: OBSOLETE Portable Annotation Rules
+  comments:
+  - The JCVI is developing a collection of mixed-evidence annotation rules, under
+    the working name BrainGrab/RuleBase (BGRB). A rule has two parts. The first is
+    the set of conditions that must be met for the rule to fire. The second is the
+    set actions to be taken for rules that have fired. BGRB rules are designed to
+    serve as proxies for the annotators that create them. They have very high fidelity
+    but may have low coverage. Types of evidence used in combination include HMM hits
+    and BLAST matches, hits to neighboring genes, pathway reconstruction reports from
+    the Genome Properties system, and species taxonomy. BLAST matches are described
+    by a number of separate parameters for raw score, percent sequence identity, and
+    coverage of total sequence length by the match region. These parameters are customized
+    for each protein family in order to achieve high fidelity in automated annotation
+    systems. The flexible syntax makes it possible to use existing protein family
+    classifiers, such as Pfam and TIGRFAMs HMMs, in new ways. It is especially useful
+    in assigning GO terms to proteins such as SelD (selenide, water dikinase) that
+    have different roles in different contexts.
+- authors: GO ontology editors
+  id: GO_REF:0000061
+  year: 2013
+  layout: goref
+  title: Representation of a molecular function involved in a biological process in
+    the Gene Ontology
+  comments:
+  - We have created a standard template for classes describing molecular function
+    involved in other biological processes. The underlying equivalence axiom template
+    is "P and 'part_of' some W", where P is a molecular function and W is a biological
+    processes.
+- authors: GO ontology editors
+  id: GO_REF:0000092
+  year: 2014
+  layout: goref
+  title: Representation for the biosynthesis from or via a chemical as biological
+    process in the Gene Ontology
+  comments:
+  - 'We have created a standard template for classes describing the biosynthesis of
+    a chemical entity from or via an other chemical entity as biological processes.
+    The underlying equivalence axiom templates are "GO:0009058 and ''has output''
+    some T and ''has input'' some F" (biosynthesis from) and "GO:0009058 and ''has
+    output'' some T and ''has intermediate'' some I" (biosynthesis via), where T,F,
+    and I are chemical entities (CHEBI:24431). The approach to combine GO and ChEBI
+    has been described in the following publication: PMID:23895341.'
+- authors: AgBase biocurators
+  id: GO_REF:0000055
+  year: 2013
+  is_obsolete: true
+  layout: goref
+  title: OBSOLETE Gene Ontology Cellular Component annotation based on cellular fractionation.
+  comments:
+  - Assignment of GO Cellular Component terms based on experimental evidence of cellular
+    localization from Differential Detergent Fractionation (DDF). Cellular proteins
+    are differentially fractionated and detected using mass spectrometry. Subcellular
+    localization is based upon identification of proteins in different fractions and
+    analysis of their predicted transmembrane domains. Proteins are assigned GO CC
+    based upon a manually reviewed DDF2GO mapping file.
+- authors: RNAcentral (1). (1) European Bioinformatics Institute (EMBL-EBI), Hinxton,
+    Cambridgeshire, United Kingdom
+  id: GO_REF:0000115
+  year: 2018
+  layout: goref
+  title: Automatic Gene Ontology annotation of non-coding RNA sequences through association
+    of Rfam records with GO terms
+  comments:
+  - "Rfam (http://rfam.org, PMID:29112718) is a database of non-coding RNA families\
+    \ which are manually\nannotated with GO terms by Rfam curators. RNAcentral (http://rnacentral.org,\
+    \ PMID:27794554) maintains\na comprehensive collection of non-coding RNA sequences\
+    \ that are regularly annotated with Rfam families\nusing the Infernal software\
+    \ (PMID:24008419). When a non-coding RNA sequence is matched to one or more Rfam\
+    \ families\nby sequence similarity, the GO terms associated with the Rfam family\
+    \ are transitively assigned to the non-coding RNA sequence.\nAnnotations resulting\
+    \ from the transfer of GO terms are assigned the ECO:0000256 evidence code\n(match\
+    \ to sequence model evidence used in automatic assertion) and include RNAcentral\
+    \ and Rfam accessions. \nThe annotations are available on the GOA and EMBL-EBI\
+    \ FTP sites. \nThe mapping between Rfam families and GO terms is available at\
+    \ http://www.geneontology.org/external2go/rfam2go, \nand the Infernal software\
+    \ can be downloaded at http://eddylab.org/infernal. To report an annotation error\
+    \ or inconsistency, \nor for further information, please visit the RNAcentral\
+    \ website at http://rnacentral.org."
+- alt_id:
+  - GO_REF:0000009
+  - GO_REF:0000013
+  authors: GOA curators
+  external_accession:
+  - MGI:1354194
+  - J:60000
+  - ZFIN:ZDB-PUB-020723-1
+  - SGD_REF:S000124038
+  id: GO_REF:0000004
+  year: 2000
+  layout: goref
+  title: Gene Ontology annotation based on UniProtKB keyword mapping.
+  comments:
+  - 'Transitive assignments using UniProtKB keywords. The UniProtKB keyword controlled
+    vocabulary has been created and used by the UniProt Knowledgebase (UniProtKB)
+    to supply 10 different categories of information to UniProtKB entries. Further
+    information on the UniProtKB keyword resource can be found at http://www.uniprot.org/docs/keywlist.
+    <br>Further information on the UniProt annotation methods is available at  https://www.uniprot.org/help/manual_curation
+    and https://www.uniprot.org/help/automatic_annotation.
 
-  <br>When a UniProtKB keyword describes a concept that is within the scope of the
-  Gene Ontology, it is investigated to determine whether it is appropriate to map
-  the keyword to an equivalent term in GO. The mapping between UniProtKB keywords
-  and GO terms is carried out manually. Definitions and hierarchies of the terms in
-  the two resources are compared and the mapping generated will reflect the most correct
-  correspondence. The translation table between GO terms and UniProtKB keywords is
-  maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/uniprotkb_kw2go.'
-- Formerly GOA:spkw.
----
-authors: GO ontology editors
-id: GO_REF:0000086
-year: 2013
-layout: goref
-title: Representation of cell differentiation as biological process in the Gene Ontology
-comments:
-- We have created a standard template for classes describing the differentiation process
-  for a cell type as a biological process. The underlying equivalence axiom template
-  is "GO:0030154 and 'results in acquisition of features of' some C", where C is a
-  native cell (CL:0000003).
----
-authors: AgBase, BHF-UCL, Parkinson's UK-UCL, dictyBase, HGNC, Roslin Institute, FlyBase
-  and UniProtKB curators.
-external_accession:
-- dictyBase_REF:9
-- J:73065
-- J:104715
-- FB:FBrf0202953
-- FB:FBrf0212479
-- FB:FBrf0232278
-- FB:FBrf0232279
-id: GO_REF:0000024
-url: http://www.ebi.ac.uk/GOA/ISS_method.html
-year: 2011
-layout: goref
-title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
-  by curator judgment of sequence similarity.
-comments:
-- 'Method for transferring manual annotations to an entry based on a curator''s judgment
-  of its similarity to a putative ortholog that has annotations that are supported
-  with experimental evidence. Annotations are created when a curator judges that the
-  sequence of a protein shows high similarity to another protein that has annotation(s)
-  supported by experimental evidence (and therefore display one of the evidence codes
-  EXP, IDA, IGI, IMP, IPI or IEP). Annotations resulting from the transfer of GO terms
-  display the ''ISS'' evidence code and include an accession for the protein from
-  which the annotation was projected in the ''with'' field (column 8). This field
-  can contain either a UniProtKB accession or an IPI (International Protein Index)
-  identifier. Only annotations with an experimental evidence code and which do not
-  have the ''NOT'' qualifier are transferred. Putative orthologs are chosen using
-  information combined from a variety of complementary sources. Potential orthologs
-  are initially identified using sequence similarity search programs such as BLAST.
-  Orthology relationships are then verified manually using a combination of resources
-  including sequence analysis tools, phylogenetic and comparative genomics databases
-  such as Ensembl Compara, INPARANOID and OrthoMCL, as well as other specialised databases
-  such as species-specific collections (e.g. HGNC''s HCOP). In all cases curators
-  check each alignment and use their experience to assess whether similarity is considered
-  to be strong enough to infer that the two proteins have a common function so that
-  they can confidently project an annotation. While there is no fixed cut-off point
-  in percentage sequence similarity, generally proteins which have greater than 30%
-  identity that covers greater than 80% of the length of both proteins are examined
-  further. For mammalian proteins this cut-off tends to be higher, with an average
-  of 80% identity over 90% of the length of both proteins. Strict orthologs are desirable
-  but not essential. In general, when there is evidence of multiple paralogs for a
-  single species, annotations using less specific GO terms are transferred to the
-  paralogs, however, annotations using more specific GO terms may be transferred to
-  the most similar paralog in each species, this decision is taken on a case by case
-  basis and may be influenced by statements by researchers in the field. Further detailed
-  information on this procedure, including how ISS annotations are made to protein
-  isoforms, can be found at: http://www.ebi.ac.uk/GOA/ISS_method.html.'
----
-authors: GO ontology editors
-id: GO_REF:0000075
-year: 2013
-layout: goref
-title: Representation of transport of a chemical into a cellular component as biological
-  process in the Gene Ontology
-comments:
-- 'We have created a standard template for classes describing the transport of a chemical
-  entity (ChEBI) into a cellular component as a biological process. The underlying
-  equivalence axiom template is "GO:0006810 and ''has_target_end_location'' some T
-  and ''imports'' some S", where T is a cellular component and S is a chemical entity
-  (CHEBI:24431). The approach to combine GO and ChEBI has been described in the following
-  publication: PMID:23895341.'
----
-authors: Sascha Steinbiss, GeneDB curators
-id: GO_REF:0000101
-year: 2015
-layout: goref
-title: Automated transfer of experimentally-verified GO annotation data to close orthologs
-comments:
-- This reference is used to describe functional annotations transferred from one or
-  more reference ("source") organisms to a newly annotated ("target") organism on
-  the basis of ortholog cluster membership. In detail, predicted (e.g. by AUGUSTUS,
-  see doi:10.1186/1471-2105-7-62) or transferred (e.g. via RATT, see doi:10:1093/nar/gkg1268)
-  gene models in the target genome are translated and processed by OrthoMCL 1.4 together
-  with reference protein sequences to produce clusters of gene products derived from
-  orthologous genes. For each cluster, GO terms are automatically transferred from
-  source products to the target gene products if they are experimentally verified
-  (IDA (ECO:0000314), IMP (ECO:0000315), IPI (ECO:0000353), IGI (ECO:0000316), (EXP
-  ECO:0000269). They are tagged with the ISO evidence code and the "with/from" is
-  populated with the source feature references (e.g. "GeneDB:LmjF.28.0960"). OrthoMCL
-  runs are done using the parameterization suggested in the OrthoMCL algorithm document
-  (blastall -F 'm S' -e 1e-5).
----
-authors: UniProt-GOA
-external_accession:
-- ZFIN:ZDB-PUB-130131-1
-id: GO_REF:0000041
-year: 2012
-layout: goref
-title: Gene Ontology annotation based on UniPathway vocabulary mapping.
-comments:
-- Transitive assignment of GO terms based on the UniPathway pathway vocabulary. UniPathway
-  is a manually curated resource of enzyme-catalyzed and spontaneous chemical reactions.
-  It provides a hierarchical representation of metabolic pathways. Descriptions of
-  the pathway(s) that a particular protein is involved in are included in UniProtKB
-  records.<br>UniPathway data are cross-linked to existing pathway resources such
-  as KEGG and MetaCyc. Further information on the UniPathway resource is available
-  at http://www.unipathway.org/obiwarehouse/unipathway.<br>When a UniPathway pathway
-  describes a concept that is within the scope of the Gene Ontology, it is investigated
-  to determine whether it is appropriate to map the term to an equivalent term in
-  GO. The mapping between UniPathway terms and GO terms is carried out manually. Definitions
-  and hierarchies of the terms in the two resources are compared and the mapping generated
-  will reflect the most correct correspondence. The translation table between GO terms
-  and UniPathway pathways is maintained by the UniPathway team and is available at
-  http://www.grenoble.prabi.fr/dev/obiwarehouse/download/unipathway/public/unipathway2go.tsv.
----
-authors: Mouse Genome Informatics scientific curators
-citation: PMID:11374909
-external_accession:
-- MGI:1347124
-- J:56000
-id: GO_REF:0000010
-is_obsolete: true
-year: 1999
-layout: goref
-title: OBSOLETE Gene Ontology annotation by the MGI curatorial staff, mouse gene nomenclature
-comments:
-- For annotations documented via this citation, curators designed queries based on
-  their knowledge of mouse gene nomenclature to group genes that shared common molecular
-  functions, biological processes or cellular components. GO annotations were assigned
-  to these genes in groups. Details of this strategy can be found in Hill et al.,
-  Genomics (2001) 74:121-128.
----
-authors: PomBase curators
-id: GO_REF:0000051
-year: 2012
-layout: goref
-title: S. pombe keyword mapping
-comments:
-- Active 2006-2012.
-- Keywords derived from manually curated primary annotation, e.g. gene product descriptions,
-  are mapped to GO terms. Annotations made by this method have the evidence code Non-traceable
-  Author Statement (NAS), and are filtered from the PomBase annotation files wherever
-  another annotation exists that is equally or more specific, and supported by experimental
-  or manually evaluated comparative evidence (such as ISS and its subtypes). Formerly
-  GOC:pombekw2GO.
----
-authors: TBD
-external_accession:
-- FB:FBrf0233689
-id: GO_REF:0000111
-year: 2016
-layout: goref
-title: Gene Ontology annotations Inferred by Curator (IC) using at least one Inferred
-  by Sequence Similarity (ISS) annotation to support the inference
-comments:
-- "The Gene Ontology Consortium uses the IC (Inferred by Curator; ECO:0000305) evidence\
-  \ code when assignment of a GO term cannot be supported by direct experimental or\
-  \ sequence-based evidence, but can, based on a curator\u2019s biological knowledge,\
-  \ be reasonably inferred from existing GO annotations to the same gene/gene product.\
-  \  Use of the IC evidence code with GO_REF:0000111 indicates that a curator inferred\
-  \ the GO term based on at least one supporting annotation with an 'Inferred from\
-  \ Sequence Similarity' (ISS; ECO:0000250) evidence code.  Note that additional supporting\
-  \ annotations may be experimentally evidenced. When using GO_REF:0000111, the 'with/from'\
-  \ field must contain all GO identifiers used as supporting annotations."
----
-authors: GO ontology editors
-id: GO_REF:0000065
-year: 2013
-layout: goref
-title: Representation of transport of a chemical entity as a biological process in
-  the Gene Ontology
-comments:
-- 'We have created a standard template for classes describing transport of a chemical
-  entity (ChEBI) as a biological process. The underlying equivalence axiom template
-  is "GO:0006810 and ''transports or maintains localization of'' some X", where X
-  is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI has been
-  described in the following publication: PMID:23895341.'
----
-authors: Brian K. Hall (Dalhousie University), Matthew Vickaryous (Ontario Veterinary
-  College, University of Guelph), David Blackburn, University of Kansas; Wasila Dahdul,
-  University of South Dakota and NESCent; Alexander Diehl, Mouse Genome Informatics
-  (MGI); Melissa Haendel, Oregon Health Sciences University; John G. Lundberg, Department
-  of Ichthyology, Academy of Natural Sciences, Philadelphia; Paula Mabee, Department
-  of Biology, University of South Dakota; Martin Ringwald, Mouse Genome Informatics
-  (MGI); Erik Segerdell, Oregon Health Sciences University; Ceri Van Slyke, Zebrafish
-  Information Network (ZFIN); Monte Westerfield, Zebrafish Information Network (ZFIN)
-  and Institute of Neuroscience, University of Oregon.
-id: GO_REF:0000034
-year: 2010
-layout: goref
-title: Phenoscape Skeletal Anatomy Jamboree
-comments:
-- Skeletal cell terms and relationships were added and revised at the Skeletal Anatomy
-  Jamboree held by Phenoscape (NSF grant BDI-0641025) and hosted by the National Evolutionary
-  Synthesis Center (NESCent), April 9-10, 2010.
----
-authors: Mouse Genome Informatics scientific curators
-external_accession:
-- J:164563
-- J:155856
-- RGD:1624291
-id: GO_REF:0000096
-year: 2014
-layout: goref
-title: Automated transfer of experimentally-verified manual GO annotation data to
-  close orthologs.
-comments:
-- 'Mouse Genome Database (MGD), The HUGO Gene Nomenclature Committee (HGNC), and Rat
-  Genome Database (RGD) have extensive procedures in place, overseen by expert curation,
-  to establish orthology relationships between their genes. The Experimentally based
-  annotations annotated by each group (IDA, IMP IPI, IGI, and EXP) are used to provide
-  annotations  to the respective mouse and rat orthologs, and given the ISO evidence
-  code and an entry in the inferred_from field to indicate the orthologous entity. '
----
-authors: GO ontology editors
-id: GO_REF:0000089
-year: 2013
-layout: goref
-title: Representation of single-organism and multi-organism biological processes in
-  the Gene Ontology
-comments:
-- We have created a standard template for classes describing the single-organism and
-  multi-organism biological processes. The underlying equivalence axiom templates
-  are "P and 'bearer_of' some PATO:0002487" (single-organism) and "P and 'bearer_of'
-  some PATO:0002486" (multi-organism), where P is a biological process.
----
-authors: FlyBase
-id: GO_REF:0000099
-is_obsolete: true
-year: 2014
-layout: goref
-title: OBSOLETE Gene Ontology annotation based on DNA/RNA sequence records
-comments:
-- Prior to 2005, FlyBase made GO annotations based on information in DNA/RNA sequence
-  records in GenBank/EMBL/DDBJ. We no longer add GO annotations based on sequence
-  records and gradually replacing these GO annotations as other sources of evidence
-  become available.
----
-authors: GO ontology editors
-id: GO_REF:0000088
-year: 2013
-layout: goref
-title: Representation of protein complex by molecular function in the Gene Ontology
-comments:
-- We have created a standard template for classes defining a protein complex by a
-  molecular function as a cellular component. The underlying equivalence axiom template
-  is "GO:0043234 and 'capable_of' some ?A", where A is a molecular function.
----
-authors: FlyBase
-id: GO_REF:0000098
-is_obsolete: true
-year: 2014
-layout: goref
-title: OBSOLETE Gene Ontology annotation based on research conference abstracts
-comments:
-- Prior to 2008, FlyBase made GO annotations based on information in abstracts for
-  research conferences, primarily the Annual Drosophila Research Conference and the
-  European Drosophila Research Conference. We no longer curate conference abstracts
-  and we are gradually replacing all abstract-based GO annotation with annotation
-  based on experimental data in primary research papers.
+    <br>When a UniProtKB keyword describes a concept that is within the scope of the
+    Gene Ontology, it is investigated to determine whether it is appropriate to map
+    the keyword to an equivalent term in GO. The mapping between UniProtKB keywords
+    and GO terms is carried out manually. Definitions and hierarchies of the terms
+    in the two resources are compared and the mapping generated will reflect the most
+    correct correspondence. The translation table between GO terms and UniProtKB keywords
+    is maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/uniprotkb_kw2go.'
+  - Formerly GOA:spkw.
+- authors: GO ontology editors
+  id: GO_REF:0000086
+  year: 2013
+  layout: goref
+  title: Representation of cell differentiation as biological process in the Gene
+    Ontology
+  comments:
+  - We have created a standard template for classes describing the differentiation
+    process for a cell type as a biological process. The underlying equivalence axiom
+    template is "GO:0030154 and 'results in acquisition of features of' some C", where
+    C is a native cell (CL:0000003).
+- authors: AgBase, BHF-UCL, Parkinson's UK-UCL, dictyBase, HGNC, Roslin Institute,
+    FlyBase and UniProtKB curators.
+  external_accession:
+  - dictyBase_REF:9
+  - J:73065
+  - J:104715
+  - FB:FBrf0202953
+  - FB:FBrf0212479
+  - FB:FBrf0232278
+  - FB:FBrf0232279
+  id: GO_REF:0000024
+  url: http://www.ebi.ac.uk/GOA/ISS_method.html
+  year: 2011
+  layout: goref
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity.
+  comments:
+  - 'Method for transferring manual annotations to an entry based on a curator''s
+    judgment of its similarity to a putative ortholog that has annotations that are
+    supported with experimental evidence. Annotations are created when a curator judges
+    that the sequence of a protein shows high similarity to another protein that has
+    annotation(s) supported by experimental evidence (and therefore display one of
+    the evidence codes EXP, IDA, IGI, IMP, IPI or IEP). Annotations resulting from
+    the transfer of GO terms display the ''ISS'' evidence code and include an accession
+    for the protein from which the annotation was projected in the ''with'' field
+    (column 8). This field can contain either a UniProtKB accession or an IPI (International
+    Protein Index) identifier. Only annotations with an experimental evidence code
+    and which do not have the ''NOT'' qualifier are transferred. Putative orthologs
+    are chosen using information combined from a variety of complementary sources.
+    Potential orthologs are initially identified using sequence similarity search
+    programs such as BLAST. Orthology relationships are then verified manually using
+    a combination of resources including sequence analysis tools, phylogenetic and
+    comparative genomics databases such as Ensembl Compara, INPARANOID and OrthoMCL,
+    as well as other specialised databases such as species-specific collections (e.g.
+    HGNC''s HCOP). In all cases curators check each alignment and use their experience
+    to assess whether similarity is considered to be strong enough to infer that the
+    two proteins have a common function so that they can confidently project an annotation.
+    While there is no fixed cut-off point in percentage sequence similarity, generally
+    proteins which have greater than 30% identity that covers greater than 80% of
+    the length of both proteins are examined further. For mammalian proteins this
+    cut-off tends to be higher, with an average of 80% identity over 90% of the length
+    of both proteins. Strict orthologs are desirable but not essential. In general,
+    when there is evidence of multiple paralogs for a single species, annotations
+    using less specific GO terms are transferred to the paralogs, however, annotations
+    using more specific GO terms may be transferred to the most similar paralog in
+    each species, this decision is taken on a case by case basis and may be influenced
+    by statements by researchers in the field. Further detailed information on this
+    procedure, including how ISS annotations are made to protein isoforms, can be
+    found at: http://www.ebi.ac.uk/GOA/ISS_method.html.'
+- authors: GO ontology editors
+  id: GO_REF:0000075
+  year: 2013
+  layout: goref
+  title: Representation of transport of a chemical into a cellular component as biological
+    process in the Gene Ontology
+  comments:
+  - 'We have created a standard template for classes describing the transport of a
+    chemical entity (ChEBI) into a cellular component as a biological process. The
+    underlying equivalence axiom template is "GO:0006810 and ''has_target_end_location''
+    some T and ''imports'' some S", where T is a cellular component and S is a chemical
+    entity (CHEBI:24431). The approach to combine GO and ChEBI has been described
+    in the following publication: PMID:23895341.'
+- authors: Sascha Steinbiss, GeneDB curators
+  id: GO_REF:0000101
+  year: 2015
+  layout: goref
+  title: Automated transfer of experimentally-verified GO annotation data to close
+    orthologs
+  comments:
+  - This reference is used to describe functional annotations transferred from one
+    or more reference ("source") organisms to a newly annotated ("target") organism
+    on the basis of ortholog cluster membership. In detail, predicted (e.g. by AUGUSTUS,
+    see doi:10.1186/1471-2105-7-62) or transferred (e.g. via RATT, see doi:10:1093/nar/gkg1268)
+    gene models in the target genome are translated and processed by OrthoMCL 1.4
+    together with reference protein sequences to produce clusters of gene products
+    derived from orthologous genes. For each cluster, GO terms are automatically transferred
+    from source products to the target gene products if they are experimentally verified
+    (IDA (ECO:0000314), IMP (ECO:0000315), IPI (ECO:0000353), IGI (ECO:0000316), (EXP
+    ECO:0000269). They are tagged with the ISO evidence code and the "with/from" is
+    populated with the source feature references (e.g. "GeneDB:LmjF.28.0960"). OrthoMCL
+    runs are done using the parameterization suggested in the OrthoMCL algorithm document
+    (blastall -F 'm S' -e 1e-5).
+- authors: UniProt-GOA
+  external_accession:
+  - ZFIN:ZDB-PUB-130131-1
+  id: GO_REF:0000041
+  year: 2012
+  layout: goref
+  title: Gene Ontology annotation based on UniPathway vocabulary mapping.
+  comments:
+  - Transitive assignment of GO terms based on the UniPathway pathway vocabulary.
+    UniPathway is a manually curated resource of enzyme-catalyzed and spontaneous
+    chemical reactions. It provides a hierarchical representation of metabolic pathways.
+    Descriptions of the pathway(s) that a particular protein is involved in are included
+    in UniProtKB records.<br>UniPathway data are cross-linked to existing pathway
+    resources such as KEGG and MetaCyc. Further information on the UniPathway resource
+    is available at http://www.unipathway.org/obiwarehouse/unipathway.<br>When a UniPathway
+    pathway describes a concept that is within the scope of the Gene Ontology, it
+    is investigated to determine whether it is appropriate to map the term to an equivalent
+    term in GO. The mapping between UniPathway terms and GO terms is carried out manually.
+    Definitions and hierarchies of the terms in the two resources are compared and
+    the mapping generated will reflect the most correct correspondence. The translation
+    table between GO terms and UniPathway pathways is maintained by the UniPathway
+    team and is available at http://www.grenoble.prabi.fr/dev/obiwarehouse/download/unipathway/public/unipathway2go.tsv.
+- authors: Mouse Genome Informatics scientific curators
+  citation: PMID:11374909
+  external_accession:
+  - MGI:1347124
+  - J:56000
+  id: GO_REF:0000010
+  is_obsolete: true
+  year: 1999
+  layout: goref
+  title: OBSOLETE Gene Ontology annotation by the MGI curatorial staff, mouse gene
+    nomenclature
+  comments:
+  - For annotations documented via this citation, curators designed queries based
+    on their knowledge of mouse gene nomenclature to group genes that shared common
+    molecular functions, biological processes or cellular components. GO annotations
+    were assigned to these genes in groups. Details of this strategy can be found
+    in Hill et al., Genomics (2001) 74:121-128.
+- authors: PomBase curators
+  id: GO_REF:0000051
+  year: 2012
+  layout: goref
+  title: S. pombe keyword mapping
+  comments:
+  - Active 2006-2012.
+  - Keywords derived from manually curated primary annotation, e.g. gene product descriptions,
+    are mapped to GO terms. Annotations made by this method have the evidence code
+    Non-traceable Author Statement (NAS), and are filtered from the PomBase annotation
+    files wherever another annotation exists that is equally or more specific, and
+    supported by experimental or manually evaluated comparative evidence (such as
+    ISS and its subtypes). Formerly GOC:pombekw2GO.
+- authors: TBD
+  external_accession:
+  - FB:FBrf0233689
+  id: GO_REF:0000111
+  year: 2016
+  layout: goref
+  title: Gene Ontology annotations Inferred by Curator (IC) using at least one Inferred
+    by Sequence Similarity (ISS) annotation to support the inference
+  comments:
+  - "The Gene Ontology Consortium uses the IC (Inferred by Curator; ECO:0000305) evidence\
+    \ code when assignment of a GO term cannot be supported by direct experimental\
+    \ or sequence-based evidence, but can, based on a curator\u2019s biological knowledge,\
+    \ be reasonably inferred from existing GO annotations to the same gene/gene product.\
+    \  Use of the IC evidence code with GO_REF:0000111 indicates that a curator inferred\
+    \ the GO term based on at least one supporting annotation with an 'Inferred from\
+    \ Sequence Similarity' (ISS; ECO:0000250) evidence code.  Note that additional\
+    \ supporting annotations may be experimentally evidenced. When using GO_REF:0000111,\
+    \ the 'with/from' field must contain all GO identifiers used as supporting annotations."
+- authors: GO ontology editors
+  id: GO_REF:0000065
+  year: 2013
+  layout: goref
+  title: Representation of transport of a chemical entity as a biological process
+    in the Gene Ontology
+  comments:
+  - 'We have created a standard template for classes describing transport of a chemical
+    entity (ChEBI) as a biological process. The underlying equivalence axiom template
+    is "GO:0006810 and ''transports or maintains localization of'' some X", where
+    X is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI has
+    been described in the following publication: PMID:23895341.'
+- authors: Brian K. Hall (Dalhousie University), Matthew Vickaryous (Ontario Veterinary
+    College, University of Guelph), David Blackburn, University of Kansas; Wasila
+    Dahdul, University of South Dakota and NESCent; Alexander Diehl, Mouse Genome
+    Informatics (MGI); Melissa Haendel, Oregon Health Sciences University; John G.
+    Lundberg, Department of Ichthyology, Academy of Natural Sciences, Philadelphia;
+    Paula Mabee, Department of Biology, University of South Dakota; Martin Ringwald,
+    Mouse Genome Informatics (MGI); Erik Segerdell, Oregon Health Sciences University;
+    Ceri Van Slyke, Zebrafish Information Network (ZFIN); Monte Westerfield, Zebrafish
+    Information Network (ZFIN) and Institute of Neuroscience, University of Oregon.
+  id: GO_REF:0000034
+  year: 2010
+  layout: goref
+  title: Phenoscape Skeletal Anatomy Jamboree
+  comments:
+  - Skeletal cell terms and relationships were added and revised at the Skeletal Anatomy
+    Jamboree held by Phenoscape (NSF grant BDI-0641025) and hosted by the National
+    Evolutionary Synthesis Center (NESCent), April 9-10, 2010.
+- authors: Mouse Genome Informatics scientific curators
+  external_accession:
+  - J:164563
+  - J:155856
+  - RGD:1624291
+  id: GO_REF:0000096
+  year: 2014
+  layout: goref
+  title: Automated transfer of experimentally-verified manual GO annotation data to
+    close orthologs.
+  comments:
+  - 'Mouse Genome Database (MGD), The HUGO Gene Nomenclature Committee (HGNC), and
+    Rat Genome Database (RGD) have extensive procedures in place, overseen by expert
+    curation, to establish orthology relationships between their genes. The Experimentally
+    based annotations annotated by each group (IDA, IMP IPI, IGI, and EXP) are used
+    to provide annotations  to the respective mouse and rat orthologs, and given the
+    ISO evidence code and an entry in the inferred_from field to indicate the orthologous
+    entity. '
+- authors: GO ontology editors
+  id: GO_REF:0000089
+  year: 2013
+  layout: goref
+  title: Representation of single-organism and multi-organism biological processes
+    in the Gene Ontology
+  comments:
+  - We have created a standard template for classes describing the single-organism
+    and multi-organism biological processes. The underlying equivalence axiom templates
+    are "P and 'bearer_of' some PATO:0002487" (single-organism) and "P and 'bearer_of'
+    some PATO:0002486" (multi-organism), where P is a biological process.
+- authors: FlyBase
+  id: GO_REF:0000099
+  is_obsolete: true
+  year: 2014
+  layout: goref
+  title: OBSOLETE Gene Ontology annotation based on DNA/RNA sequence records
+  comments:
+  - Prior to 2005, FlyBase made GO annotations based on information in DNA/RNA sequence
+    records in GenBank/EMBL/DDBJ. We no longer add GO annotations based on sequence
+    records and gradually replacing these GO annotations as other sources of evidence
+    become available.
+- authors: GO ontology editors
+  id: GO_REF:0000088
+  year: 2013
+  layout: goref
+  title: Representation of protein complex by molecular function in the Gene Ontology
+  comments:
+  - We have created a standard template for classes defining a protein complex by
+    a molecular function as a cellular component. The underlying equivalence axiom
+    template is "GO:0043234 and 'capable_of' some ?A", where A is a molecular function.
+- authors: FlyBase
+  id: GO_REF:0000098
+  is_obsolete: true
+  year: 2014
+  layout: goref
+  title: OBSOLETE Gene Ontology annotation based on research conference abstracts
+  comments:
+  - Prior to 2008, FlyBase made GO annotations based on information in abstracts for
+    research conferences, primarily the Annual Drosophila Research Conference and
+    the European Drosophila Research Conference. We no longer curate conference abstracts
+    and we are gradually replacing all abstract-based GO annotation with annotation
+    based on experimental data in primary research papers.

--- a/metadata/gorefs/gorefs.yaml
+++ b/metadata/gorefs/gorefs.yaml
@@ -1,0 +1,2045 @@
+authors: GOA-UniProt curators
+id: GO_REF:0000029
+is_obsolete: true
+year: 2007
+layout: goref
+title: OBSOLETE Gene Ontology annotation based on information extracted from curated
+  UniProtKB entries
+comments:
+- Active 2001-2007.
+- Method by which GO terms were manually assigned to UniProt KnowledgeBase accessions,
+  using either a NAS or TAS evidence code, by applying information extracted from
+  the corresponding publicly-available, manually curated UniProtKB entry. Such GO
+  annotations were submitted by the GOA-UniProt group from 2001, but this annotation
+  practice was discontinued in 2007.
+---
+authors: GO ontology editors
+id: GO_REF:0000078
+year: 2013
+layout: goref
+title: Representation for the transport or vesicle-mediated transport of a chemical
+  from and/or to a cell component as biological process in the Gene Ontology
+comments:
+- 'We have created a standard template for classes describing the transport or vesicle-mediated
+  transport of a chemical entity (ChEBI) from and/or to a cellular component as a
+  biological process. The underlying equivalence axiom templates are "GO:0006810 and
+  ''transports or maintains localization of'' some X [ and ''has_target_start_location''
+  some F] [ and ''has_target_end_location'' some T]" (transport) and "GO:0016192 and
+  ''transports or maintains localization of'' some X [ and ''has_target_start_location''
+  some F] [ and ''has_target_end_location'' some T]" (vesicle-mediated transport),
+  where F and T are cellular components and X is a chemical entity (CHEBI:24431).
+  The approach to combine GO and ChEBI has been described in the following publication:
+  PMID:23895341.'
+---
+authors: GO ontology editors
+id: GO_REF:0000068
+year: 2013
+layout: goref
+title: Representation of metabolic triad (metabolism, catabolism, biosynthesis) as
+  biological process in the Gene Ontology
+comments:
+- 'We have created a standard template for classes each describing the metabolism,
+  catabolism, or biosynthesis of a chemical entity (ChEBI) as a process. The underlying
+  equivalence axiom templates are "GO:0008152 and ''has participant'' some X" (metabolism),
+  "GO:0009056 and ''has input'' some X" (catabolism), "GO:0009058 and ''has output''
+  some X" and (biosynthesis),  where X is a chemical entity (CHEBI:24431). The approach
+  to combine GO and ChEBI has been described in the following publication: PMID:23895341.'
+---
+authors: UniProt-GOA
+id: GO_REF:0000039
+year: 2011
+layout: goref
+title: OBSOLETE Gene Ontology annotation based on the manual assignment of UniProtKB
+  Subcellular Location terms in UniProtKB/Swiss-Prot entries.
+comments:
+- Transitive assignment of GO terms based on the UniProtKB Subcellular Location vocabulary.
+  UniProtKB Subcellular Location is a controlled vocabulary used to supply subcellular
+  location information to UniProtKB entries in the SUBCELLULAR LOCATION lines. Terms
+  from this vocabulary are annotated manually to UniProtKB/Swiss-Prot entries. Further
+  information on the UniProtKB manual annotation method is available at http://www.uniprot.org/faq/45.<br>When
+  a UniProtKB Subcellular Location term describes a concept that is within the scope
+  of the Gene Ontology, it is investigated to determine whether it is appropriate
+  to map the term to an equivalent term in GO. The mapping between UniProtKB Subcellular
+  Location terms and GO terms is carried out manually. Definitions and hierarchies
+  of the terms in the two resources are compared and the mapping generated will reflect
+  the most correct correspondence. The translation table between GO terms and UniProtKB
+  Subcellular Location terms is maintained by the UniProt-GOA team and available at
+  http://www.geneontology.org/external2go/spsl2go.
+---
+authors: Ensembl curators, GOA curators
+id: GO_REF:0000019
+is_obsolete: true
+year: 2006
+layout: goref
+title: OBSOLETE Automatic transfer of experimentally verified manual GO annotation
+  data to orthologs using Ensembl Compara
+comments:
+- GO terms from a source species are projected on to one or more target species based
+  on gene orthology obtained from the Ensembl Compara system. Only one to one and
+  apparent one to one orthologies are used for a restricted range of species. Only
+  GO annotations with a manual experimental evidence type of IDA, IEP, IGI, IMP or
+  IPI are projected. Projected GO annotations using this technique will receive the
+  evidence code, inferred from electronic annotation, 'IEA'. The Ensembl protein identifier
+  of the annotation source is indicated in the 'With' column of the GOA association
+  file.
+---
+authors: GOA curators
+id: GO_REF:0000108
+year: 2016
+layout: goref
+title: Automatic assignment of GO terms using logical inference, based on on inter-ontology
+  links.
+comments:
+- GO terms are automatically assigned based on inter-ontology links to generate inferred
+  annotations. Annotations from Molecular Function to Biological Process can be propagated,
+  as well as between Biological Process and Cellular Component. Annotations that are
+  created using this inference method receive either the evidence code ECO:0000366
+  (evidence based on logical inference from automatic annotation used in automatic
+  assertion) or ECO:0000364 (evidence based on logical inference from manual annotation
+  used in automatic assertion), depending on whether the source annotation has a manual
+  or automatic evidence code. Both of these codes map up to the GO Inferred from Electronic
+  Annotation (IEA) evidence code.
+---
+authors: TIGR Arabidopsis annotation team
+external_accession:
+- TAIR:Communication:501714663
+id: GO_REF:0000048
+is_obsolete: true
+year: 2005
+layout: goref
+title: OBSOLETE TIGR's Eukaryotic Manual Gene Ontology Assignment Method
+comments:
+- This describes TIGR curators' interpretation of a combination of evidence. Our internal
+  software tools present us with a great deal of evidence based on domains, sequence
+  similarities, signal sequences, paralogous proteins, etc. The curator interprets
+  the body of evidence to make a decision about a GO assignment when an external reference
+  is not available. The curator places one or more accessions that informed the decision
+  in the "with" field.
+---
+authors: GO ontology editors
+id: GO_REF:0000058
+year: 2013
+layout: goref
+title: Representation of regulation in the Gene Ontology (biological process)
+comments:
+- We have created a standard template for the definition of classes for the regulation
+  of a biological process. This includes the definitions for positive and negative
+  regulation. The equivalence axiom templates are "GO:0065007 and 'regulates' some
+  X" (regulation), "GO:0065007 and 'negatively_regulates' some X" (negative regulation),
+  and "GO:0065007 and 'positively_regulates' some X" (positive regulation), where
+  X is a biological process.
+---
+authors: DictyBase curators
+external_accession:
+- dictyBase_REF:10158
+id: GO_REF:0000018
+is_obsolete: true
+year: 2005
+layout: goref
+title: OBSOLETE dictyBase 'Inferred from Electronic Annotation (BLAST method)'
+comments:
+- Gene Ontology (GO) annotations with the evidence code 'Inferred from Electronic
+  Annotation' (IEA) are assigned automatically to gene products in dictyBase. All
+  Dictyostelium protein sequences are analyzed by BLAST against GO gene association
+  sequence files, identifying proteins in other organisms that align with Dictyostelium
+  proteins with an E value less than or equal to e-50. GO annotations that have been
+  manually assigned to these proteins from other species are then imported and attached
+  to the corresponding gene product in dictyBase. The proteins from which the annotations
+  are derived are displayed in the 'Evidence' column on the Gene Ontology evidence
+  and references page.
+---
+authors: TrypTag
+id: GO_REF:0000109
+year: 2016
+layout: goref
+title: Gene Ontology annotation based on curation of genome-wide subcellular localisation
+  of proteins using fluorescent protein tagging in Trypanosoma brucei
+comments:
+- 'Trypanosomes are exquisitely structured cells in which protein localisation can
+  be extremely informative for likely function. TrypTag is a project using expression
+  of N- and C-terminal mNeonGreen fusion proteins from the endogenous loci to determine
+  the subcellular localisation of every gene in the Trypanosoma brucei genome. GO
+  Cellular Component terms are manually assigned by curators studying fluorescence
+  microscope images of the resulting cells labelled with mNeonGreen fusion proteins.
+  As trypanosomes are a pathogenic basal eukaryote, this will indicate likely function
+  of both highly conserved eukaryote genes and parasite-specific genes. Resource URL:
+  http://www.tryptag.org Protein subcellular localisation images can be viewed on
+  the Tryptag website, e.g. http://www.tryptag.org?id=Tb927.8.1550'
+---
+authors: Ensembl Genomes
+id: GO_REF:0000049
+is_obsolete: true
+year: 2012
+layout: goref
+title: OBSOLETE Automatic transfer of experimentally verified manual GO annotation
+  data to fungal orthologs using Ensembl Compara
+comments:
+- GO terms from a source species are projected onto one or more target species based
+  on gene orthology obtained from the Ensembl Compara system. One to one, one to many
+  and many to many orthologies are used but annotations are only projected between
+  orthologs that have at least a 40% peptide identity to each other. Only GO annotations
+  with an evidence type of IDA, IEP, IGI, IMP or IPI are projected, no annotations
+  with a 'NOT' qualifier are projected and annotations to the GO:0005515 protein binding
+  term are not projected. Projected GO annotations using this technique will receive
+  the evidence code Inferred from Electronic Annotation (IEA). The model organism
+  database identifier of the annotation source will be indicated in the 'With' column
+  of the GOA association file.
+- Duplicate of GO_REF:0000107.
+---
+authors: GO ontology editors
+id: GO_REF:0000059
+year: 2013
+layout: goref
+title: Representation of regulation in the Gene Ontology (molecular function)
+comments:
+- We have created a standard template for the definition of classes for the regulation
+  of a molecular function. This includes the definitions for positive and negative
+  regulation. The equivalence axiom templates are "GO:0065007 and 'regulates' some
+  X" (regulation), "GO:0065007 and 'negatively_regulates' some X" (negative regulation),
+  and "GO:0065007 and 'positively_regulates' some X" (positive regulation), where
+  X is a molecular function.
+---
+authors: Mouse Genome Informatics scientific curators
+external_accession:
+- MGI:2154458
+- J:73065
+id: GO_REF:0000008
+year: 2001
+layout: goref
+title: Gene Ontology annotation by the MGI curatorial staff, curated orthology
+comments:
+- The sequence conservation that permits the establishment of orthology between mouse
+  and rat or mouse and human genes is a strong predictor of the conservation of function
+  for the gene product across these species. Therefore, in instances where a mouse
+  gene product has not been functionally characterized, but its human or rat orthologs
+  have, Mouse Genome Informatics (MGI) curators append the GO terms associated with
+  the orthologous gene(s) to the mouse gene. Only those GO terms assigned by experimental
+  determination to the ortholog of the mouse gene will be adopted by MGI. GO terms
+  that are assigned to the ortholog of the mouse gene computationally (i.e. IEA),
+  will not be transferred to the mouse ortholog. The evidence code represented by
+  this citation is Inferred by Sequence Orthology (ISO).
+---
+authors: PAMGO_MGG curators
+id: GO_REF:0000028
+year: 2008
+layout: goref
+title: Criteria for IDA, IEP, ISS, IGC, RCA, and IEA assignment in PAMGO_MGG
+comments:
+- This GO reference describes the criteria used in assigning the evidence codes of
+  IDA (ECO:0000314), IEP (ECO:0000270), ISS (ECO:0000250), IGC (ECO_0000317), RCA
+  (ECO:0000245) and IEA (ECO:0000501) to annotate gene products from PAMGO_MGG. Standard
+  BLASTP from NCBI was used (http://www.ncbi.nih.gov/blast) to iteratively search
+  reciprocal best hits and thus identify orthologs between predicted proteins of Magnaporthe
+  grisea and GO proteins from multiple organisms with published association to GO
+  terms. The alignments were manually reviewed for those hits with e-value equal to
+  zero and with 80% or better coverage of both query and subject sequences, and for
+  those hits with e&lt;=10^-20, pid &gt;=35 and sequence coverage &gt;=80%. Furthermore,
+  experimental or reviewed data from literature and other sources were incorporated
+  into the GO annotation. IDA was assigned to an annotation if normal function of
+  its gene was determined through transfections into a cell line and overexpression.
+  IEP was assigned to an annotation if according to microarray experiments, its gene
+  was upregulated in a biological process and the fold change was equal to or bigger
+  than 10, or if according to Massively Parallel Signature Sequencing (MPSS), its
+  gene was upregulated only in a certain biological process and the fold change was
+  equal to or bigger than 10. ISS was assigned to an annotation if the entry at the
+  With_column was experimentally characterized and the pairwise alignments were manually
+  reviewed. IGC was assigned to an annotation if it based on comparison and analysis
+  of gene location and structure, clustering of genes, and phylogenetic reconstruction
+  of these genes. RCA was assigned to an annotation if it based on integrated computational
+  analysis of whole genome microarray data, and matches to InterPro, pfam, and COG
+  etc. IEA was assigned to an annotation if its function assignment based on computational
+  work, and no manual review was done.
+---
+authors: GO ontology editors
+id: GO_REF:0000079
+year: 2013
+layout: goref
+title: Representation of assembly or disassembly of a cell component as biological
+  process in the Gene Ontology
+comments:
+- We have created a standard template for classes describing the assembly or disassembly
+  of a cellular component as a biological process. The underlying equivalence axiom
+  templates are "GO:0022607 and 'results_in_assembly_of' some C" (assembly) and "GO:0022411
+  and 'results_in_disassembly_of' some C" (disassembly), where C is a cellular component.
+---
+authors: GO ontology editors
+id: GO_REF:0000069
+year: 2013
+layout: goref
+title: Representation of transmembrane transport of a chemical as biological process
+  in the Gene Ontology
+comments:
+- 'We have created a standard template for classes describing the transmembrane transport
+  of a chemical entity (ChEBI) as a biological process. The underlying equivalence
+  axiom template is "GO:0055085 and ''transports or maintains localization of'' some
+  X", where X is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI
+  has been described in the following publication: PMID:23895341.'
+---
+authors: UniProt-GOA
+id: GO_REF:0000038
+is_obsolete: true
+year: 2011
+layout: goref
+title: OBSOLETE Gene Ontology annotation based on automatic assignment of UniProtKB
+  keywords in UniProtKB/TrEMBL entries.
+comments:
+- 'Transitive assignments using UniProtKB keywords. The UniProtKB keyword controlled
+  vocabulary has been created and used by the UniProt Knowledgebase (UniProtKB) to
+  supply 10 different categories of information to UniProtKB entries. Further information
+  on the UniProtKB keyword resource can be found at http://www.uniprot.org/docs/keywlist.
+  UniProtKB keywords are automatically assigned to UniProtKB/TrEMBL entries from the
+  underlying nucleic acid databases and/or by the UniProt automatic annotation program.
+  Further information on the prediction systems applied by UniProt is available here:
+  http://www.uniprot.org/program/automatic_annotation.<br>When a UniProtKB keyword
+  describes a concept that is within the scope of the Gene Ontology, it is investigated
+  to determine whether it is appropriate to map the keyword to an equivalent term
+  in GO. The mapping between UniProtKB keywords and GO terms is carried out manually.
+  Definitions and hierarchies of the terms in the two resources are compared and the
+  mapping generated will reflect the most correct correspondence. The translation
+  table between GO terms and UniProtKB keywords is maintained by the UniProt-GOA team
+  and available at http://www.geneontology.org/external2go/uniprotkb_kw2go.'
+- Duplicate of GO_REF:0000043.
+---
+authors: FlyBase
+id: GO_REF:0000106
+is_obsolete: true
+year: 2016
+layout: goref
+title: OBSOLETE Gene Ontology annotation based on protein sequence records.
+comments:
+- Between 1986 and 2005 GO annotations were made by FlyBase curators based on information
+  in UniProtKB/Swiss-Prot protein sequence records. We no longer add GO annotations
+  based on sequence records and are gradually replacing these GO annotations as other
+  sources of evidence become available.
+---
+authors: UniProt-GOA
+id: GO_REF:0000046
+is_obsolete: true
+year: 2012
+layout: goref
+title: OBSOLETE Gene Ontology annotation based on UniProtKB/TrEMBL Subcellular Location
+  vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt.
+comments:
+- "Transitive assignment of GO terms based on the UniProtKB/TrEMBL Subcellular Location\
+  \ vocabulary. UniProtKB Subcellular Location is a controlled vocabulary used to\
+  \ supply subcellular location information to UniProtKB entries in the SUBCELLULAR\
+  \ LOCATION lines. Terms from this vocabulary are annotated manually to UniProtKB/Swiss-Prot\
+  \ entries but are automatically assigned to UniProtKB/TrEMBL entries from the underlying\
+  \ nucleic acid databases and/or by the UniProt automatic annotation program.<br>Further\
+  \ information on these two different annotation methods is available at http://www.uniprot.org/faq/45\
+  \ and http://www.uniprot.org/program/automatic_annotation.<br> The translation table\
+  \ between GO terms and UniProtKB Subcellular Location term is maintained by the\
+  \ UniProt-GOA team and available at http://www.geneontology.org/external2go/spsl2go.<br>Please\
+  \ note that the GO term in the annotation assigned with this GO reference has been\
+  \ changed from that originally applied by the UniProtKB Subcellular Location2GO\
+  \ mapping. This change has been carried out by the UniProt group to ensure the GO\
+  \ annotation obeys the GO Consortium\u2019s ontology structure and taxonomic constraints.\
+  \ Further information on the rules used by UniProt to transform specific incorrect\
+  \ IEA annotations is available at http://www.ebi.ac.uk/QuickGO/AnnotationPostProcessing.html."
+- Duplicate of GO_REF:0000023.
+---
+authors: GOA curators, UniProt curators
+external_accession:
+- SGD_REF:S000125578
+id: GO_REF:0000023
+is_obsolete: true
+year: 2007
+layout: goref
+title: OBSOLETE Gene Ontology annotation based on UniProtKB Subcellular Location vocabulary
+  mapping.
+comments:
+- Transitive assignment of GO terms based on the UniProtKB Subcellular Location vocabulary.
+  UniProtKB Subcellular Location is a controlled vocabulary used to supply subcellular
+  location information to UniProtKB entries in the SUBCELLULAR LOCATION lines. Terms
+  from this vocabulary are annotated manually to UniProtKB/Swiss-Prot entries but  are
+  automatically assigned to UniProtKB/TrEMBL entries from the underlying nucleic acid
+  databases and/or by the UniProt automatic annotation program.<br>Further information
+  on these two different annotation methods is available at http://www.uniprot.org/faq/45
+  and http://www.uniprot.org/program/automatic_annotation .<br>When a UniProtKB Subcellular
+  Location term describes a concept that is within the scope of the Gene Ontology,
+  it is investigated to determine whether it is appropriate to map the term to an
+  equivalent term in GO. The mapping between UniProtKB Subcellular Location terms
+  and GO terms is carried out manually. Definitions and hierarchies of the terms in
+  the two resources are compared and the mapping generated will reflect the most correct
+  correspondence. The translation table between GO terms and UniProtKB Subcellular
+  Location term is maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/spsl2go
+  .
+- Duplicate of GO_REF:0000039.
+---
+authors: GO ontology editors
+id: GO_REF:0000072
+year: 2013
+layout: goref
+title: Representation of chemical homeostasis and cellular chemical homeostasisl as
+  biological process in the Gene Ontology
+comments:
+- 'We have created a standard template for classes describing the homeostasis and
+  cellular homeostasis for a chemical entity (ChEBI) as a biological process. The
+  underlying equivalence axiom templates are "GO:0048878 and ''regulates level of''
+  some X" (homeostasis) and "GO:0055082 and ''regulates level of'' some X" (cellular
+  homeostasis), where X is a chemical entity (CHEBI:24431). The approach to combine
+  GO and ChEBI has been described in the following publication: PMID:23895341.'
+---
+authors: GO ontology editors
+id: GO_REF:0000081
+year: 2013
+layout: goref
+title: Representation of plant formation as biological process in the Gene Ontology
+comments:
+- We have created a standard template for classes describing the formation of a plant
+  structure as a biological process. The underlying equivalence axiom template is
+  "'anatomical structure formation involved in morphogenesis' and 'results in formation
+  of' some P", where P is a plant anatomical entity (PO:0025131).
+---
+authors: GO ontology editors
+id: GO_REF:0000091
+year: 2014
+layout: goref
+title: Representation of cell migration as biological processes in the Gene Ontology
+comments:
+- We have created a standard template for classes describing the cell migration process
+  for a cell type as a biological process. The underlying equivalence axiom template
+  is "'cell migration' and 'alters_location_of' some C", where C is a native cell
+  (CL:0000004).
+---
+authors: GO ontology editors
+id: GO_REF:0000062
+year: 2013
+layout: goref
+title: Representation of processes occurring in parts of the cell in the Gene Ontology
+comments:
+- We have created a standard template for classes describing processes occurring in
+  parts of the cell. The underlying equivalence axiom template is "P and 'occurs in'
+  some C", where P is a biological process and C is a cellular component.
+---
+authors: Pascale Gaudet, Michael Livstone, Paul Thomas, The Reference Genome Project
+external_accession:
+- SGD_REF:S000146947
+- TAIR:Communication:501741973
+- MGI:MGI:4459044
+- 'J:161428 '
+- ZFIN:ZDB-PUB-110330-1
+- FB:FBrf0232076
+id: GO_REF:0000033
+url: http://gocwiki.geneontology.org/index.php/PAINT
+year: 2010
+is_obsolete: true
+layout: goref
+title: OBSOLETE Annotation inferences using phylogenetic trees
+comments:
+- This GO_REF was originally used to support PAINT annotations. The SOP has changed,
+  and now phylogenetic annotations are supported using the identifier for the family
+  itself.
+- The goal of the GO Reference Genome Project, described in PMID 19578431, is to provide
+  accurate, complete and consistent GO annotations for all genes in twelve model organism
+  genomes.To this end, GO curators are annotating evolutionary trees from the PANTHER
+  database with GO terms describing molecular function, biological process and cellular
+  component. GO terms based on experimental data from the scientific literature are
+  used to annotate ancestral genes in the phylogenetic tree by sequence similarity
+  (ISS), and unannotated descendants of these ancestral genes are inferred to have
+  inherited these same GO annotations by descent. The annotations are done using a
+  tool called PAINT (Phylogenetic Annotation and INference Tool).
+---
+authors: The GO Consortium
+id: GO_REF:0000056
+year: 2013
+is_obsolete: true
+layout: goref
+title: OBSOLETE Taxon constraints to detect inconsistencies in annotation and ontology
+  structure.
+comments:
+- 'GO is intended to cover the full range of species, therefore GO terms are defined
+  to be taxon neutral, avoiding reliance on taxon information for full definition
+  of the given process, function, or component. For certain terms, however, there
+  is obvious implicit taxon specificity, such that the term should only be used to
+  categorize gene products from particular species. Taxon specificity of GO terms
+  is captured using relationships such as "only_in_taxon" and "never_in_taxon". All
+  taxon constraints are inherited by sub-types and parts of the GO term they are applied
+  to. Taxon constraints are used to prevent inappropriate annotations from being made
+  by curators as well as to identify pre-existing annotations that violate the taxon
+  constraints. Errors in annotations are automatically detected by looking for inconsistencies
+  between the taxonomic origin of the annotated gene products and the implicit taxon
+  specificity of the GO terms. The inconsistencies are passed on to curators for correction,
+  in some cases the constraints need to be tightened or relaxed or the structure of
+  the ontology needs to be adjusted. The taxon constraints are further described in
+  this publication: Deegan, Dimmer and Mungall. BMC Bionformatics (2010) Formalization
+  of taxon-based constraints to detect inconsistencies in annotaiton and ontology
+  development. (PMID:20973947). '
+---
+authors: GO Central curators, GOA curators, Rhea curators
+citation: PMID:30272209
+id: GO_REF:0000116
+year: 2020
+layout: goref
+title: Automatic Gene Ontology annotation based on Rhea mapping.
+comments:
+- 'Rhea (https://www.rhea-db.org/, PMID:30272209) is an expert-curated knowledgebase
+  of chemical and transport reactions of biological interest - and the standard for
+  enzyme and transporter annotation in UniProtKB (PMID:31688925). Rhea uses the chemical
+  dictionary ChEBI (Chemical Entities of Biological Interest) to describe reaction
+  participants and their chemical transformations in a computationally tractable manner.
+  GO terms corresponding to Rhea reactions are assigned a Rhea database cross-reference.
+  The corresponding GO term is automatically applied to all UniProt entries annotated
+  with a Rhea reaction. The mapping file is available at: http://current.geneontology.org/ontology/external2go/rhea2go.'
+---
+authors: GO ontology editors
+id: GO_REF:0000076
+year: 2013
+layout: goref
+title: Representation of transport or vesicle-mediated transport from cell component
+  to cell component as biological process in the Gene Ontology
+comments:
+- We have created a standard template for classes describing the transport or vesicle-mediated
+  transport from cellular component to cellular component as a biological process.
+  The underlying equivalence axiom templates are "GO:0006810 and 'has_target_start_location'
+  some F and 'has_target_end_location' some T" (transport) and "GO:0016192 and 'has_target_start_location'
+  some F and 'has_target_end_location' some T" (vesicle-mediated transport), where
+  F and T are a cellular components.
+---
+authors: PAMGO_GAT curators
+id: GO_REF:0000027
+year: 2007
+layout: goref
+title: BLAST search criteria for ISS assignment in PAMGO_GAT
+comments:
+- This GO reference describes the criteria used in assigning the evidence code of
+  ISS via BLAST searches to annotate gene products from PAMGO_GAT. Standard BLASTP
+  from NCBI was used (http://www.ncbi.nih.gov/blast) to query the non-redundant (NR)
+  database. Hits are considered to be significant if the E-value is at or less than
+  10^-4. All other parameters are default according to http://www.ncbi.nih.gov/blast.
+---
+authors: GO ontology editors
+id: GO_REF:0000085
+year: 2013
+layout: goref
+title: Representation of cell apoptotic process as biological process in the Gene
+  Ontology
+comments:
+- We have created a standard template for classes describing the apoptotic process
+  for a cell type as a biological process. The underlying equivalence axiom template
+  is "'apoptotic process' and 'occurs in' some C", where C is a native cell (CL:0000003).
+---
+authors: GO ontology editors
+id: GO_REF:0000102
+is_obsolete: true
+year: 2015
+layout: goref
+title: OBSOLETE Representation of cellular component binding as molecular functions
+  in the Gene Ontology
+comments:
+- We have created a standard template for classes cellular component binding as a
+  molecular function. The underlying equivalence axiom template is "'binding' and
+  'has input' some C", where C is a cellular component (GO:0005575).
+---
+authors: UniProt-GOA
+id: GO_REF:0000042
+is_obsolete: true
+year: 2012
+layout: goref
+title: OBSOLETE Gene Ontology annotation through association of InterPro records with
+  GO terms, accompanied by conservative changes to GO terms applied by UniProt.
+comments:
+- "Transitive assignment of GO terms based on InterPro classification. For any database\
+  \ entry (representing a protein or protein-coding gene) that has been annotated\
+  \ with one or more InterPro domains, The corresponding GO terms are obtained from\
+  \ a translation table of InterPro entries to GO terms (interpro2go) generated manually\
+  \ by the InterPro team at EBI. The mapping file is available at http://www.geneontology.org/external2go/interpro2go.<br>Please\
+  \ note that the GO term in the annotation assigned with this GO reference has been\
+  \ changed from that originally applied by the InterPro2GO mapping. This change has\
+  \ been carried out by the UniProt group to ensure the GO annotation obeys the GO\
+  \ Consortium\u2019s ontology structure and taxonomic constraints. Further information\
+  \ on the rules used by UniProt to transform specific incorrect IEA annotations is\
+  \ available at http://www.ebi.ac.uk/QuickGO/AnnotationPostProcessing.html."
+- Duplicate of GO_REF:0000002.
+---
+authors: Human Protein Atlas
+id: GO_REF:0000052
+year: 2013
+layout: goref
+title: Gene Ontology annotation based on curation of immunofluorescence data
+comments:
+- 'GO Cellular Component terms are manually assigned by curators studying high resolution
+  confocal microscopy images of immunohistochemically stained tissue. The methodology
+  uses antibody-based proteomics which combines high-throughput generation of affinity-purified
+  antibodies with protein profiling in a variety of cells and tissues. Further information
+  on the annotation methods can be found at http://www.proteinatlas.org/about/assays+annotation
+  <br>Annotations are only exported to the GO Consortium if the localizations are
+  supported by literature, according to the following validation grading:<br>Supportive
+  - Subcellular localization supported by literature.<br>1) One/multiple localizations
+  supported by literature.<br>2) Multiple localizations partly supported (at least
+  one) by literature.<br>3) One/multiple localizations in cytoplasm (i.e. Golgi, mitochondria,
+  ER etc) with literature supporting cytoplasmic localization. <br>Prior to February
+  2013, all Human Protein Atlas annotations were referenced by PMID:18029348 (Barbe
+  et al. 2008 Mol. Cell Proteomics. 7:499-508), a paper describing the protein localization
+  pilot study and methodology used by the Human Protein Atlas. However, it has been
+  decided that these annotations are more correctly described by a GO reference.<br>Resource
+  URL: http://www.proteinatlas.org <br>Protein subcellular localization images can
+  be viewed on the Human Protein Atlas website, e.g. http://www.proteinatlas.org/ENSG00000175899/summary#ifcelline'
+---
+authors: Ivan Erill, James Hu, Community Assessment of Community Annotation with Ontologies
+id: GO_REF:0000112
+is_obsolete: true
+year: 2017
+layout: goref
+title: OBSOLETE Gene Ontology annotation by CACAO biocurators
+comments:
+- This GO reference describes the criteria used by biocurators participating in the
+  Community Assessment of Community Annotation with Ontologies (CACAO) to annotate
+  gene products from genomes of interest through the use of computational methods
+  to establish and manually validate function or homology to gene products. In particular,
+  this GO reference describes the criteria used to make annotations based on evidence
+  codes ISS, ISA, ISO, ISM and IGC. To perform ISS-, ISA-, and ISO-based annotations
+  on a gene product, CACAO biocurators use sequence- and structure-based search algorithms
+  (e.g. BLASTP, HHPred) to establish homology, conservation of sequence and structure
+  functional determinants between the target gene product and gene products from other
+  organisms with published GO annotations supported by experimental codes and lacking
+  NOT qualifiers. These gene products are referenced in the WITH field of the annotation
+  using their xref database accession. ISM-based annotations make use of published
+  computational methods (e.g. TMHMM, SignalP) to predict gene product structure, localization
+  or function. IGC-based annotations are made on the basis of suggestive evidence
+  for function based on synteny. Parameters and criteria for use of all computational
+  methods (e.g. e-value) are listed and versioned in the publicly available CACAO
+  documentation (http://gowiki.tamu.edu/). Annotations made by CACAO biocurators are
+  reviewed by CACAO team instructors before their release.
+---
+alt_id:
+- GO_REF:0000005
+authors: GOA curators, MGI curators
+citation: PMID:11374909
+external_accession:
+- MGI:2152096
+- J:72245
+- ZFIN:ZDB-PUB-031118-3
+- SGD_REF:S000124037
+id: GO_REF:0000003
+year: 2001
+layout: goref
+title: Gene Ontology annotation based on Enzyme Commission mapping.
+comments:
+- Transitive assignment using Enzyme Commission identifiers. This method is used for
+  any database entry, such as a protein record in UniProtKB or TrEMBL, that has had
+  an Enzyme Commission number assigned. The corresponding GO term is determined using
+  the EC cross-references in the GO molecular function ontology. Also see Hill et
+  al., Genomics (2001) 74:121-128. The mapping file is available at http://www.geneontology.org/external2go/ec2go.
+- Formerly GOA:spec.
+---
+authors: Mouse Genome Informatics scientific curators and FlyBase
+id: GO_REF:0000095
+year: 2014
+layout: goref
+title: Literature reference not indexed by PubMed
+comments:
+- This article is not referenced in PubMed. Please see contributing data resource
+  for details.
+---
+authors: UniProt-GOA
+id: GO_REF:0000037
+is_obsolete: true
+year: 2011
+evidence_codes:
+- ECO:0000501
+layout: goref
+title: OBSOLETE Gene Ontology annotation based on manual assignment of UniProtKB keywords
+  in UniProtKB/Swiss-Prot entries.
+comments:
+- Transitive assignments using UniProtKB keywords. The UniProtKB keyword controlled
+  vocabulary has been created and used by the UniProt Knowledgebase (UniProtKB) to
+  supply 10 different categories of information to UniProtKB entries. Further information
+  on the UniProtKB keyword resource can be found at http://www.uniprot.org/docs/keywlist.
+  UniProtKB keywords are manually applied to UniProtKB/Swiss-Prot entries by UniProt
+  curators. Further information on the UniProtKB manual annotation process is available
+  at http://www.uniprot.org/faq/45.<br>When a UniProtKB keyword describes a concept
+  that is within the scope of the Gene Ontology, it is investigated to determine whether
+  it is appropriate to map the keyword to an equivalent term in GO. The mapping between
+  UniProtKB keywords and GO terms is carried out manually. Definitions and hierarchies
+  of the terms in the two resources are compared and the mapping generated will reflect
+  the most correct correspondence. The translation table between GO terms and UniProtKB
+  keywords is maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/uniprotkb_kw2go.
+- Duplicate of GO_REF:0000043.
+---
+authors: GO ontology editors
+id: GO_REF:0000066
+year: 2013
+layout: goref
+title: Representation of transport of a chemical entity as molecular function in the
+  Gene Ontology
+comments:
+- 'We have created a standard template for classes describing the transport of a chemical
+  entity (ChEBI) as a molecular function. The underlying equivalence axiom template
+  is "GO:0005215 and ''transports or maintains localization of'' some X", where X
+  is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI has been
+  described in the following publication: PMID:23895341.'
+---
+authors: GO ontology editors
+id: GO_REF:0000077
+year: 2013
+is_obsolete: true
+layout: goref
+title: OBSOLETE Representation of transport of a cellular component as biological
+  process in the Gene Ontology
+comments:
+- We have created a standard template for classes describing the transport or vesicle-mediated
+  transport of a cellular component as a biological process. The underlying equivalence
+  axiom templates are "GO:0006810 and 'transports or maintains localization of' some
+  C" (transport) and "GO:0016192 and 'transports or maintains localization of' some
+  C" (vesicle-mediated transport), where C is a cellular component.
+---
+authors: Jennifer Deegan nee Clark (1, 5), Alexander D. Diehl (1,7), Elisabeth Ehler
+  (2), Georgine Faulkner (3), Erika Feltrin (4), Jennifer Fordham (2), Midori Harris
+  (1, 5), Ralph Knoell (6) David Hill (1, 7), Paolo Laveder (8), Alessandra Nori (8),
+  Carlo Reggiani (8), Vincenzo Sorrentino (9), Giorgio Valle (4), Pompeo Volpe (8)
+  (1. The Gene Ontology Consortium, 2. King's College, London, UK, 3. ICGEB, Trieste,
+  Italy, 4. CRIBI - University of Padua, Padua, Italy 5. EMBL-EBI, Hinxton, Cambridgeshire,
+  UK, 6. University of Goettingen, Goettingen, Germany 7. Mouse Genome Informatics,
+  Bar Harbor, ME, 8. University of Padua, Padua, Italy, 9. University of Siena, Siena,
+  Italy)
+citation: PMID:19178689
+id: GO_REF:0000026
+is_obsolete: true
+year: 2007
+layout: goref
+title: OBSOLETE Improving the representation of muscle biology in the biological process
+  and cellular component ontologies.
+comments:
+- 'A meeting focused on the biology of skeletal and smooth muscle has been held on
+  24-25 July 2007 at the University of Padua, Italy, as a collaboration with the GO
+  consortium and CRIBI Biotechnology Center. The aims of this effort were to provide
+  a comprehensive representation of muscle biology in the biological process and cellular
+  component ontologies and to improve the organization of muscle-specific terms to
+  better describe the current knowledge of biological mechanisms in muscle tissue.
+  Thus, the collaboration brought together experts in several areas of muscle biology
+  and physiology who carried out a thorough review of the existing GO muscle terms
+  as these terms were largely created by non-muscle experts using older definitions.
+  In particular, several areas are being addressed actively in current research: the
+  biological processes of muscle contraction, muscle plasticity, muscle development,
+  and muscle regeneration; and the sarcoplasmic reticulum and membrane delimited compartments.
+  This work resulted in the addition of 159 new terms and in the modification of 57
+  terms to bring them in line with current usage. Funding for the meeting was provided
+  by Italian Telethon Foundation.'
+---
+authors: GO ontology editors
+id: GO_REF:0000084
+year: 2013
+layout: goref
+title: Representation of plant structural organization as biological process in the
+  Gene Ontology
+comments:
+- We have created a standard template for classes describing the structural organization
+  of a plant structure as a biological process. The underlying equivalence axiom template
+  is "'anatomical structure arrangement' and 'results in structural organization of'
+  some P", where P is a plant anatomical entity (PO:0025131).
+---
+authors: Michelle Gwinn, TIGR curators
+id: GO_REF:0000012
+year: 2003
+layout: goref
+title: Pairwise alignment (TIGR)
+comments:
+- 'Pairwise alignments are generated by taking two sequences and aligning them so
+  that the maximum number of amino acids in each protein match, or are similar to,
+  each other. Tools such as BLAST work by comparing a protein-of-interest individually
+  with every protein in a database of known protein sequences and retaining only those
+  matches with a high probability of being significant. Basic BLAST generates local
+  alignments between proteins for regions of high similarity. Other pairwise alignment
+  tools attempt to generate global (full-length) protein alignments. A tool called
+  Blast_Extend_repraze (BER, http://ber.sourceforge.net) has some benefits over basic
+  BLAST. Input into the BER tool includes the underlying DNA sequence for each protein
+  as well as 300 nucleotides upstream and downstream of the predicted boundaries of
+  the protein coding sequence. This allows annotators to see the DNA sequence that
+  underlies the query protein as part of the alignment. In addition, the BER tool
+  is able to look for continuation of regions of similarity through frameshifts and
+  in-frame stop codons.  If such regions are found the alignment is continued. BER
+  searches are done in a two-step process: step one is a BLAST search against a non-redundant
+  protein database, significant BLAST hits are stored in a mini-database for each
+  query protein; step two is a modified Smith-Waterman alignment between the query
+  and the proteins in its mini-database. In order to assess whether a given BER alignment
+  is good enough to assert that the query shares the function of the match protein,
+  one must look at a several factors. First of all, the match protein must itself
+  be experimentally characterized in order to avoid transitive annotation errors.
+  In addition, any residues or secondary structures known to be important for function
+  in the match protein must be conserved in the query. The alignment should be visually
+  inspected to look for any areas of lesser quality that might indicate the two proteins
+  do not share the same function. Although it is impossible to set cutoff values for
+  percent identity and length of match that will apply for every alignment, there
+  are some guidelines. In general at least 40% identity that extends over the full
+  lengths of both proteins is required in order to even consider functional equivalence.
+  However, this percentage is highly dependent on the length and complexity of the
+  proteins. 40% identity between two proteins 500 amino acids long is much more significant
+  that 40% identity between two proteins that are only 100 amino acids long. Therefore,
+  the annotator''s experience and knowledge of what is considered significant for
+  the organism and protein family in question is very important. Some sets of proteins
+  are much more highly conserved than others and therefore tolerances for percent
+  identity may have to be adjusted. Finally, the alignment must be considered in the
+  context of what else is known about the query protein and the organism as a whole.'
+---
+authors: GO ontology editors
+id: GO_REF:0000103
+is_obsolete: true
+year: 2015
+layout: goref
+title: OBSOLETE Representation of cellular component organization as biological process
+  in the Gene Ontology
+comments:
+- We have created a standard template for classes cellular component organization
+  as a biological process. The underlying equivalence axiom template is "'cellular
+  component organization' and 'results_in_organization_of' some C", where C is a cellular
+  component (GO:0005575).
+---
+authors: UniProt-GOA
+id: GO_REF:0000043
+external_accession:
+- SGD_REF:S000148669
+- J:60000
+- TAIR:AnalysisReference:501756968
+- TAIR:AnalysisReference:501756970
+year: 2012
+layout: goref
+title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
+comments:
+- 'Transitive assignments using UniProtKB/Swiss-Prot keywords. The UniProtKB keyword
+  controlled vocabulary contains 10 different categories of information to UniProtKB
+  entries. Further information on the UniProtKB keyword resource can be found at https://www.uniprot.org/keywords/.
+
+  UniProtKB keywords are assigned to UniProtKB/Swiss-Prot entries by UniProt curators
+  as part of the UniProtKB manual curation process. UniProtKB keywords are also automatically
+  assigned to UniProtKB/TrEMBL entries from the underlying nucleic acid databases
+  and/or by the UniProt automatic annotation program.
+
+  Further information on the two different UniProt annotation methods is available
+  at https://www.uniprot.org/help/keywords..
+
+  When a UniProtKB keyword describes a concept that is within the scope of the Gene
+  Ontology, a mapping is manually made to the corresponding GO term.The translation
+  table between GO terms and UniProtKB keywords is maintained by the EBI GOA team
+  and available at http://www.geneontology.org/external2go/uniprotkb_kw2go.'
+---
+authors: 'GO ontology editors '
+id: GO_REF:0000053
+year: 2013
+is_obsolete: true
+layout: goref
+title: OBSOLETE Automatic classification of GO using the ELK reasoner
+comments:
+- We use the <a href="http://code.google.com/p/elk-reasoner/">ELK reasoner</a> as
+  part of an ontology development and release pipeline to automatically construct
+  and check a large portion of the GO graph. The editors version of the GO (gene_ontology_write.obo)
+  contains additional metadata, including provenance of graph links. Every week, the
+  GO pipeline executes a process which first removes all links tagged as "is_inferred".
+  The reasoner then generates a list of inferred links which are automatically added
+  to the ontology with the "is_inferred" tag set. The pipeline generates a report
+  describing which links have changed as a part of this process.
+---
+authors: "Marcio Luis Acencio (1), George Georghiou (2), Sandra Orchard (2), Liv Thommensen\
+  \ (1), Martin Kuiper (1) and Astrid L\xE6greid (1). (1) Norwegian University of\
+  \ Science and Technology (NTNU), Trondheim, Norway; (2) European Bioinformatics\
+  \ Institute (EBI), Hinxton, Cambridgeshire, United Kingdom"
+id: GO_REF:0000113
+year: 2018
+layout: goref
+title: Gene Ontology annotation of human sequence-specific DNA binding transcription
+  factors (DbTFs) based on the TFClass database
+comments:
+- 'The TFClass (http://tfclass.bioinf.med.uni-goettingen.de/index.jsf) database provides
+  a comprehensive classification of mammalian DNA binding transcription factors (DbTFs)
+  based on their DNA binding domains (DBDs) (PMID:29087517). TFClass classifies mammalian
+  DbTFs by a five-level classification in which the four highest levels represent
+  groups defined by structural and sequence similarities (superclass, class, family,
+  subfamily, and genera) (more details at http://www.edgar-wingender.de/TFClass_schema.html).
+  This classification is based on the combination of background knowledge of the molecular
+  structural features of DBDs (PMID:9340487, PMID:23427989) and phylogenetic trees
+  constructed via multiple sequence alignment with hierarchical clustering of manually
+  validated DBDs and/or full-length protein sequences retrieved from UniProt (PMID:23427989,
+  PMID:23180794, PMID:23427989). '
+- 'The NTNU curation team has evaluated each family and assigned a molecular function
+  annotation, GO:0000981 (DNA-binding transcription factor activity, RNA polymerase
+  II-specific), and a cellular component annotation GO:0000790 (nuclear chromatin),
+  as appropriate. The superclass/class/family or subfamily ID is specified in the
+  "With/From" field. The annotations are supported by the evidence code ECO:0005556
+  (multiple sequence alignment evidence used in manual assertion). '
+---
+alt_id:
+- GO_REF:0000007
+- GO_REF:0000014
+- GO_REF:0000016
+- GO_REF:0000017
+authors: DDB, FB, MGI, GOA, ZFIN curators
+external_accession:
+- MGI:2152098
+- J:72247
+- ZFIN:ZDB-PUB-020724-1
+- FB:FBrf0174215
+- dictyBase_REF:10157
+- SGD_REF:S000124036
+id: GO_REF:0000002
+year: 2001
+layout: goref
+title: Gene Ontology annotation through association of InterPro records with GO terms.
+comments:
+- Transitive assignment of GO terms based on InterPro classification. For any database
+  entry (representing a protein or protein-coding gene) that has been annotated with
+  one or more InterPro domains, The corresponding GO terms are obtained from a translation
+  table of InterPro entries to GO terms (interpro2go) generated manually by the InterPro
+  team at EBI. The mapping file is available at http://www.geneontology.org/external2go/interpro2go.
+- Formerly GOA:interpro. Note that GO annotations based on InterPro-to-GO transitive
+  assignment may undergo subsequent filtering, e.g. to remove annotations redundant
+  with manual curation; consult documentation from the annotation providers for further
+  information.
+---
+authors: GO ontology editors
+id: GO_REF:0000094
+year: 2014
+layout: goref
+title: Representation of metazoan development as biological process in the Gene Ontology
+comments:
+- We have created a standard template for classes describing the development of a
+  metazoan structure as a biological process. The underlying equivalence axiom template
+  is "'anatomical structure development' and 'results in development of' some E",
+  where E is a anatomical entity (UBERON:0001062).
+---
+authors: GO Annotation working group
+external_accession:
+- SGD_REF:S000147045
+id: GO_REF:0000036
+year: 2011
+layout: goref
+title: Manual annotations that require more than one source of functional data to
+  support the assignment of the associated GO term
+comments:
+- The Gene Ontology Consortium uses the IC (Inferred by Curator) evidence code when
+  an annotation cannot be supported by any direct evidence, but can be inferred by
+  GO annotations that have been annotated to the same gene/gene product identifier
+  in conjunction with the curator's knowledge of biology (supporting GO annotations
+  must not be IC-evidenced). In many cases an IC-evidenced annotation simply applies
+  the same reference that was used in the supporting GO annotation.  The use of IC
+  evidence code in an annotation with reference GO_REF:0000036 signifies a curator
+  inferred the GO term based on evidence from multiple sources of evidence/GO annotations.
+  The 'with/from' field in these annotations will therefore supply more than one GO
+  identifier, obtained from the set of supporting GO annotations assigned to the same
+  gene/gene product identifier which cite publicly-available references.
+---
+authors: GO ontology editors
+id: GO_REF:0000067
+year: 2013
+layout: goref
+title: Representation of binding to a chemical entity as molecular function in the
+  Gene Ontology
+comments:
+- 'We have created a standard template for classes describing the binding to a chemical
+  entity (ChEBI) as a molecular function. The underlying equivalence axiom template
+  is "GO:0005488 and ''has input'' some X", where X is a chemical entity (CHEBI:24431).
+  The approach to combine GO and ChEBI has been described in the following publication:
+  PMID:23895341.'
+---
+authors: GOA curators
+id: GO_REF:0000107
+year: 2016
+layout: goref
+title: Automatic transfer of experimentally verified manual GO annotation data to
+  orthologs using Ensembl Compara.
+comments:
+- GO terms from a source species are projected onto one or more target species based
+  on gene orthology obtained from Ensembl Compara. One-to-one, one-to-many and many-to-many
+  orthology relations and anntations are transferred between orthologs that have at
+  least a 40% peptide identity to each other. Only GO annotations with evidence codes
+  ECO:0000314 (IDA), ECO:0000270 (IEP), ECO:0000316 (IGI), ECO:0000315 (IMP), and
+  ECO:0000353 (IPI), or their descendants, are transferred; annotations with a 'NOT'
+  qualifier are not transferred, and neither are annotations to GO:0005515 (protein
+  binding). Annotations that are transferred using this method receive the evidence
+  code ECO:0000265 (sequence orthology evidence used in automatic assertion), which
+  maps up to the GO Inferred from Electronic Annotation (IEA) evidence code.  The
+  model organism database identifier of the annotation source will be indicated in
+  the 'With' column of the GOA association file.
+---
+authors: GO curators
+id: GO_REF:0000047
+year: 2012
+layout: goref
+title: Gene Ontology annotation based on absence of key sequence residues.
+comments:
+- This describes a method for supplying a NOT-qualified, IKR-evidenced GO annotation
+  to a gene product, when general sequence homology considerations would suggest a
+  function or location, or a role in a biological process, but where a curator has
+  determined that the absence of key sequence residues, known to be required for an
+  expected activity or location, indicating the gene product is unlikely to be able
+  to carry out the implied activity, involvement in a process or cellular component
+  location. This reference should only be used used when an IKR-evidenced annotation
+  is made based on curator judgement from manually reviewing the sequence of the gene
+  product and where no publication can be found to support the curators conclusion.
+  It is preferable to cite a peer-reviewed publication (such as a PubMed identifier)
+  for IKR-evidenced annotations whenever possible. Curators will have carefully reviewed
+  the sequence of the annotated protein, and established that the key residues known
+  to be required for an expected activity or location are not present. Inclusion of
+  an identifier in the 'with/from' field, that highlights to the user the lacking
+  residues(e.g. an alignment, domain or rule identifier) is absolutely required when
+  annotating to IKR with this GO_REF. Documentation on the GOC website provides more
+  details on the <a href = "http://www.geneontology.org/GO.evidence.shtml#ikr">correct
+  use of the IKR evidence code</a>.
+---
+authors: Alison Deckhut Augustine (1), Alan Collmer (2), Judith A. Blake (3, 4), Candace
+  W. Collmer (2, 3), Shane C. Burgess (5), Lindsay Grey Cowell (6), Jennifer I. Clark
+  (3, 7), Bernard de Bono (7), Russell T. Collins (8), Alexander D. Diehl (3, 4),
+  Michelle Gwinn Giglio (3, 9), Jamie A. Lee (10), Linda Hannick (3, 9), Jane Lomax
+  (3, 7), Midori A. Harris (3, 7), Christopher J. Mungall (3, 11), David P. Hill (3,
+  4), Richard H. Scheuermann (10), Amelia Ireland (3, 7), Alessandro Sette (12) (1.
+  NIAID, 2. Cornell University, 3. The GO Consortium, 4. Mouse Genome Informatics,
+  5. Mississippi State University, 6. Duke University, 7. EMBL-EBI, 8. University
+  of Cambridge, 9. The Institute for Genomic Research, 10. U.T. Southwestern Medical
+  Center, 11. HHMI, 12. La Jolla Institute for Allergy and Immunology)
+id: GO_REF:0000022
+year: 2005
+layout: goref
+title: Improving the representation of immunology in the biological process Ontology
+comments:
+- GO terms describing processes, functions, and cellular components related to the
+  immune system have existed in the GO from its beginning and been used extensively
+  in the annotation of gene products. However, particularly in the biological process
+  ontology, the initial set of terms relating to immunology failed to cover the breadth
+  of known immunological processes, and in many cases diverged from current usage
+  and understanding in their names, definitions, and ontological placement. As part
+  of a larger effort to improve the representation of immunology in the GO, a GO Content
+  Meeting was held November 15-16, 2005, at The Institute for Genomic Research, to
+  discuss improvements to representation of immunology in the biological process ontology
+  of the GO. As a result of the meeting, a number of high level terms for immunological
+  processes were created, an overall structure for immunologically related terms was
+  established, and certain existing terms were renamed or redefined as well to bring
+  them in line with current usage.
+---
+authors: GO ontology editors
+id: GO_REF:0000073
+year: 2013
+layout: goref
+title: Representation of import of a chemical as biological process in the Gene Ontology
+comments:
+- 'We have created a standard template for classes describing the import of a chemical
+  entity (ChEBI) as a biological process. The underlying equivalence axiom template
+  is "GO:0006810 and ''imports'' some X", where X is a chemical entity (CHEBI:24431).
+  The approach to combine GO and ChEBI has been described in the following publication:
+  PMID:23895341.'
+---
+authors: GO ontology editors
+id: GO_REF:0000080
+year: 2013
+layout: goref
+title: Representation of plant development as biological process in the Gene Ontology
+comments:
+- We have created a standard template for classes describing the development of a
+  plant structure as a biological process. The underlying equivalence axiom template
+  is "'anatomical structure development' and 'results in development of' some P",
+  where P is a plant anatomical entity (PO:0025131).
+---
+authors: GO ontology editors
+id: GO_REF:0000090
+year: 2013
+layout: goref
+title: Automatic creation of relationships between ontology branches in the Gene Ontology
+comments:
+- 'We have created a rule-based approach to create relations between the branches
+  of the Gene Ontology. The approach uses the equivalence axioms and a given pattern
+  to create non-subClassOf relationships between the three different branches of the
+  Gene Ontology (biological process, molecular function, cellular component). Currently,
+  there are the following rules: "''transporter activity'' and ''transports_or_maintains_localization_of''
+  some X'' -part_of-&gt; "transport and ''transports_or_maintains_localization_of''
+  some X"; "''transmembrane transporter activity'' and ''transports_or_maintains_localization_of''
+  some X -part_of-&gt; ''transmembrane transport'' and ''transports_or_maintains_localization_of''
+  some X"'
+---
+authors: GO ontology editors
+id: GO_REF:0000063
+year: 2013
+layout: goref
+title: Representation of processes regulated by other regulating processes in the
+  Gene Ontology
+comments:
+- We have created a standard template for classes describing processes regulated by
+  other regulating processes. The underlying equivalence axiom template is "R and
+  'results_in' some P", where R is a biological process and P is a regulation of biological
+  process subclass.
+---
+authors: Christopher J. Mungall, Tanya Z. Berardini, David P. Hill
+id: GO_REF:0000032
+is_obsolete: true
+url: http://wiki.geneontology.org/index.php/GAF_Inference
+layout: goref
+title: OBSOLETE Inference of Biological Process annotations from inter-ontology links
+comments:
+- We use the GOBO library to propagate annotations from Molecular Function to Biological
+  Process. This results in both increased numbers of annotations, and increased consistency
+  between curators.
+- Duplicate of GO_REF:0000108.
+---
+authors: Mouse Genome Informatics scientific curators
+citation: PMID:11374909
+external_accession:
+- MGI:2152097
+- J:72246
+id: GO_REF:0000006
+is_obsolete: true
+year: 2001
+layout: goref
+title: OBSOLETE Gene Ontology annotation by the MGI curatorial staff, Mouse Locus
+  Catalog
+comments:
+- For annotations documented via this citation, curators used the information in the
+  Mouse Locus Catalog in MGI to assign GO terms. The GO terms were assigned based
+  on MLC textual descriptions of genes that could not be traced to the primary literature.
+  Details of this strategy can be found in Hill et al, Genomics (2001) 74:121-128.
+---
+authors: UniProt
+id: GO_REF:0000117
+year: 2021
+layout: goref
+title: Electronic Gene Ontology annotations created by ARBA machine learning models
+comments:
+- ARBA predicts Gene Ontology (GO) terms among other types of functional annotation
+  such as Protein Description (DE), Keywords (KW), Enzyme Commission numbers (EC),
+  sucellular LOcation (LO), etc. For all annotation types, reviewed UniProtKB/Swiss-Prot
+  records having manual annotations as reference data are used to perform the machine
+  learning phase and generate prediction models. For GO terms, ARBA has an additional
+  feature to augment reference data using the relations between GO terms in the GO
+  graph. The data augmentation is based on adding more general annotations into records
+  containing manual GO terms, which will result in richer reference data. The predicted
+  GO terms are then propagated to all unreviewed UniProtKB/TrEMBL proteins that meet
+  the conditions of ARBA models. GO annotations using this technique receive the evidence
+  code Inferred from Electronic Annotation (IEA; ECO:0000501). These annotations are
+  updated regularly by UniProt and are available for download on both the GO and GOA
+  EBI ftp sites.
+---
+authors: GO ontology editors
+id: GO_REF:0000087
+year: 2013
+layout: goref
+title: Representation of protein localization and establishment of protein localization
+  as biological process in the Gene Ontology
+comments:
+- We have created a standard template for classes describing the protein localization
+  and establishment of protein localization to a cellular component as a biological
+  process. The underlying equivalence axiom templates are "GO:0008104 and 'has_target_end_location'
+  some C" (protein localization) and "GO:0045184 and 'has_target_end_location' some
+  C" (establishment of protein localization), where C is cellular component.
+---
+authors: Michelle Gwinn, TIGR curators
+id: GO_REF:0000025
+year: 2007
+layout: goref
+title: Operon structure as IGC evidence
+comments:
+- Genes in prokaryotic organisms are often arranged in operons. Genes in an operon
+  are all transcribed into one mRNA. Generally the genes in the operons code for proteins
+  that all have related functions. For example, they may be the steps in a biochemical
+  pathway, or they may be the subunits of a protein complex. Often the genes in operons
+  shared between organisms are syntenic; that is, the same genes are in the same order
+  in the operon in different species. When assessing sequence-comparison-based evidence
+  during the process of manual annotation of a genome, it is often the case that some
+  of the genes in the operon will have strong sequence-based evidence while others
+  will have weak evidence. If seen alone, not in the presence of an operon, the weak
+  evidence in question may not be sufficient to make a functional annotation. However,
+  in the presence of an operon in which there is strong evidence for some of the genes,
+  the very presence of the gene in the operon is a strong indication that the gene
+  shares in the process carried out by the operon. If the putative function is one
+  expected to exist for the process in question and particularly if that function
+  has been observed in the same operon in another species, then the annotation should
+  be made. This type of evidence is inferred from the context of the gene in an operon,
+  and therefore the evidence code is IGC "inferred from genomic context."
+---
+authors: GO ontology editors
+id: GO_REF:0000074
+year: 2013
+layout: goref
+title: Representation of export of a chemical as biological process in the Gene Ontology
+comments:
+- 'We have created a standard template for classes describing the export of a chemical
+  entity (ChEBI) as a biological process. The underlying equivalence axiom template
+  is "GO:0006810 and ''exports'' some X", where X is a chemical entity (CHEBI:24431).
+  The approach to combine GO and ChEBI has been described in the following publication:
+  PMID:23895341.'
+---
+authors: Ivan Erill, SEA-PHAGE biocurators
+id: GO_REF:0000100
+is_obsolete: true
+year: 2014
+layout: goref
+title: OBSOLETE Gene Ontology annotation by SEA-PHAGE biocurators
+comments:
+- This GO reference describes the criteria used by biocurators of the SEA-PHAGE consortium
+  for the annotation of predicted gene products from newly sequenced bacteriophage
+  genomes in the SEA-PHAGE phagesdb.org and other databases and in the GenBank records
+  periodically released to NCBI for these genomes. In particular, this GO reference
+  describes the criteria used to assign evidence codes ISS, ISA, ISO, ISM, IGC and
+  ND. To assign ISS, ISA, ISO and ISM evidence codes, SEA-PHAGE biocurators use a
+  varied array of bioinformatics tools to establish homology and conservation of sequence
+  and structure functional determinants with proteins from multiple organisms with
+  published association to experimental GO terms and lacking NOT qualifiers. These
+  proteins are referenced in the WITH field of the annotation using their xref database
+  accession. The primary tools for homology search in ISS, ISA, ISO and ISM assignments
+  are BLASTP and HHpred, using a maximum e-value of 10^-7 for BLASTP and a minimum
+  probability of 0.9 for HHpred, and manual inspection of alignments in both cases.
+  For ISS and ISA assignments, BLASTP alignments are required to have at least 75%
+  coverage and 30% identity. For ISO assignments, orthology is further validated using
+  reciprocal BLASTP with the identified hit. For HHpred results, ISS or ISM annotations
+  are made only if the source for the original GO annotation explicitly defines a
+  matched domain function, or if more than half of the domains of the query protein
+  are identified in the matching protein. All ISS, ISA, ISO and ISM assignments entail
+  the manual verification of the source for the GO term in the matching protein sequence
+  and critical curator assessment of the likelihood of preservation of function, process
+  or component in the context of bacteriophage biology. IGC codes are assigned on
+  the basis of suggestive evidence for function based on synteny, as inferred from
+  whole-genome comparative analyses of multiple bacteriophage genomes using primarily
+  the Phamerator software platform, and with special emphasis on the bacteriophage
+  virion structure and assembly genes. When extensive review of published literature
+  on putative homologs reveals no experimental evidence of function, component or
+  process for a particular gene product, it is assigned an ND evidence code and annotated
+  to the root term for Cellular Component, Molecular Function and Biological Process.
+  As part of the review process for assignment of ISS, ISA, ISO, IGC and ISM evidence
+  codes, SEA-PHAGE curators are required to analyze the reference literature for identified
+  matches and shall perform GO annotations with appropriate evidence codes if these
+  were not available.
+---
+authors: UniProt-GOA
+id: GO_REF:0000040
+is_obsolete: true
+year: 2011
+layout: goref
+title: OBSOLETE Gene Ontology annotation based on the automatic assignment of UniProtKB
+  Subcellular Location terms in UniProtKB/TrEMBL entries.
+comments:
+- Transitive assignment of GO terms based on the UniProtKB Subcellular Location vocabulary.
+  UniProtKB Subcellular Location is a controlled vocabulary used to supply subcellular
+  location information to UniProtKB entries in the SUBCELLULAR LOCATION lines. Terms
+  from this vocabulary are applied automatically to UniProtKB/TrEMBL entries from
+  the underlying nucleic acid databases and/or by the UniProt automatic annotation
+  program. Further information on the UniProtKB automatic annotation program is available
+  at http://www.uniprot.org/faq/45.<br>When a UniProtKB Subcellular Location term
+  describes a concept that is within the scope of the Gene Ontology, it is investigated
+  to determine whether it is appropriate to map the term to an equivalent term in
+  GO. The mapping between UniProtKB Subcellular Location terms and GO terms is carried
+  out manually. Definitions and hierarchies of the terms in the two resources are
+  compared and the mapping generated will reflect the most correct correspondence.
+  The translation table between GO terms and UniProtKB Subcellular Location terms
+  is maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/spsl2go.
+---
+authors: Michelle Gwinn, TIGR curators
+id: GO_REF:0000011
+year: 2003
+layout: goref
+title: Hidden Markov Models (TIGR)
+comments:
+- A Hidden Markov Model (HMM) is a statistical representation of patterns found in
+  a data set. When using HMMs with proteins, the HMM is a statistical model of the
+  patterns of the amino acids found in a multiple alignment of a set of proteins called
+  the "seed". Seed proteins are chosen based on sequence similarity to each other.
+  Seed members can be chosen with different levels of relationship to each other.
+  They can be members of a superfamily (ex. ABC transporter, ATP-binding proteins),
+  they can all share the same exact specific function (ex. biotin synthase) or they
+  could share another type of relationship of intermediate specificity (ex. subfamily,
+  domain). New proteins can be scored against the model generated from the seed according
+  to how closely the patterns of amino acids in the new proteins match those in the
+  seed. There are two scores assigned to the HMM which allow annotators to judge how
+  well any new protein scores to the model. Proteins scoring above the "trusted cutoff"
+  score can be assumed to be part of the group defined by the seed. Proteins scoring
+  below the "noise cutoff" score can be assumed to NOT be a part of the group. Proteins
+  scoring between the trusted and noise cutoffs may be part of the group but may not.
+  One of the important features of HMMs is that they are built from a multiple alignment
+  of protein sequences, not a pairwise alignment. This is significant, since shared
+  similarity between many proteins is much more likely to indicate shared functional
+  relationship than sequence similarity between just two proteins. The usefulness
+  of an HMM is directly related to the amount of care that is taken in chosing the
+  seed members, building a good multiple alignment of the seed members, assessing
+  the level of specificity of the model, and choosing the cutoff scores correctly.
+  In order to properly assess what functional relevance an above-trusted scoring HMM
+  match has to a query, one must carefully determine what the functional scope of
+  the HMM is. If the HMM models proteins that all share the same function then it
+  is likely possible to assign a specific function to high-scoring match proteins
+  based on the HMM. If the HMM models proteins that have a wide variety of functions,
+  then it will not be possible to assign a specific function to the query based on
+  the HMM match, however, depending on the nature of the HMM in question, it may be
+  possible to assign a more general (family or subfamily level) function. In order
+  to determine the functional scope of an HMM, one must carefully read the documentation
+  associated with the HMM. The annotator must also consider whether the function attributed
+  to the proteins in the HMM makes sense for the query based on what is known about
+  the organism in which the query protein resides and in light of any other information
+  that might be available about the query protein. After carefully considering all
+  of these issues the annotator makes an annotation.
+---
+authors: GO curators
+id: GO_REF:0000001
+year: 1998
+layout: goref
+title: GO Consortium unpublished data
+comments:
+- No abstract available.
+- This reference will normally be replaced upon publication of the data supporting
+  the annotation. Formerly GOC:unpublished.
+---
+authors: PomBase curators
+external_accession:
+- FB:FBrf0231277
+id: GO_REF:0000050
+year: 2012
+layout: goref
+title: Manual transfer of GO annotation data to genes by curator judgment of sequence
+  model
+comments:
+- Transitive assignment of GO terms to a gene based on a curator's judgment of its
+  match to a sequence model,such as a Pfam or InterPro entry, that has manually curated
+  GO annotations, mappings to GO terms, or a description from which GO terms can be
+  inferred. A statistical model of a sequence or group of sequences is used to make
+  a prediction about the function of a protein or RNA. Annotations are created when
+  a curator evaluates the results, using criteria that include excluding false positives
+  and ensuring that the annotation is accurate for all matches. Statistical scores
+  (such as e values and cutoff scores) and the functional specificity of the model
+  may also be (but are not always) considered. Annotations resulting from the transfer
+  of GO terms use the 'ISM' evidence code and include an accession for the model from
+  which the annotation was projected in the 'with' field (column 8).
+---
+authors: FlyBase
+external_accession:
+- FB:FBrf0159903
+id: GO_REF:0000110
+year: 2003
+layout: goref
+title: Gene Ontology annotation of Drosophila melanogaster nuclear genes encoding
+  proteins targeted to the mitochondrion.
+comments:
+- Gene Ontology annotation of Drosophila melanogaster nuclear genes encoding proteins
+  targeted to the mitochondrion based on analysis by MitoDrome (http://mitodrome.ba.itb.cnr.it/)
+  by comparison of human mitochondrial proteins available in SWISSPROT vs. the Drosophila
+  genome, ESTs and cDNA sequences available in the FlyBase database (PMID:12520013).
+---
+authors: GO ontology editors
+id: GO_REF:0000064
+year: 2013
+layout: goref
+title: Representation of cell components as part of other cell components in the Gene
+  Ontology
+comments:
+- We have created a standard template for classes describing cell components as part
+  of other cell components. The underlying equivalence axiom template is "P and 'part_of'
+  some W", where P and W are cell components.
+---
+authors: Ensembl, GRAMENE, GOA curators
+id: GO_REF:0000035
+year: 2011
+layout: goref
+title: Automatic transfer of experimentally verified manual GO annotation data to
+  plant orthologs using Ensembl Compara
+comments:
+- GO terms from a source species are projected onto one or more target species based
+  on gene orthology obtained from the Ensembl Compara system. One to one, one to many
+  and many to many orthologies are used but annotations are only projected between
+  orthologs that have at least a 40% peptide identity to each other. Only GO annotations
+  with an evidence type of IDA, IEP, IGI, IMP or IPI are projected, no annotations
+  with a 'NOT' qualifier are projected and annotations to the GO:0005515 protein binding
+  term are not projected. Projected GO annotations using this technique will receive
+  the evidence code Inferred from Electronic Annotation (IEA). The model organism
+  database identifier of the annotation source will be indicated in the 'With' column
+  of the GOA association file.
+- Duplicate of GO_REF:0000107.
+---
+authors: FlyBase
+id: GO_REF:0000097
+year: 2014
+layout: goref
+title: Gene Ontology annotation based on personal communication to FlyBase
+comments:
+- FlyBase occasionally makes GO annotations based on information that has been sent
+  to us directly by researchers as a personal communication to FlyBase. In each case,
+  the full details of the communication including any associated data and analyses
+  are recorded in a FlyBase publication (FBrf) available from our website (http://flybase.org).
+---
+authors: GO Curators
+external_accession:
+- ECO:0000307
+- AspGD_REF:ASPL0000111607
+- CGD_REF:CAL0125086
+- dictyBase_REF:2
+- dictyBase_REF:9851
+- FB:FBrf0159398
+- MGI:MGI:2156816
+- RGD:1598407
+- SGD_REF:S000069584
+- TAIR:Communication:1345790
+- ZFIN:ZDB-PUB-031118-1
+- GO_REF:nd
+id: GO_REF:0000015
+year: 2002
+layout: goref
+title: Use of the ND evidence code for Gene Ontology (GO) terms.
+comments:
+- Direct annotations to any of the three root terms 'molecular function; GO:0003674',
+  'biological process; GO:0008150' or 'cellular component; GO:0005575' indicate that
+  curators have found no data supporting an annotation to a more specific term, either
+  in the literature and/or by sequence similarity for this gene or protein as of the
+  date of the annotation.
+---
+authors: UniProt curators
+external_accession:
+- ZFIN:ZDB-PUB-170525-1
+id: GO_REF:0000104
+year: 2015
+layout: goref
+title: Electronic Gene Ontology annotations created by transferring manual GO annotations
+  between related proteins based on shared sequence features.
+comments:
+- 'GO terms are manually assigned to each rule in UniRule. These rules are prepared
+  manually by UniProt curators based on the annotations present in reviewed UniProtKB/Swiss-Prot
+  records that share sequence features, sequence similarity and taxonomy. The assigned
+  GO terms are then transferred to all unreviewed UniProtKB/TrEMBL proteins that meet
+  the conditions given in the UniRule rule. GO annotations using this technique receive
+  the evidence code Inferred from Electronic Annotation (IEA; ECO:0000501). These
+  annotations are updated regularly by UniProt and are available for download on both
+  the GO and GOA EBI ftp sites. To report an annotation error or inconsistency, or
+  for further information, please contact the UniProt Automated Annotation team at
+  automated_annotation@ebi.ac.uk. UniRule is a collaboration between the European
+  Bioinformatics Institute (EMBL-EBI), the Swiss Institute of Bioinformatics (SIB),
+  and the Protein Information Resource at Georgetown University (PIR). For further
+  information, please see UniProt: a hub for protein information Nucleic Acids Res.
+  2015, 43, D204, doi: 10.1093/nar/gku989 or www.uniprot.org.'
+---
+authors: UniProt-GOA
+id: GO_REF:0000044
+external_accession:
+- TAIR:AnalysisReference:501756971
+- TAIR:AnalysisReference:50175724
+year: 2012
+layout: goref
+title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+  vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt.
+comments:
+- "Transitive assignment of GO terms based on the UniProtKB/Swiss-Prot Subcellular\
+  \ Location vocabulary. UniProtKB Subcellular Location is a controlled vocabulary\
+  \ used to supply subcellular location information to UniProtKB entries in the SUBCELLULAR\
+  \ LOCATION lines. Terms from this vocabulary are annotated manually to UniProtKB/Swiss-Prot\
+  \ entries but are automatically assigned to UniProtKB/TrEMBL entries from the underlying\
+  \ nucleic acid databases and/or by the UniProt automatic annotation program.\nFurther\
+  \ information on these two different annotation methods is available https://www.uniprot.org/help/keywords.\
+  \ \nWhen a UniProtKB Subcellular Location term describes a concept that is within\
+  \ the scope of the Gene Ontology, a mapping is manually made to the corresponding\
+  \ GO term. The translation table between GO terms and UniProtKB Subcellular Location\
+  \ term is maintained by the EBI GOA team and available at http://www.geneontology.org/external2go/spsl2go."
+---
+authors: GO ontology editors
+id: GO_REF:0000083
+year: 2013
+layout: goref
+title: Representation of plant morphogenesis as biological process in the Gene Ontology
+comments:
+- We have created a standard template for classes describing the morphogenesis of
+  a plant structure as a biological process. The underlying equivalence axiom template
+  is "'anatomical structure morphogenesis' and 'results in morphogenesis of' some
+  P", where P is a plant anatomical entity (PO:0025131).
+---
+authors: GO ontology editors
+id: GO_REF:0000070
+year: 2013
+layout: goref
+title: Representation of transmembrane transporter activity as molecular function
+  in the Gene Ontology
+comments:
+- 'We have created a standard template for classes describing the transmembrane transporter
+  activity a chemical entity (ChEBI) as molecular function. This includes variants
+  for secondary active transmembrane transporter activity (GO:0015291), uptake transmembrane
+  transporter activity (GO:0015563), and ATPase activity, coupled to transmembrane
+  movement of substances (GO:0042626). The underlying equivalence axiom template is
+  "G and ''transports or maintains localization of'' some X",  where the genus G is
+  either GO:0022857 (transmembrane transporter activity), GO:0015291, GO:0015563,
+  or GO:0042626 depending on the variant. The variable X is a chemical entity (CHEBI:24431).
+  The approach to combine GO and ChEBI has been described in the following publication:
+  PMID:23895341.'
+---
+authors: Judith Blake (1, 2), William Bug (3), Rex Chisholm (1, 4), Jennifer Clark
+  (1, 5), Erika Feltrin (6), Jacqueline Finger (2), David Hill (1, 2), Midori Harris
+  (1, 5), Terry Hayamizu (2), Doug Howe (9), Maryanne Martone (7), Kathleen Millen
+  (8), Francis Sele (4) (1. The Gene Ontology Consortium, 2. Mouse Genome Informatics,
+  Bar Harbor, ME, 3. Drexel University, Philadelphia, PA, 4. Northwestern University,
+  Chicago, IL, 5. EMBL-EBI, Hinxton, Cambridgeshire, UK, 6. The University of Padua,
+  Padua, Italy, 7. The University of California at San Diego, San Diego, CA, 8. The
+  University of Chicago, Chicago, IL, 9. The Zebrafish Information Network, University
+  of Oregon, Eugene, OR)
+id: GO_REF:0000021
+year: 2006
+layout: goref
+title: Improving the representation of central nervous system development in the biological
+  process ontology
+comments:
+- 'Current genetic and molecular studies in many model organisms are aimed at understanding
+  formation and development of the nervous system. Up until this point, the GO has
+  had a very shallow representation of processes pertaining to the nervous system.
+  In June 2006, curators from MGI and ZFIN met with researchers studying central nervous
+  system development to improve the representation of these processes in GO. In particular,
+  emphasis was placed on three areas that are being addressed actively in current
+  research: forebrain development, hindbrain development and neural tube development.
+  This collaboration resulted in the addition of over 500 terms that reflect the development
+  of the forebrain, the hindbrain, and the neural tube from the perspective of biological
+  process and anatomical structure.'
+---
+authors: Alexander D. Diehl, Alison Deckhut Augustine, Judith A. Blake, Lindsay G.
+  Cowell, Elizabeth S. Gold, Timothy A. Gondre-Lewis, Anna Maria Masci, Terrence F.
+  Meehan, Penelope A. Morel, Anastasia Nijnik, Bjoern Peters, Bali Pulendran, Richard
+  H. Scheuermann, Q. Alison Yao, Martin S. Zand, Christopher J. Mungall
+id: GO_REF:0000031
+url: http://www.bioontology.org/wiki/index.php/NIAID_Cell_Ontology_Workshop_May_2008
+year: 2008
+is_obsolete: true
+layout: goref
+title: OBSOLETE NIAID Cell Ontology Workshop
+comments:
+- The NIAID sponsored a Cell Ontology Workshop, May 13-14, 2008, in Bethesda, focusing
+  on improving representation of immune cell types in the Cell Ontology. The participants
+  in the workshop worked together to extend the current ontology in the area of immune
+  cell types and to provide the necessary information for the upcoming restructuring
+  of the Cell Ontology in single-inheritance form with genus-differentia definitions.
+---
+authors: GO ontology editors
+id: GO_REF:0000060
+year: 2013
+layout: goref
+title: Representation of processes involved in other process in the Gene Ontology
+comments:
+- We have created a standard template for classes describing processes involved in
+  other processes. The underlying equivalence axiom template is "P and 'part_of' some
+  W", where P and W are biological processes.
+---
+authors: GO ontology editors
+id: GO_REF:0000093
+year: 2014
+layout: goref
+title: Representation for the degradation to or via a chemical as biological process
+  in the Gene Ontology
+comments:
+- 'We have created a standard template for classes describing the degradation of a
+  chemical entity to or via an other chemical entity as biological processes. The
+  underlying equivalence axiom templates are "GO:0009056 and ''has input'' some S
+  and ''has output'' some T" (catabolism to) and "GO:0009056 and ''has input'' some
+  S and ''has intermediate'' some I" (catabolism via), where S,T, and I are chemical
+  entities (CHEBI:24431). The approach to combine GO and ChEBI has been described
+  in the following publication: PMID:23895341.'
+---
+authors: LIFEdb
+id: GO_REF:0000054
+year: 2013
+layout: goref
+title: Gene Ontology annotation based on curation of intracellular localizations of
+  expressed fusion proteins in living cells.
+comments:
+- 'LIFEdb is a database that was created to manage the experimental data produced
+  by the German Cancer Research Institute (DKFZ) and its collaborators, from work
+  on cDNAs contained in the German cDNA Consortium collection. <br>A novel cloning
+  technology was used to rapidly generate N- and C-terminal green fluorescent protein
+  fusions of cDNAs to examine the intracellular localizations of expressed fusion
+  proteins in living cells. GO Cellular Component terms are manually assigned by curators
+  studying fluorescence microscope images of cells labelled with GFP-fused cDNAs.
+  Protein coding regions of novel full length cDNAs are tagged with the coding sequence
+  of the green fluorescent protein, the fusion proteins are then expressed and analyzed
+  for their subcellular localization. <br>Prior to February 2013, all LIFEdb annotations
+  were referenced by PMID: 11256614 (Simpson et al. 2000 EMBO Rep. 1:287-292), a paper
+  describing the protein subcellular localization pilot study and methodology used
+  by LIFEdb. However, it has been decided that these annotations are more correctly
+  described by a GO reference. <br>Resource URL: http://www.dkfz.de/en/mga/Groups/LIFEdb-Database.html
+  <br>Protein subcellular localization images can be viewed on the LIFEdb website,
+  http://www.dkfz.de/gpcf/lifedb.php'
+---
+authors: Birgit Meldal and Sandra Orchard (1). (1) European Bioinformatics Institute
+  (EBI), Hinxton, Cambridgeshire, United Kingdom
+id: GO_REF:0000114
+year: 2018
+layout: goref
+title: Manual transfer of experimentally-verified manual GO annotation data to homologous
+  complexes by curator judgment of sequence, composition and function similarity
+comments:
+- Method for transferring manual annotations to an entry based on a curator's judgment
+  of its similarity to a putative homolog that has annotations that are supported
+  with experimental evidence. Annotations are created when a curator judges that the
+  sequence, composition and function of a complex shows high similarity to another
+  complex that has annotation(s) supported by experimental evidence (and therefore
+  display one of the evidence codes ECO:0000353 [IPI] or ECO:0005543). Annotations
+  resulting from the transfer of GO terms display the ECO:0005610, ECO:0005544 or
+  ECO:0005546 evidence codes and include an accession for the complex from which the
+  annotation was projected in the 'with/from' field (column 8). This field MUST contain
+  a Complex Portal accession identifier. Putative homologs are chosen using information
+  combined from a variety of complementary sources. Potential homologs are initially
+  identified using sequence similarity search programs such as BLAST. Homologous relationships
+  are then verified manually using a combination of resources including sequence analysis
+  tools, phylogenetic and comparative genomics databases such as Ensembl Compara,
+  INPARANOID and OrthoMCL, as well as other specialised databases such as species-specific
+  collections (e.g. HGNC's HCOP). In all cases curators check the alignments for each
+  complex component and use their experience to assess whether similarity is considered
+  to be strong enough to infer that the two proteins have a common function so that
+  they can confidently project an annotation. While there is no fixed cut-off point
+  in percentage sequence similarity, generally proteins which have greater than 70%
+  identity that covers greater than 90% of the length of both proteins are examined
+  further. Whilst we expect subunit composition to be conserved between closely related
+  species, this is not an absolute rule and orthologous complexes may differ if a
+  subunit cannot be traced in one species or is experimentally shown not to be present.
+  When there is evidence of multiple paralogs for a single species, multiple variants
+  of the complex can be inferred.
+---
+authors: FlyBase
+external_accession:
+- FB:FBrf0145624
+id: GO_REF:0000105
+year: 2016
+layout: goref
+title: Gene Ontology annotation of transfer RNAs based on tRNAscan-SE analysis of
+  the Drosophila melanogaster genome (2002).
+comments:
+- 'Gene Ontology annotation based on predicted cytoplasmic tRNAs using tRNAscan-SE
+  analysis (doi: 10.1093/nar/25.5.0955) of the Drosophila melanogaster genome (2002).
+  Annotations have been reviewed by FlyBase (2015) and found to be consistent when
+  compared with the most recent tRNAscan-SE analysis of the genome (http://gtrnadb.ucsc.edu/genomes/eukaryota/Dmela6/).'
+---
+authors: UniProt-GOA
+id: GO_REF:0000045
+is_obsolete: true
+year: 2012
+layout: goref
+title: OBSOLETE Gene Ontology annotation based on UniProtKB/TrEMBL entries keyword
+  mapping, accompanied by conservative changes to GO terms applied by UniProt.
+comments:
+- "Transitive assignments using UniProtKB/TrEMBL keywords. The UniProtKB keyword controlled\
+  \ vocabulary has been created and used by the UniProt Knowledgebase (UniProtKB)\
+  \ to supply 10 different categories of information to UniProtKB/TrEMBL entries entries.\
+  \ Further information on the UniProtKB keyword resource can be found at http://www.uniprot.org/docs/keywlist.<br>UniProtKB\
+  \ keywords are assigned to UniProtKB/UniProtKB entries by UniProt curators as part\
+  \ of the UniProtKB manual curation process. In contrast however, UniProtKB keywords\
+  \ are automatically assigned to UniProtKB/TrEMBL entries from the underlying nucleic\
+  \ acid databases and/or by the UniProt automatic annotation program.<br>Further\
+  \ information on the two different UniProt annotation methods is available at http://www.uniprot.org/faq/45\
+  \ and http://www.uniprot.org/program/automatic_annotation.<br>When a UniProtKB keyword\
+  \ describes a concept that is within the scope of the Gene Ontology, it is investigated\
+  \ to determine whether it is appropriate to map the keyword to an equivalent term\
+  \ in GO. The translation table between GO terms and UniProtKB keywords is maintained\
+  \ by the UniProt-GOA team and available at http://www.geneontology.org/external2go/uniprotkb_kw2go.<br>Please\
+  \ note that the GO term in the annotation assigned with this GO reference has been\
+  \ changed from that originally applied by the UniProtKB keywords 2GO mapping. This\
+  \ change has been carried out by the UniProt group to ensure the GO annotation obeys\
+  \ the GO Consortium\u2019s ontology structure and taxonomic constraints. Further\
+  \ information on the rules used by UniProt to transform specific incorrect IEA annotations\
+  \ is available at http://www.ebi.ac.uk/QuickGO/AnnotationPostProcessing.html."
+- Duplicate of GO_REF:0000004.
+---
+authors: GO ontology editors
+id: GO_REF:0000082
+is_obsolete: true
+year: 2013
+layout: goref
+title: OBSOLETE Representation of plant maturation as biological process in the Gene
+  Ontology
+comments:
+- We have created a standard template for classes describing the maturation of a plant
+  structure as a biological process. The underlying equivalence axiom template is
+  "'developmental maturation' and 'results in developmental progression of' some P",
+  where P is a plant anatomical entity (PO:0025131).
+---
+authors: GO ontology editors
+id: GO_REF:0000071
+year: 2013
+layout: goref
+title: Representation of response to and cellular response to a chemical as biological
+  process in the Gene Ontology
+comments:
+- 'We have created a standard template for classes describing the response to and
+  cellular response to a chemical entity (ChEBI) as a biological process. The underlying
+  equivalence axiom templates are "GO:0050896 and ''has input'' some X" (response
+  to) and "GO:0070887 and ''has input'' some X" (cellular response to), where X is
+  a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI has been described
+  in the following publication: PMID:23895341.'
+---
+authors: Swiss Institute of Bioinformatics (SIB) curators, GOA curators
+id: GO_REF:0000020
+year: 2006
+layout: goref
+title: Electronic Gene Ontology annotations created by transferring manual GO annotations
+  between orthologous microbial proteins
+comments:
+- 'GO terms are manually assigned to each HAMAP family rule. High-quality Automated
+  and Manual Annotation of microbial Proteins (HAMAP) family rules are a collection
+  of orthologous microbial protein families, from bacteria, archaea and plastids,
+  generated manually by expert curators. The assigned GO terms are then transferred
+  to all the proteins that belong to each HAMAP family. Only GO terms from the molecular
+  function and biological process ontologies are assigned. GO annotations using this
+  technique will receive the evidence code Inferred from Electronic Annotation (IEA).
+  These annotations are updated monthly by HAMAP and are available for download on
+  both GO and GOA EBI ftp sites. To report an annotation error or inconsistency, or
+  for further information, please contact the GO Consortium at gohelp@genome.stanford.edu
+  or submit a comment the SourceForge Annotation Issues tracker (http://sourceforge.net/projects/geneontology/).
+  HAMAP is a project based at the Swiss Institute of Bioinformatics (Gattiker et al.
+  2003, Comp. Biol and Chem. 27: 49-58). For further information, please see http://www.expasy.org/sprot/hamap/.'
+---
+authors: Daniel Haft, JCVI
+id: GO_REF:0000030
+year: 2008
+is_obsolete: true
+layout: goref
+title: OBSOLETE Portable Annotation Rules
+comments:
+- The JCVI is developing a collection of mixed-evidence annotation rules, under the
+  working name BrainGrab/RuleBase (BGRB). A rule has two parts. The first is the set
+  of conditions that must be met for the rule to fire. The second is the set actions
+  to be taken for rules that have fired. BGRB rules are designed to serve as proxies
+  for the annotators that create them. They have very high fidelity but may have low
+  coverage. Types of evidence used in combination include HMM hits and BLAST matches,
+  hits to neighboring genes, pathway reconstruction reports from the Genome Properties
+  system, and species taxonomy. BLAST matches are described by a number of separate
+  parameters for raw score, percent sequence identity, and coverage of total sequence
+  length by the match region. These parameters are customized for each protein family
+  in order to achieve high fidelity in automated annotation systems. The flexible
+  syntax makes it possible to use existing protein family classifiers, such as Pfam
+  and TIGRFAMs HMMs, in new ways. It is especially useful in assigning GO terms to
+  proteins such as SelD (selenide, water dikinase) that have different roles in different
+  contexts.
+---
+authors: GO ontology editors
+id: GO_REF:0000061
+year: 2013
+layout: goref
+title: Representation of a molecular function involved in a biological process in
+  the Gene Ontology
+comments:
+- We have created a standard template for classes describing molecular function involved
+  in other biological processes. The underlying equivalence axiom template is "P and
+  'part_of' some W", where P is a molecular function and W is a biological processes.
+---
+authors: GO ontology editors
+id: GO_REF:0000092
+year: 2014
+layout: goref
+title: Representation for the biosynthesis from or via a chemical as biological process
+  in the Gene Ontology
+comments:
+- 'We have created a standard template for classes describing the biosynthesis of
+  a chemical entity from or via an other chemical entity as biological processes.
+  The underlying equivalence axiom templates are "GO:0009058 and ''has output'' some
+  T and ''has input'' some F" (biosynthesis from) and "GO:0009058 and ''has output''
+  some T and ''has intermediate'' some I" (biosynthesis via), where T,F, and I are
+  chemical entities (CHEBI:24431). The approach to combine GO and ChEBI has been described
+  in the following publication: PMID:23895341.'
+---
+authors: AgBase biocurators
+id: GO_REF:0000055
+year: 2013
+is_obsolete: true
+layout: goref
+title: OBSOLETE Gene Ontology Cellular Component annotation based on cellular fractionation.
+comments:
+- Assignment of GO Cellular Component terms based on experimental evidence of cellular
+  localization from Differential Detergent Fractionation (DDF). Cellular proteins
+  are differentially fractionated and detected using mass spectrometry. Subcellular
+  localization is based upon identification of proteins in different fractions and
+  analysis of their predicted transmembrane domains. Proteins are assigned GO CC based
+  upon a manually reviewed DDF2GO mapping file.
+---
+authors: RNAcentral (1). (1) European Bioinformatics Institute (EMBL-EBI), Hinxton,
+  Cambridgeshire, United Kingdom
+id: GO_REF:0000115
+year: 2018
+layout: goref
+title: Automatic Gene Ontology annotation of non-coding RNA sequences through association
+  of Rfam records with GO terms
+comments:
+- "Rfam (http://rfam.org, PMID:29112718) is a database of non-coding RNA families\
+  \ which are manually\nannotated with GO terms by Rfam curators. RNAcentral (http://rnacentral.org,\
+  \ PMID:27794554) maintains\na comprehensive collection of non-coding RNA sequences\
+  \ that are regularly annotated with Rfam families\nusing the Infernal software (PMID:24008419).\
+  \ When a non-coding RNA sequence is matched to one or more Rfam families\nby sequence\
+  \ similarity, the GO terms associated with the Rfam family are transitively assigned\
+  \ to the non-coding RNA sequence.\nAnnotations resulting from the transfer of GO\
+  \ terms are assigned the ECO:0000256 evidence code\n(match to sequence model evidence\
+  \ used in automatic assertion) and include RNAcentral and Rfam accessions. \nThe\
+  \ annotations are available on the GOA and EMBL-EBI FTP sites. \nThe mapping between\
+  \ Rfam families and GO terms is available at http://www.geneontology.org/external2go/rfam2go,\
+  \ \nand the Infernal software can be downloaded at http://eddylab.org/infernal.\
+  \ To report an annotation error or inconsistency, \nor for further information,\
+  \ please visit the RNAcentral website at http://rnacentral.org."
+---
+alt_id:
+- GO_REF:0000009
+- GO_REF:0000013
+authors: GOA curators
+external_accession:
+- MGI:1354194
+- J:60000
+- ZFIN:ZDB-PUB-020723-1
+- SGD_REF:S000124038
+id: GO_REF:0000004
+year: 2000
+layout: goref
+title: Gene Ontology annotation based on UniProtKB keyword mapping.
+comments:
+- 'Transitive assignments using UniProtKB keywords. The UniProtKB keyword controlled
+  vocabulary has been created and used by the UniProt Knowledgebase (UniProtKB) to
+  supply 10 different categories of information to UniProtKB entries. Further information
+  on the UniProtKB keyword resource can be found at http://www.uniprot.org/docs/keywlist.
+  <br>Further information on the UniProt annotation methods is available at  https://www.uniprot.org/help/manual_curation
+  and https://www.uniprot.org/help/automatic_annotation.
+
+  <br>When a UniProtKB keyword describes a concept that is within the scope of the
+  Gene Ontology, it is investigated to determine whether it is appropriate to map
+  the keyword to an equivalent term in GO. The mapping between UniProtKB keywords
+  and GO terms is carried out manually. Definitions and hierarchies of the terms in
+  the two resources are compared and the mapping generated will reflect the most correct
+  correspondence. The translation table between GO terms and UniProtKB keywords is
+  maintained by the UniProt-GOA team and available at http://www.geneontology.org/external2go/uniprotkb_kw2go.'
+- Formerly GOA:spkw.
+---
+authors: GO ontology editors
+id: GO_REF:0000086
+year: 2013
+layout: goref
+title: Representation of cell differentiation as biological process in the Gene Ontology
+comments:
+- We have created a standard template for classes describing the differentiation process
+  for a cell type as a biological process. The underlying equivalence axiom template
+  is "GO:0030154 and 'results in acquisition of features of' some C", where C is a
+  native cell (CL:0000003).
+---
+authors: AgBase, BHF-UCL, Parkinson's UK-UCL, dictyBase, HGNC, Roslin Institute, FlyBase
+  and UniProtKB curators.
+external_accession:
+- dictyBase_REF:9
+- J:73065
+- J:104715
+- FB:FBrf0202953
+- FB:FBrf0212479
+- FB:FBrf0232278
+- FB:FBrf0232279
+id: GO_REF:0000024
+url: http://www.ebi.ac.uk/GOA/ISS_method.html
+year: 2011
+layout: goref
+title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+  by curator judgment of sequence similarity.
+comments:
+- 'Method for transferring manual annotations to an entry based on a curator''s judgment
+  of its similarity to a putative ortholog that has annotations that are supported
+  with experimental evidence. Annotations are created when a curator judges that the
+  sequence of a protein shows high similarity to another protein that has annotation(s)
+  supported by experimental evidence (and therefore display one of the evidence codes
+  EXP, IDA, IGI, IMP, IPI or IEP). Annotations resulting from the transfer of GO terms
+  display the ''ISS'' evidence code and include an accession for the protein from
+  which the annotation was projected in the ''with'' field (column 8). This field
+  can contain either a UniProtKB accession or an IPI (International Protein Index)
+  identifier. Only annotations with an experimental evidence code and which do not
+  have the ''NOT'' qualifier are transferred. Putative orthologs are chosen using
+  information combined from a variety of complementary sources. Potential orthologs
+  are initially identified using sequence similarity search programs such as BLAST.
+  Orthology relationships are then verified manually using a combination of resources
+  including sequence analysis tools, phylogenetic and comparative genomics databases
+  such as Ensembl Compara, INPARANOID and OrthoMCL, as well as other specialised databases
+  such as species-specific collections (e.g. HGNC''s HCOP). In all cases curators
+  check each alignment and use their experience to assess whether similarity is considered
+  to be strong enough to infer that the two proteins have a common function so that
+  they can confidently project an annotation. While there is no fixed cut-off point
+  in percentage sequence similarity, generally proteins which have greater than 30%
+  identity that covers greater than 80% of the length of both proteins are examined
+  further. For mammalian proteins this cut-off tends to be higher, with an average
+  of 80% identity over 90% of the length of both proteins. Strict orthologs are desirable
+  but not essential. In general, when there is evidence of multiple paralogs for a
+  single species, annotations using less specific GO terms are transferred to the
+  paralogs, however, annotations using more specific GO terms may be transferred to
+  the most similar paralog in each species, this decision is taken on a case by case
+  basis and may be influenced by statements by researchers in the field. Further detailed
+  information on this procedure, including how ISS annotations are made to protein
+  isoforms, can be found at: http://www.ebi.ac.uk/GOA/ISS_method.html.'
+---
+authors: GO ontology editors
+id: GO_REF:0000075
+year: 2013
+layout: goref
+title: Representation of transport of a chemical into a cellular component as biological
+  process in the Gene Ontology
+comments:
+- 'We have created a standard template for classes describing the transport of a chemical
+  entity (ChEBI) into a cellular component as a biological process. The underlying
+  equivalence axiom template is "GO:0006810 and ''has_target_end_location'' some T
+  and ''imports'' some S", where T is a cellular component and S is a chemical entity
+  (CHEBI:24431). The approach to combine GO and ChEBI has been described in the following
+  publication: PMID:23895341.'
+---
+authors: Sascha Steinbiss, GeneDB curators
+id: GO_REF:0000101
+year: 2015
+layout: goref
+title: Automated transfer of experimentally-verified GO annotation data to close orthologs
+comments:
+- This reference is used to describe functional annotations transferred from one or
+  more reference ("source") organisms to a newly annotated ("target") organism on
+  the basis of ortholog cluster membership. In detail, predicted (e.g. by AUGUSTUS,
+  see doi:10.1186/1471-2105-7-62) or transferred (e.g. via RATT, see doi:10:1093/nar/gkg1268)
+  gene models in the target genome are translated and processed by OrthoMCL 1.4 together
+  with reference protein sequences to produce clusters of gene products derived from
+  orthologous genes. For each cluster, GO terms are automatically transferred from
+  source products to the target gene products if they are experimentally verified
+  (IDA (ECO:0000314), IMP (ECO:0000315), IPI (ECO:0000353), IGI (ECO:0000316), (EXP
+  ECO:0000269). They are tagged with the ISO evidence code and the "with/from" is
+  populated with the source feature references (e.g. "GeneDB:LmjF.28.0960"). OrthoMCL
+  runs are done using the parameterization suggested in the OrthoMCL algorithm document
+  (blastall -F 'm S' -e 1e-5).
+---
+authors: UniProt-GOA
+external_accession:
+- ZFIN:ZDB-PUB-130131-1
+id: GO_REF:0000041
+year: 2012
+layout: goref
+title: Gene Ontology annotation based on UniPathway vocabulary mapping.
+comments:
+- Transitive assignment of GO terms based on the UniPathway pathway vocabulary. UniPathway
+  is a manually curated resource of enzyme-catalyzed and spontaneous chemical reactions.
+  It provides a hierarchical representation of metabolic pathways. Descriptions of
+  the pathway(s) that a particular protein is involved in are included in UniProtKB
+  records.<br>UniPathway data are cross-linked to existing pathway resources such
+  as KEGG and MetaCyc. Further information on the UniPathway resource is available
+  at http://www.unipathway.org/obiwarehouse/unipathway.<br>When a UniPathway pathway
+  describes a concept that is within the scope of the Gene Ontology, it is investigated
+  to determine whether it is appropriate to map the term to an equivalent term in
+  GO. The mapping between UniPathway terms and GO terms is carried out manually. Definitions
+  and hierarchies of the terms in the two resources are compared and the mapping generated
+  will reflect the most correct correspondence. The translation table between GO terms
+  and UniPathway pathways is maintained by the UniPathway team and is available at
+  http://www.grenoble.prabi.fr/dev/obiwarehouse/download/unipathway/public/unipathway2go.tsv.
+---
+authors: Mouse Genome Informatics scientific curators
+citation: PMID:11374909
+external_accession:
+- MGI:1347124
+- J:56000
+id: GO_REF:0000010
+is_obsolete: true
+year: 1999
+layout: goref
+title: OBSOLETE Gene Ontology annotation by the MGI curatorial staff, mouse gene nomenclature
+comments:
+- For annotations documented via this citation, curators designed queries based on
+  their knowledge of mouse gene nomenclature to group genes that shared common molecular
+  functions, biological processes or cellular components. GO annotations were assigned
+  to these genes in groups. Details of this strategy can be found in Hill et al.,
+  Genomics (2001) 74:121-128.
+---
+authors: PomBase curators
+id: GO_REF:0000051
+year: 2012
+layout: goref
+title: S. pombe keyword mapping
+comments:
+- Active 2006-2012.
+- Keywords derived from manually curated primary annotation, e.g. gene product descriptions,
+  are mapped to GO terms. Annotations made by this method have the evidence code Non-traceable
+  Author Statement (NAS), and are filtered from the PomBase annotation files wherever
+  another annotation exists that is equally or more specific, and supported by experimental
+  or manually evaluated comparative evidence (such as ISS and its subtypes). Formerly
+  GOC:pombekw2GO.
+---
+authors: TBD
+external_accession:
+- FB:FBrf0233689
+id: GO_REF:0000111
+year: 2016
+layout: goref
+title: Gene Ontology annotations Inferred by Curator (IC) using at least one Inferred
+  by Sequence Similarity (ISS) annotation to support the inference
+comments:
+- "The Gene Ontology Consortium uses the IC (Inferred by Curator; ECO:0000305) evidence\
+  \ code when assignment of a GO term cannot be supported by direct experimental or\
+  \ sequence-based evidence, but can, based on a curator\u2019s biological knowledge,\
+  \ be reasonably inferred from existing GO annotations to the same gene/gene product.\
+  \  Use of the IC evidence code with GO_REF:0000111 indicates that a curator inferred\
+  \ the GO term based on at least one supporting annotation with an 'Inferred from\
+  \ Sequence Similarity' (ISS; ECO:0000250) evidence code.  Note that additional supporting\
+  \ annotations may be experimentally evidenced. When using GO_REF:0000111, the 'with/from'\
+  \ field must contain all GO identifiers used as supporting annotations."
+---
+authors: GO ontology editors
+id: GO_REF:0000065
+year: 2013
+layout: goref
+title: Representation of transport of a chemical entity as a biological process in
+  the Gene Ontology
+comments:
+- 'We have created a standard template for classes describing transport of a chemical
+  entity (ChEBI) as a biological process. The underlying equivalence axiom template
+  is "GO:0006810 and ''transports or maintains localization of'' some X", where X
+  is a chemical entity (CHEBI:24431). The approach to combine GO and ChEBI has been
+  described in the following publication: PMID:23895341.'
+---
+authors: Brian K. Hall (Dalhousie University), Matthew Vickaryous (Ontario Veterinary
+  College, University of Guelph), David Blackburn, University of Kansas; Wasila Dahdul,
+  University of South Dakota and NESCent; Alexander Diehl, Mouse Genome Informatics
+  (MGI); Melissa Haendel, Oregon Health Sciences University; John G. Lundberg, Department
+  of Ichthyology, Academy of Natural Sciences, Philadelphia; Paula Mabee, Department
+  of Biology, University of South Dakota; Martin Ringwald, Mouse Genome Informatics
+  (MGI); Erik Segerdell, Oregon Health Sciences University; Ceri Van Slyke, Zebrafish
+  Information Network (ZFIN); Monte Westerfield, Zebrafish Information Network (ZFIN)
+  and Institute of Neuroscience, University of Oregon.
+id: GO_REF:0000034
+year: 2010
+layout: goref
+title: Phenoscape Skeletal Anatomy Jamboree
+comments:
+- Skeletal cell terms and relationships were added and revised at the Skeletal Anatomy
+  Jamboree held by Phenoscape (NSF grant BDI-0641025) and hosted by the National Evolutionary
+  Synthesis Center (NESCent), April 9-10, 2010.
+---
+authors: Mouse Genome Informatics scientific curators
+external_accession:
+- J:164563
+- J:155856
+- RGD:1624291
+id: GO_REF:0000096
+year: 2014
+layout: goref
+title: Automated transfer of experimentally-verified manual GO annotation data to
+  close orthologs.
+comments:
+- 'Mouse Genome Database (MGD), The HUGO Gene Nomenclature Committee (HGNC), and Rat
+  Genome Database (RGD) have extensive procedures in place, overseen by expert curation,
+  to establish orthology relationships between their genes. The Experimentally based
+  annotations annotated by each group (IDA, IMP IPI, IGI, and EXP) are used to provide
+  annotations  to the respective mouse and rat orthologs, and given the ISO evidence
+  code and an entry in the inferred_from field to indicate the orthologous entity. '
+---
+authors: GO ontology editors
+id: GO_REF:0000089
+year: 2013
+layout: goref
+title: Representation of single-organism and multi-organism biological processes in
+  the Gene Ontology
+comments:
+- We have created a standard template for classes describing the single-organism and
+  multi-organism biological processes. The underlying equivalence axiom templates
+  are "P and 'bearer_of' some PATO:0002487" (single-organism) and "P and 'bearer_of'
+  some PATO:0002486" (multi-organism), where P is a biological process.
+---
+authors: FlyBase
+id: GO_REF:0000099
+is_obsolete: true
+year: 2014
+layout: goref
+title: OBSOLETE Gene Ontology annotation based on DNA/RNA sequence records
+comments:
+- Prior to 2005, FlyBase made GO annotations based on information in DNA/RNA sequence
+  records in GenBank/EMBL/DDBJ. We no longer add GO annotations based on sequence
+  records and gradually replacing these GO annotations as other sources of evidence
+  become available.
+---
+authors: GO ontology editors
+id: GO_REF:0000088
+year: 2013
+layout: goref
+title: Representation of protein complex by molecular function in the Gene Ontology
+comments:
+- We have created a standard template for classes defining a protein complex by a
+  molecular function as a cellular component. The underlying equivalence axiom template
+  is "GO:0043234 and 'capable_of' some ?A", where A is a molecular function.
+---
+authors: FlyBase
+id: GO_REF:0000098
+is_obsolete: true
+year: 2014
+layout: goref
+title: OBSOLETE Gene Ontology annotation based on research conference abstracts
+comments:
+- Prior to 2008, FlyBase made GO annotations based on information in abstracts for
+  research conferences, primarily the Annual Drosophila Research Conference and the
+  European Drosophila Research Conference. We no longer curate conference abstracts
+  and we are gradually replacing all abstract-based GO annotation with annotation
+  based on experimental data in primary research papers.

--- a/scripts/goref_parser/parser.py
+++ b/scripts/goref_parser/parser.py
@@ -1,6 +1,6 @@
-from email import header
 import os
 import sys
+import json
 import logging
 
 sys.path.append("../parser/goref.py")
@@ -10,6 +10,7 @@ sys.path.append("../parser/utils.py")
 from utils import get_html_string, merge_dicts
 
 import yaml
+import ruamel.yaml
 import markdown
 
 
@@ -22,7 +23,14 @@ if __name__ == "__main__":
     for file_name in os.listdir("metadata/gorefs/"):
         if any(
             non_goref in file_name
-            for non_goref in ["README-editors.md", "Makefile", "README.md"]
+            for non_goref in [
+                "README-editors.md",
+                "Makefile",
+                "README.md",
+                "gorefs.yaml",
+                "gorefs.json",
+                "gorefs.schema.json",
+            ]
         ):
             continue
 
@@ -68,4 +76,9 @@ if __name__ == "__main__":
     # export combined list of yamldown dicts compiled from all gorefs
     # and export to YAML
     with open("gorefs.yaml", "w") as outfile:
-        yaml.dump_all(combined_dict_list, outfile, sort_keys=False)
+        yaml.dump(combined_dict_list, outfile, sort_keys=False)
+
+    # convert the dumped YAML file into JSON
+    with open("gorefs.yaml", "r") as yaml_in, open("gorefs.json", "w") as json_out:
+        yaml_object = ruamel.yaml.safe_load(yaml_in)
+        json.dump(yaml_object, json_out, indent=4)


### PR DESCRIPTION
Modify the goref parser so that it can generate a `gorefs.json` equivalent to `gorefs.yaml` so that it can be validated by the JSON Schema in PR #1814.