### PR TITLE
Fix typo in ORCID

### DIFF
--- a/metadata/users.yaml
+++ b/metadata/users.yaml
@@ -1172,7 +1172,7 @@
     - 'http://rgd.mcw.edu'
   nickname: 'Stan Laulederkind'
   organization: RGD
-  uri: 'https://orcid.org/0000-0001-5356-4174-4174'
+  uri: 'https://orcid.org/0000-0001-5356-4174'
   xref: 'GOC:sl'
 -
   nickname: 'Simon Twigger'


### PR DESCRIPTION
The ORCID for Stan Laulederkind has a duplicated segment.