### PR TITLE
Update users.yaml

### DIFF
--- a/metadata/users.yaml
+++ b/metadata/users.yaml
@@ -1239,6 +1239,11 @@
   uri: 'GOC:sgd_curators'
   xref: 'GOC:sgd_curators'
 -
+  nickname: 'Curators at Reactome'
+  organization: Reactome
+  uri: 'GOC:reactome_curators'
+  xref: 'GOC:reactome_curators'
+-
   authorizations:
     noctua:
       go:


### PR DESCRIPTION
To complement https://github.com/geneontology/pathways2GO/issues/126.

We need some value for the contributor field for Reactome models. Without curator data available in the BioPAX, we can just use this placeholder `GOC:reactome_curators` following the SGD solution (`GOC:sgd_curators`) used for the YeastPathways contributor field.

@deustp01 @cmungall @kltm This sound good?