### PR TITLE
Update requirements.txt to up ontobio

### DIFF
--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML
-ontobio==2.8.14
+ontobio==2.8.15
 click
 pyparsing==2.4.7
 antlr4-python3-runtime==4.9.3


### PR DESCRIPTION
For https://github.com/geneontology/go-site/issues/2070 and https://github.com/geneontology/go-releases/issues/50.

Upgrades `ontobio` to bring in these fixes:

https://github.com/biolink/ontobio/pull/647
https://github.com/biolink/ontobio/pull/648
