### PR TITLE
Revise SPARQL queries that mark Noctua models and filter non-production.

### DIFF
--- a/pipeline/Makefile
+++ b/pipeline/Makefile
@@ -214,6 +214,7 @@ target/blazegraph.jnl: $(BGJAR) target/rdf target/noctua-models
 target/blazegraph-internal.jnl: target/blazegraph.jnl
 	cp $< $@
 	JAVA_OPTS=-Xmx$(BGMEM) blazegraph-runner --journal=$@ update sparql/insert/insert_noctua_metadata.sparql
+	JAVA_OPTS=-Xmx$(BGMEM) blazegraph-runner --journal=$@ update sparql/insert/insert_inferred_models_metadata.sparql
 	JAVA_OPTS=-Xmx$(BGMEM) blazegraph-runner --journal=$@ update sparql/insert/insert_ontology_metadata.sparql
 	JAVA_OPTS=-Xmx$(BGMEM) blazegraph-runner --journal=$@ update sparql/insert/insert_reflexive_subclass_closure.sparql
 

--- a/pipeline/sparql/delete/delete_non_production.sparql
+++ b/pipeline/sparql/delete/delete_non_production.sparql
@@ -1,6 +1,7 @@
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX lego: <http://geneontology.org/lego/>
 PREFIX : <http://model.geneontology.org/>
 
 DELETE {
@@ -9,38 +10,20 @@ DELETE {
   }
 }
 WHERE {
-
   # This is all triples from noctua cam graphs, including inferred graphs
-# Total
-
-  GRAPH ?g {
+  {
     ?g :graphType :noctuaCam .
-    ?s ?p ?o .
+    ?g lego:modelstate ?state .
+    FILTER(?state != "production")
   }
-
-  # We'll subtract out production (cause we want to keep them)
-  FILTER NOT EXISTS {
-    {
-      # Find production graphs
-      GRAPH ?g {
-        ?g :graphType :noctuaCam .
-        ?g <http://geneontology.org/lego/modelstate> ?state .
-        FILTER(?state = "production")
-        ?s ?p ?o .
-      }
-    }
-    UNION {
-      # Union with inferred graphs from the found production
-      GRAPH ?g {
-        ?g :graphType :noctuaCam .
-        ?g prov:wasDerivedFrom ?asserted .
-        ?s ?p ?o
-      }
-      GRAPH ?asserted {
-        ?asserted :graphType :noctuaCam .
-        ?asserted <http://geneontology.org/lego/modelstate> ?state .
-        FILTER(?state = "production")
-      }
-    }
+  UNION
+  {
+    ?g :graphType :noctuaInferences .
+    ?g prov:wasDerivedFrom ?asserted .
+    ?asserted lego:modelstate ?state .
+    FILTER(?state != "production")
+  }
+  GRAPH ?g {    
+    ?s ?p ?o .
   }
 }

--- a/pipeline/sparql/insert/insert_inferred_models_metadata.sparql
+++ b/pipeline/sparql/insert/insert_inferred_models_metadata.sparql
@@ -5,12 +5,15 @@ PREFIX : <http://model.geneontology.org/>
 
 INSERT {
   GRAPH ?g {
-    ?g :graphType :noctuaCam .
+    ?g :graphType :noctuaInferences .
   }
 }
 WHERE {
   GRAPH ?g {
-    ?g a owl:Ontology .
+    ?g prov:wasDerivedFrom ?ag .
+  }
+  # Copied asserted models also have wasDerivedFrom links
+  FILTER NOT EXISTS {
     ?g <http://geneontology.org/lego/modelstate> ?state .
-  } 
+  }
 }


### PR DESCRIPTION
Fixes #2013.

With this change, asserted Noctua models continue to have `graphType` `noctuaCam`. Now the graphs containing inferences have `graphType` `noctuaInferences` instead of `noctuaCam`.