### PR TITLE
Update db-xrefs.yaml for new Xenbase URIs

### DIFF
--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -2843,27 +2843,27 @@
     - type_name: gene
       type_id: SO:0000704
       id_syntax: XB-(GENE|LINE|TRANSGENE|MORPHOLINO)-[0-9]+
-      url_syntax: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=[example_id]
+      url_syntax: http://www.xenbase.org/entry/[example_id]
       example_id: Xenbase:XB-GENE-6255962
-      example_url: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=XB-GENE-6255962
+      example_url: http://www.xenbase.org/entry/XB-GENE-6255962
     - type_name: morpholino oligo
       type_id: SO:0000034
       id_syntax: XB-(GENE|LINE|TRANSGENE|MORPHOLINO)-[0-9]+
-      url_syntax: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=[example_id]
+      url_syntax: http://www.xenbase.org/entry/[example_id]
       example_id: Xenbase:XB-MORPHOLINO-17250301
-      example_url: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=XB-MORPHOLINO-17250301
+      example_url: http://www.xenbase.org/entry/XB-MORPHOLINO-17250301
     - type_name: transgene
       type_id: SO:0000902
       id_syntax: XB-(GENE|LINE|TRANSGENE|MORPHOLINO)-[0-9]+
-      url_syntax: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=[example_id]
+      url_syntax: http://www.xenbase.org/entry/[example_id]
       example_id: Xenbase:XB-TRANSGENE-17326811
-      example_url: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=XB-TRANSGENE-17326811
+      example_url: http://www.xenbase.org/entry/XB-TRANSGENE-17326811
     - type_name: strain
       type_id: EFO:0005135
       id_syntax: XB-(GENE|LINE|TRANSGENE|MORPHOLINO)-[0-9]+
-      url_syntax: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=[example_id]
+      url_syntax: http://www.xenbase.org/entry/[example_id]
       example_id: Xenbase:XB-LINE-1248
-      example_url: http://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=XB-LINE-1248
+      example_url: http://www.xenbase.org/entry/XB-LINE-1248
 - database: YeastFunc
   name: Yeast Function
   generic_urls:


### PR DESCRIPTION
This updates the URL syntax for Xenbase to our new simplified approach, the old ones may be non-functional due to rearrangements of our site code.