### PR TITLE
Update requirements.txt for GO_REF:0000033

### DIFF
--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML
-ontobio==2.8.20
+ontobio==2.8.22
 click
 pyparsing==2.4.7
 antlr4-python3-runtime==4.9.3


### PR DESCRIPTION
This `ontobio` bump will pull in the correct check for `GO_REF:0000033` in IBAs - https://github.com/biolink/ontobio/pull/665