### PR TITLE
change https-> http to match minerva URI expansion for SGD

### DIFF
--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -2373,7 +2373,7 @@
   name: Saccharomyces Genome Database
   synonyms:
     - SGDID
-  rdf_uri_prefix: http://identifiers.org/sgd
+  rdf_uri_prefix: http://identifiers.org/sgd/
   generic_urls:
     - http://www.yeastgenome.org/
   entity_types:

--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -2829,7 +2829,7 @@
   name: WormBase database of nematode biology
   synonyms:
     - WormBase
-  rdf_uri_prefix: http://identifiers.org/wb/
+  rdf_uri_prefix: http://identifiers.org/wormbase/
   generic_urls:
     - http://www.wormbase.org/
   entity_types:

--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -2373,7 +2373,7 @@
   name: Saccharomyces Genome Database
   synonyms:
     - SGDID
-  rdf_uri_prefix: https://identifiers.org/sgd
+  rdf_uri_prefix: http://identifiers.org/sgd
   generic_urls:
     - http://www.yeastgenome.org/
   entity_types:

--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -1259,7 +1259,7 @@
       example_url: http://www.ebi.ac.uk/complexportal/complex/EBI-10205244
 - database: InterPro
   name: InterPro database of protein domains and motifs
-  rdf_uri_prefix: https://registry.identifiers.org/registry/interpro
+  rdf_uri_prefix: http://identifiers.org/interpro/
   synonyms:
     - INTERPRO
     - IPR
@@ -1477,7 +1477,7 @@
       example_url: https://maizegdb.org/gene_center/gene/12098
 - database: MaizeGDB_Locus
   name: MaizeGDB
-  rdf_uri_prefix: https://identifiers.org/maizegdb.locus
+  rdf_uri_prefix: http://identifiers.org/maizegdb.locus/
   generic_urls:
     - https://www.maizegdb.org/
   entity_types:
@@ -1570,7 +1570,7 @@
   name: Metabolic Encyclopedia of metabolic and other pathways
   synonyms:
     - METACYC
-  rdf_uri_prefix: https://identifiers.org/metacyc.reaction
+  rdf_uri_prefix: http://identifiers.org/metacyc.reaction/
   generic_urls:
     - https://metacyc.org/
   entity_types:
@@ -1600,7 +1600,7 @@
       example_id: MGD:Adcy9
 - database: MGI
   name: Mouse Genome Informatics
-  rdf_uri_prefix: https://identifiers.org/MGI
+  rdf_uri_prefix: http://identifiers.org/MGI/
   generic_urls:
     - http://www.informatics.jax.org/
   entity_types:
@@ -1675,7 +1675,7 @@
     - GeneID
     - LocusID
     - NCBI_Gene
-  rdf_uri_prefix: https://identifiers.org/ncbigene
+  rdf_uri_prefix: http://identifiers.org/ncbigene/
   generic_urls:
     - http://www.ncbi.nlm.nih.gov/
   entity_types:
@@ -1797,7 +1797,7 @@
       type_id: BET:0000000
 - database: PANTHER
   name: Protein ANalysis THrough Evolutionary Relationships Classification System
-  rdf_uri_prefix: https://identifiers.org/panther.family
+  rdf_uri_prefix: http://identifiers.org/panther.family/
   generic_urls:
     - http://www.pantherdb.org/
   entity_types:
@@ -2011,7 +2011,7 @@
       example_url: http://planteome.org/po_ref/00001
 - database: PlasmoDB
   name: PlasmoDB
-  rdf_uri_prefix: https://identifiers.org/plasmodb
+  rdf_uri_prefix: http://identifiers.org/plasmodb/
   generic_urls:
     - https://plasmodb.org
   entity_types:
@@ -2030,7 +2030,7 @@
       type_id: BET:0000000
 - database: PomBase
   name: PomBase
-  rdf_uri_prefix: https://identifiers.org/pombase
+  rdf_uri_prefix: http://identifiers.org/pombase/
   generic_urls:
     - https://www.pombase.org/
   entity_types:
@@ -2201,7 +2201,7 @@
   synonyms:
     - REACTOME
     - REAC
-  rdf_uri_prefix: https://identifiers.org/reactome
+  rdf_uri_prefix: http://identifiers.org/reactome/
   generic_urls:
     - https://www.reactome.org/
   entity_types:
@@ -2273,7 +2273,7 @@
   synonyms:
     - RAD
     - RGDID
-  rdf_uri_prefix: https://identifiers.org/rgd
+  rdf_uri_prefix: http://identifiers.org/rgd/
   generic_urls:
     - https://rgd.mcw.edu/
   entity_types:
@@ -2417,7 +2417,7 @@
   name: Sol Genomics Network
   synonyms:
     - SGN_gene
-  rdf_uri_prefix: https://identifiers.org/sgn
+  rdf_uri_prefix: http://identifiers.org/sgn/
   generic_urls:
     - https://www.sgn.cornell.edu/
   entity_types:
@@ -2545,7 +2545,7 @@
       type_id: BET:0000000
 - database: TAIR
   name: The Arabidopsis Information Resource
-  rdf_uri_prefix: https://identifiers.org/tair.locus
+  rdf_uri_prefix: http://identifiers.org/tair.locus/
   generic_urls:
     - http://www.arabidopsis.org/
   entity_types:
@@ -2594,7 +2594,7 @@
       example_url: http://www.tcdb.org/tcdb/index.php?tc=9.A.4.1.1
 - database: TGD
   name: Tetrahymena Genome Database
-  rdf_uri_prefix: https://identifiers.org/tgd
+  rdf_uri_prefix: http://identifiers.org/tgd/
   generic_urls:
     - http://www.ciliate.org/
   entity_types:
@@ -2649,7 +2649,7 @@
       example_url: http://dendrome.ucdavis.edu/treegenes/protein/view_protein.php?id=254
 - database: TriTrypDB
   name: TriTrypDB
-  rdf_uri_prefix: https://identifiers.org/tritrypdb
+  rdf_uri_prefix: http://identifiers.org/tritrypdb/
   generic_urls:
     - https://tritrypdb.org/
   entity_types:
@@ -2759,7 +2759,7 @@
 - database: UniProtKB
   name: Universal Protein Knowledgebase
   description: A central repository of protein sequence and function created by joining the information contained in Swiss-Prot, TrEMBL, and PIR database
-  rdf_uri_prefix: https://identifiers.org/uniprot
+  rdf_uri_prefix: http://identifiers.org/uniprot/
   generic_urls:
     - http://www.uniprot.org
   entity_types:
@@ -2829,7 +2829,7 @@
   name: WormBase database of nematode biology
   synonyms:
     - WormBase
-  rdf_uri_prefix: https://identifiers.org/wb
+  rdf_uri_prefix: http://identifiers.org/wb/
   generic_urls:
     - http://www.wormbase.org/
   entity_types:
@@ -2936,7 +2936,7 @@
       example_url: https://en.wikipedia.org/w/index.php?title=Fallopian_tube&oldid=998395727
 - database: Xenbase
   name: Xenbase
-  rdf_uri_prefix: https://identifiers.org/xenbase
+  rdf_uri_prefix: http://identifiers.org/xenbase/
   generic_urls:
     - http://www.xenbase.org/
   entity_types:
@@ -2978,7 +2978,7 @@
     - http://citgenedb.yubiolab.org
 - database: ZFIN
   name: Zebrafish Information Network
-  rdf_uri_prefix: https://identifiers.org/zfin
+  rdf_uri_prefix: http://identifiers.org/zfin/
   generic_urls:
     - http://zfin.org/
   entity_types:


### PR DESCRIPTION
see [https://github.com/geneontology/go-fastapi #87](https://github.com/geneontology/go-fastapi/issues/87)

GO-API expands `SGD:S000003407` to `https://identifiers.org/sgd/S000003407` using the `go.csv` context in prefixmaps.  `go.csv` context in prefixmaps is generated by pulling in the `rdf_uri_prefix` from the db-xrefs.yaml.  Since the URL generated from minerva in the model is `http://identifiers.org/sgd/S000003407` (note the `http` vs, `https`), no results are returned from the GO-API query.

Is this the right approach @balhoff ?
