### PR TITLE
Update downloads-page-template.html

### DIFF
--- a/scripts/downloads-page-template.html
+++ b/scripts/downloads-page-template.html
@@ -37,9 +37,8 @@
     	<span class="navbar-toggler-icon"></span>
       </button>
 
-      <a class="navbar-brand" href="index.html#home">
-    	<img src="http://geneontology.org/assets/go-logo-icon.mini.png" height="30" class="d-inline-block align-top" alt="">
-    	Gene Ontology Consortium
+      <a class="navbar-brand" href="http://geneontology.org/">
+    	<img src="http://geneontology.org/assets/go-logo.large.png" height="30" class="d-inline-block align-top" alt="">
       </a>
 
       <div class="collapse navbar-collapse" id="navbarsExampleDefault">
@@ -50,72 +49,60 @@
           </li>
 
           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="http://geneontology.org/page/documentation" id="nav02" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Documentation</a>
+            <a class="nav-link dropdown-toggle" href="http://geneontology.org/docs/introduction-to-go" id="nav02" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">About</a>
             <div class="dropdown-menu" aria-labelledby="nav02">
 
 
-    	      <a class="dropdown-item" href="http://geneontology.org/page/documentation" title="">Introduction</a>
-    	      <a class="dropdown-item" href="http://geneontology.org/faq-page" title="">FAQs</a>
-    	      <a class="dropdown-item" href="http://geneontology.org/page/ontology-documentation">Ontology</a>
-    	      <a class="dropdown-item" href="http://geneontology.org/page/annotation">Annotation</a>
-    	      <a class="dropdown-item" href="http://geneontology.org/page/annotation-extension">Annotation Extension</a>
-    	      <a class="dropdown-item" href="http://geneontology.org/page/go-database">GO database</a>
-    	      <a class="dropdown-item" href="http://geneontology.org/page/file-format-guide">File format guide</a>
-    	      <a class="dropdown-item" href="http://geneontology.org/page/annotation-tools-downloads-and-beyond">Annotation Tools, Downloads, and Beyond</a>
-    	      <a class="dropdown-item" href="http://geneontology.org/page/contributing-go">Contributing to GO</a>
-    	      <a class="dropdown-item" href="http://geneontology.org/page/submitting-go-annotations">Submitting GO Annotations</a>
-    	      <a class="dropdown-item" href="http://geneontology.org/page/other-useful-links">Other useful information</a>
-
+    	      <a class="dropdown-item" href="http://geneontology.org/docs/introduction-to-go" title="">About the GO</a>
+    	      <a class="dropdown-item" href="http://geneontology.org/docs/whoweare/">Who we are</a>
+    	      <a class="dropdown-item" href="http://geneontology.org/docs/collaborations/">Collaborations</a>
+    	      <a class="dropdown-item" href="http://geneontology.org/docs/annotation-contributors">Annotation contributors</a>
+    	      <a class="dropdown-item" href="http://geneontology.org/docs/literature/">Scientific literature</a>
+    	      <a class="dropdown-item" href="http://geneontology.org/docs/go-citation-policy/">GO citation policy and license</a>
             </div>
           </li>
 
           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="http://geneontology.org/page/downloads" id="nav03" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Downloads</a>
+            <a class="nav-link dropdown-toggle" href="http://geneontology.org/page/downloads" id="nav03" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Ontology</a>
             <div class="dropdown-menu" aria-labelledby="nav03">
-              <a class="dropdown-item" href="http://geneontology.org/page/downloads" id="nav-crit" aria-haspopup="true" aria-expanded="false">Overview</a>
-              <a class="dropdown-item" href="http://geneontology.org/page/download-annotations" id="nav-crit" aria-haspopup="true" aria-expanded="false">Annotations</a>
-              <a class="dropdown-item" href="http://geneontology.org/page/download-ontology" id="nav-crit" aria-haspopup="true" aria-expanded="false">Ontology</a>
-              <a class="dropdown-item" href="http://geneontology.org/page/download-mappings" id="nav-crit" aria-haspopup="true" aria-expanded="false">Mappings</a>
+              <a class="dropdown-item" href="http://geneontology.org/docs/ontology-documentation/" id="nav-crit" aria-haspopup="true" aria-expanded="false">Gene Ontology Overview</a>
+              <a class="dropdown-item" href="http://geneontology.org/docs/download-mappings/" id="nav-crit" aria-haspopup="true" aria-expanded="false">Cross-references of external classification systems to GO</a>
+              <a class="dropdown-item" href="http://geneontology.org/docs/go-subset-guide/" id="nav-crit" aria-haspopup="true" aria-expanded="false">Guide to GO subsets</a>
+              <a class="dropdown-item" href="http://geneontology.org/docs/contributing-to-go-terms/" id="nav-crit" aria-haspopup="true" aria-expanded="false">Contributing to the ontology</a>
             </div>
     	  </li>
 
           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="http://geneontology.org/page/go-community" id="nav04" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Community</a>
+            <a class="nav-link dropdown-toggle" href="http://geneontology.org/page/go-community" id="nav04" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Annotations</a>
             <div class="dropdown-menu" aria-labelledby="nav04">
-              <a class="dropdown-item" href="http://geneontology.org/page/go-community" id="nav-crit" aria-haspopup="true" aria-expanded="false">Overview</a>
-              <a class="dropdown-item" href="http://geneontology.org/page/go-projects" id="nav-crit" aria-haspopup="true" aria-expanded="false">GO Projects</a>
-              <a class="dropdown-item" href="http://geneontology.org/page/collaborations" id="nav-crit" aria-haspopup="true" aria-expanded="false">Collaborations</a>
-              <a class="dropdown-item" href="http://geneontology.org/aggregator" id="nav-crit" aria-haspopup="true" aria-expanded="false">Web Feeds</a>
-              <a class="dropdown-item" href="http://wiki.geneontology.org" id="nav-crit" aria-haspopup="true" aria-expanded="false">GO Wiki</a>
-              <a class="dropdown-item" href="http://geneontology.org/page/go-consortium-contributors-list" id="nav-crit" aria-haspopup="true" aria-expanded="false">GO Contributors</a>
-              <a class="dropdown-item" href="http://geneontology.org/page/go-mailing-lists" id="nav-crit" aria-haspopup="true" aria-expanded="false">GO Mailing Lists</a>
+              <a class="dropdown-item" href="http://geneontology.org/docs/go-annotations/" id="nav-crit" aria-haspopup="true" aria-expanded="false">Introduction to GO annotations</a>
+              <a class="dropdown-item" href="http://geneontology.org/docs/guide-go-evidence-codes/" id="nav-crit" aria-haspopup="true" aria-expanded="false">Guide to GO evidence codes</a>
+              <a class="dropdown-item" href="http://geneontology.org/docs/contributing-to-go/" id="nav-crit" aria-haspopup="true" aria-expanded="false">Contributing GO annotations</a>
             </div>
     	  </li>
 
           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="http://geneontology.org/page/go-tools-registry" id="nav05" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Tools</a>
+            <a class="nav-link dropdown-toggle" href="http://geneontology.org/page/go-tools-registry" id="nav05" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Downloads</a>
             <div class="dropdown-menu" aria-labelledby="nav05">
-              <a class="dropdown-item" href="http://amigo.geneontology.org" id="nav-crit" aria-haspopup="true" aria-expanded="false">AmiGO</a>
-              <a class="dropdown-item" href="http://amigo.geneontology.org/goose" id="nav-crit" aria-haspopup="true" aria-expanded="false">GOOSE</a>
-              <a class="dropdown-item" href="http://geneontology.org/page/go-enrichment-analysis" id="nav-crit" aria-haspopup="true" aria-expanded="false">GO Enrichment Analysis</a>
-              <a class="dropdown-item" href="http://amigo.geneontology.org/amigo/software_list" id="nav-crit" aria-haspopup="true" aria-expanded="false">Other GOC Tools</a>
+
+              <a class="dropdown-item" href="http://geneontology.org/docs/downloads/" id="nav-crit" aria-haspopup="true" aria-expanded="false">Downloads overview</a>
+              <a class="dropdown-item" href="http://geneontology.org/docs/download-ontology/" id="nav-crit" aria-haspopup="true" aria-expanded="false">Download ontology</a>
+              <a class="dropdown-item" href="http://geneontology.org/docs/download-go-annotations/" id="nav-crit" aria-haspopup="true" aria-expanded="false">Download annotations</a>
+              <a class="dropdown-item" href="http://geneontology.org/docs/download-go-cams/" id="nav-crit" aria-haspopup="true" aria-expanded="false">Download GO-CAMs</a>
+              <a class="dropdown-item" href="http://geneontology.org/docs/go-archives/" id="nav-crit" aria-haspopup="true" aria-expanded="false">GO Archive</a>
+              <a class="dropdown-item" href="http://geneontology.org/docs/deprecated-products-and-formats/" id="nav-crit" aria-haspopup="true" aria-expanded="false">Deprecated formats</a>		    		    
             </div>
     	  </li>
-
 
           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="http://geneontology.org/page/about" id="nav06" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">About</a>
+            <a class="nav-link dropdown-toggle" href="http://geneontology.org/page/about" id="nav06" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Help</a>
             <div class="dropdown-menu" aria-labelledby="nav06">
-              <a class="dropdown-item" href="http://geneontology.org/page/about" id="nav-crit" aria-haspopup="true" aria-expanded="false">Overview</a>
-              <a class="dropdown-item" href="http://geneontology.org/page/publications" id="nav-crit" aria-haspopup="true" aria-expanded="false">Publications</a>
-              <a class="dropdown-item" href="http://geneontology.org/page/go-citation-policy" id="nav-crit" aria-haspopup="true" aria-expanded="false">Citation policy</a>
-              <a class="dropdown-item" href="http://geneontology.org/page/use-and-license" id="nav-crit" aria-haspopup="true" aria-expanded="false">Use and license</a>
+              <a class="dropdown-item" href="http://geneontology.org/search.html" id="nav-crit" aria-haspopup="true" aria-expanded="false">Search Documentation</a>
+              <a class="dropdown-item" href="http://geneontology.org/docs/faq/" id="nav-crit" aria-haspopup="true" aria-expanded="false">Frequently Asked Questions</a>
+              <a class="dropdown-item" href="http://geneontology.org/docs/go-citation-policy/" id="nav-crit" aria-haspopup="true" aria-expanded="false">Citation and Terms</a>
+              <a class="dropdown-item" href="http://help.geneontology.org/" id="nav-crit" aria-haspopup="true" aria-expanded="false">Contact us</a>
             </div>
     	  </li>
-
-    	  <li class="nav-item">
-            <a class="nav-link" href="http://geneontology.org/page/contact-go" id="nav07" aria-haspopup="true" aria-expanded="false">Contact us</a>
-          </li>
 
         </ul>
 
@@ -238,7 +225,7 @@
 	  <p>
 	    <small>
 	      Copyright ©
-	      1999-2020 <a href="http://www.geneontology.org/"
+	      1999-2023 <a href="http://www.geneontology.org/"
 			   title="The Gene Ontology project website">the Gene
 		Ontology</a>
 	      (<a href="http://geneontology.org/page/use-and-license">CC-BY
@@ -254,14 +241,11 @@
 	    </small>
 	    <br />
 	    <small>
-	      The Gene Ontology Consortium is supported by a P41 grant
-	      from the National Human Genome Research Institute (NHGRI)
-	      [grant <a href="http://projectreporter.nih.gov/project_info_description.cfm?aid=8641714&amp;icde=0"
-			rel="external" title="National Human Genome Research Institute grant 5U41HG002273-14">5U41HG002273-14</a>]. The
-	      Gene Ontology Consortium would like to acknowledge the
-	      assistance of many more people than can be listed
-	      here. Please visit
-	      the <a href="http://geneontology.org/docs/annotation-contributors/">annotation contributors page</a> for the full list.
+	      The Gene Ontology Consortium is funded by the National
+	      Human Genome Research Institute (US National Institutes
+	      of Health), grant number <a href="https://reporter.nih.gov/search/BqfmFvQGv0CWrEFOkzTp-w/project-details/10348001"
+			rel="external" title="National Human Genome Research Institute grant 1U24HG012212">HG012212</a>,
+	      with co-funding by NIGMS.
 	    </small>
 	  </p>
 


### PR DESCRIPTION
Changes: Fixed date in footer. Removed broken links in header- made to closely resemble header on rest of site for https://github.com/geneontology/geneontology.github.io/issues/233

lines 47-49 redundant with image link if that works

also removed               <a class="dropdown-item" href="http://amigo.geneontology.org" id="nav-crit" aria-haspopup="true" aria-expanded="false">AmiGO</a>		    
	      <a class="dropdown-item" href="http://geneontology.org/page/go-enrichment-analysis" id="nav-crit" aria-haspopup="true" aria-expanded="false">GO Enrichment Analysis</a>
 but i'd quite like to keep those esp link to AmiGO