### PR TITLE
Add PHI-base to db-xrefs.yaml

### DIFF
--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -1845,6 +1845,18 @@
   entity_types:
     - type_name: entity
       type_id: BET:0000000
+- database: PHI-base
+  name: Pathogen-Host Interactions Database
+  description: PHI-base catalogues experimentally verified pathogenicity, virulence and effector genes from fungal, Oomycete and bacterial pathogens, which infect animal, plant, fungal and insect hosts.
+  generic_urls:
+    - http://www.phi-base.org/
+  entity_types:
+    - type_name: entity
+      type_id: BET:0000000
+      id_syntax: 'PHI:[0-9]+'
+      url_syntax: http://www.phi-base.org/searchFacet.htm?queryTerm=PHI:[example_id]
+      example_id: PHI:3
+      example_url: http://www.phi-base.org/searchFacet.htm?queryTerm=PHI:3
 - database: PIR
   name: Protein Information Resource
   generic_urls:


### PR DESCRIPTION
This pull request adds an entry for PHI-base (the Pathogen-Host Interactions Database) to db-xrefs.yaml. I think this is needed so that PHI-base can be added to the QuickGO Assigned_by filters.

Note that the `description` states that PHI-base catalogues genes, but we actually only reuse gene and protein identifiers from other sources (Ensembl Genomes, UniProtKB, etc). The novel data we provide is on pathogen-host interactions, which is what the `entity_types` property describes: PHI:3 is an identifier for a pathogen-host interaction.

However, the next version of our database will be migrating away from pathogen-host interaction identifiers and towards gene identifiers (we might not preserve pathogen-host interaction identifiers at all), and the GAF data we've been submitting so far comes from a curation application (PHI-Canto) that is designed for this new database schema. So if the `entity_types` are intended to be cross-referenced to the GO annotations that we submit, it probably isn't ideal to use entities from what will become a legacy version of our database. Maybe none of this matters in practice, but I thought I should flag it up.