### PR TITLE
Update requirements.txt

### DIFF
--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML
-ontobio==2.8.14
+ontobio==2.8.16
 click
 pyparsing==2.4.7
 antlr4-python3-runtime==4.9.3


### PR DESCRIPTION
This ups the `ontobio` to pull in the [fix](https://github.com/biolink/ontobio/pull/649) for #2002 specifically to handle obsoleted terms in the GO rule 61 QC test.