### PR TITLE
Update ecocyc.yaml

### DIFF
--- a/metadata/datasets/ecocyc.yaml
+++ b/metadata/datasets/ecocyc.yaml
@@ -15,6 +15,7 @@ datasets:
    type: gaf
    dataset: ecocyc
    submitter: ecocyc
+   compression: gzip
    source: https://ftp.ebi.ac.uk/pub/databases/GO/goa/proteomes/18.E_coli_MG1655.goa
    entity_type:
    status: active


### PR DESCRIPTION
@kltm just checking- this `compression:` field refers to the file in the `url:` field, not the `source:`, correct?  Source file is not .gz

Adding this as the field on products/pages/downloads.html is currently blank