### PR TITLE
Update db-xrefs.yaml

### DIFF
--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -779,16 +779,16 @@
   synonyms:
     - FlyBase
     - FLYBASE
-  rdf_uri_prefix: http://identifiers.org/flybase/
+  rdf_uri_prefix: https://registry.identifiers.org/registry/fb
   generic_urls:
     - http://flybase.org/
   entity_types:
     - type_name: gene
       type_id: SO:0000704
       id_syntax: FBgn[0-9]{7}
-      url_syntax: http://flybase.org/reports/[example_id].html
+      url_syntax: https://www.alliancegenome.org/gene/FB:[example_id]
       example_id: FB:FBgn0000024
-      example_url: http://flybase.org/reports/FBgn0000024.html
+      example_url: https://www.alliancegenome.org/gene/FB:FBgn0000024
 - database: FBbt
   name: Drosophila gross anatomy
   rdf_uri_prefix: http://purl.obolibrary.org/obo/FBbt_
@@ -1554,22 +1554,22 @@
       example_id: MGD:Adcy9
 - database: MGI
   name: Mouse Genome Informatics
-  rdf_uri_prefix: https://identifiers.org/MGI
+  rdf_uri_prefix: https://registry.identifiers.org/registry/mgi
   generic_urls:
     - http://www.informatics.jax.org/
   entity_types:
     - type_name: gene
       type_id: SO:0000704
       id_syntax: MGI:[0-9]{5,}
-      url_syntax: http://www.informatics.jax.org/accession/[example_id]
+      url_syntax: https://www.alliancegenome.org/gene/[example_id]
       example_id: MGI:MGI:1345277
-      example_url: http://www.informatics.jax.org/accession/MGI:1345277
+      example_url: https://www.alliancegenome.org/gene/MGI:1345277
     - type_name: variation
       type_id: VariO:0001
       id_syntax: MGI:[0-9]{5,}
-      url_syntax: http://www.informatics.jax.org/accession/[example_id]
+      url_syntax: https://www.alliancegenome.org/allele/[example_id]
       example_id: MGI:MGI:3590672
-      example_url: http://www.informatics.jax.org/accession/MGI:3590672
+      example_url: https://www.alliancegenome.org/allele/MGI:3590672
 - database: MIPS_funcat
   name: MIPS Functional Catalogue
   generic_urls:
@@ -2215,16 +2215,16 @@
   synonyms:
     - RAD
     - RGDID
-  rdf_uri_prefix: https://identifiers.org/rgd
+  rdf_uri_prefix: https://registry.identifiers.org/registry/rgd
   generic_urls:
     - https://rgd.mcw.edu/
   entity_types:
     - type_name: gene
       type_id: SO:0000704
       id_syntax: '[0-9]{4,7}'
-      url_syntax: https://rgd.mcw.edu/rgdweb/search/search.html?term=[example_id]
+      url_syntax: https://www.alliancegenome.org/gene/[example_id]
       example_id: RGD:2004
-      example_url: https://rgd.mcw.edu/rgdweb/search/search.html?term=2004          
+      example_url: https://www.alliancegenome.org/gene/RGD:2004          
 - database: RHEA
   name: Rhea, the Annotated Reactions Database
   description: Rhea is a manually annotated database of chemical reactions. All data in Rhea is freely accessible and available for anyone to use.
@@ -2315,16 +2315,16 @@
   name: Saccharomyces Genome Database
   synonyms:
     - SGDID
-  rdf_uri_prefix: https://identifiers.org/sgd
+  rdf_uri_prefix: https://registry.identifiers.org/registry/sgd
   generic_urls:
     - http://www.yeastgenome.org/
   entity_types:
     - type_name: gene
       type_id: SO:0000704
       id_syntax: S[0-9]{9}
-      url_syntax:  https://www.yeastgenome.org/locus/[example_id]
+      url_syntax:  https://www.alliancegenome.org/gene/[example_id]
       example_id: SGD:S000006169
-      example_url: https://www.yeastgenome.org/locus/S000006169
+      example_url: https://www.alliancegenome.org/gene/SGD:S000006169
 - database: SGD_LOCUS
   name: Saccharomyces Genome Database
   generic_urls:
@@ -2332,9 +2332,9 @@
   entity_types:
     - type_name: entity
       type_id: BET:0000000
-      url_syntax: http://www.yeastgenome.org/locus/[example_id]/overview
+      url_syntax: https://www.alliancegenome.org/gene/[example_id]
       example_id: SGD_LOCUS:GAL4
-      example_url: http://www.yeastgenome.org/locus/S000006169/overview
+      example_url: https://www.alliancegenome.org/gene/SGD:S000006169
 - database: SGD_REF
   name: Saccharomyces Genome Database
   generic_urls:
@@ -2750,22 +2750,22 @@
   name: WormBase database of nematode biology
   synonyms:
     - WormBase
-  rdf_uri_prefix: https://identifiers.org/wb
+  rdf_uri_prefix: https://registry.identifiers.org/registry/wb
   generic_urls:
     - http://www.wormbase.org/
   entity_types:
     - type_name: gene
       type_id: SO:0000704
       id_syntax: (CE[0-9]{5})|(WB(Gene|Var|RNAi|Transgene)[0-9]{8})
-      url_syntax: http://www.wormbase.org/get?name=[example_id]
+      url_syntax: https://www.alliancegenome.org/gene/[example_id]
       example_id: WB:WBGene00003001
-      example_url: http://www.wormbase.org/get?name=WBGene00003001
+      example_url: https://www.alliancegenome.org/gene/WB:WBGene00003001
     - type_name: variation
       type_id: VariO:0001
       id_syntax: (CE[0-9]{5})|(WB(Gene|Var|RNAi|Transgene)[0-9]{8})
-      url_syntax: http://www.wormbase.org/get?name=[example_id]
+      url_syntax: https://www.alliancegenome.org/allele/[example_id]
       example_id: WB:WBVar00089843
-      example_url: http://www.wormbase.org/get?name=WBVar00089843
+      example_url: https://www.alliancegenome.org/allele/WB:WBVar00089843
     - type_name: RNAi
       type_id: topic:3523
       id_syntax: (CE[0-9]{5})|(WB(Gene|Var|RNAi|Transgene)[0-9]{8})
@@ -2775,9 +2775,9 @@
     - type_name: Transgene
       type_id: SO:0000902
       id_syntax: (CE[0-9]{5})|(WB(Gene|Var|RNAi|Transgene)[0-9]{8})
-      url_syntax: http://www.wormbase.org/get?name=[example_id]
+      url_syntax: https://www.alliancegenome.org/allele/[example_id]
       example_id: WB:WBTransgene00000059
-      example_url: http://www.wormbase.org/get?name=WBTransgene00000059
+      example_url: https://www.alliancegenome.org/allele/WB:WBTransgene00000059
     - type_name: protein
       type_id: PR:000000001
       id_syntax: (CE[0-9]{5})|(WB(Gene|Var|RNAi|Transgene)[0-9]{8})
@@ -2857,16 +2857,16 @@
       example_url: https://en.wikipedia.org/w/index.php?title=Fallopian_tube&oldid=998395727
 - database: Xenbase
   name: Xenbase
-  rdf_uri_prefix: https://identifiers.org/xenbase
+  rdf_uri_prefix: https://registry.identifiers.org/registry/xenbase
   generic_urls:
     - http://www.xenbase.org/
   entity_types:
     - type_name: gene
       type_id: SO:0000704
       id_syntax: XB-(GENE|LINE|TRANSGENE|MORPHOLINO)-[0-9]+
-      url_syntax: http://www.xenbase.org/entry/[example_id]
+      url_syntax: https://www.alliancegenome.org/gene/[example_id]
       example_id: Xenbase:XB-GENE-6255962
-      example_url: http://www.xenbase.org/entry/XB-GENE-6255962
+      example_url: https://www.alliancegenome.org/gene/Xenbase:XB-GENE-6255962
     - type_name: morpholino oligo
       type_id: SO:0000034
       id_syntax: XB-(GENE|LINE|TRANSGENE|MORPHOLINO)-[0-9]+
@@ -2899,22 +2899,22 @@
     - http://citgenedb.yubiolab.org
 - database: ZFIN
   name: Zebrafish Information Network
-  rdf_uri_prefix: https://identifiers.org/zfin
+  rdf_uri_prefix: https://registry.identifiers.org/registry/zfin
   generic_urls:
     - http://zfin.org/
   entity_types:
     - type_name: gene
       type_id: SO:0000704
       id_syntax: ZDB-(TRNAG|LINCRNAG|MIRNAG|NCRNAG|SNORNAG|GENE|GENO|MRPHLNO)-[0-9]{6}-[0-9]+
-      url_syntax: http://zfin.org/[example_id]
+      url_syntax: https://www.alliancegenome.org/gene/ZFIN:[example_id]
       example_id: ZDB-GENE-990415-103
-      example_url: http://zfin.org/ZDB-GENE-990415-103
+      example_url: https://www.alliancegenome.org/gene/ZFIN:ZDB-GENE-990415-103
     - type_name: variation
       type_id: VariO:0001
       id_syntax: ZDB-(TRNAG|LINCRNAG|MIRNAG|NCRNAG|SNORNAG|GENE|GENO|MRPHLNO)-[0-9]{6}-[0-9]+
-      url_syntax: http://zfin.org/[example_id]
+      url_syntax: https://www.alliancegenome.org/gene/ZFIN:[example_id]
       example_id: ZDB-GENE-990415-103
-      example_url: http://zfin.org/ZDB-GENE-990415-103
+      example_url: https://www.alliancegenome.org/gene/ZFIN:ZDB-GENE-990415-103
 - database: TFClass
   name: TFClass is a resource for the classification of eukaryotic transcription factors based on the characteristics of their DNA-binding domains
   generic_urls:


### PR DESCRIPTION
- do the generic_urls (http://flybase.org -> https://www.alliancegenome.org/members/flybase ?) also need to be changed? 796 1559 2320 2331 2331 2755 2862 2904

- 1566 1572 are the MGI:MGI and may not be correct



**Identifier type not in Alliance:**

- SGD no SGD_REF 
- WB no RNAi or protein page. no WB_REF
- no WBbt, WBls, WBPhenotypes
- XB morpholino oligo, transgene, line