### PR TITLE
Update format specification for `gorefs.yaml` metadata file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ pipeline/*.log
 env
 __pycache__
 .idea
+.venv

--- a/metadata/gorefs/linkml-schema/gorefs-model.yaml
+++ b/metadata/gorefs/linkml-schema/gorefs-model.yaml
@@ -1,12 +1,10 @@
 id: http://purl.obolibrary.org/obo/go/references/
 name: GO_REF
 title: GO_REF LinkML schema
-description: >- 
-  LinkML schema representing the structure of
-  GO_REF metadata
+description: LinkML schema representing the structure of GO_REF metadata
 
 imports:
-- linkml:types
+  - linkml:types
 
 prefixes:
   linkml: https://w3id.org/linkml/
@@ -15,107 +13,105 @@ prefixes:
   PMID: http://www.ncbi.nlm.nih.gov/pubmed/
 default_prefix: GO_REF
 
-types:
-  Identifier:
-    typeof: string
-    description: GO_REF identifier.
-
 slots:
+  alt_id:
+    examples:
+      - value: GO_REF:0000009
+    multivalued: true
+    range: uriorcurie
+    pattern: GO_REF:[0-9]{7}
+    description: Alternate IDs for GO_REF.
+
   authors:
     examples:
-    - value: FlyBase
+      - value: FlyBase
     range: string
+    required: true
     description: Author of the GOREF.
-  id:
+
+  citation:
     examples:
-    - value: GO_REF:0000098
-    range: Identifier
-    identifier: true
-    description: GO_REF id.
-  is_obsolete:
-    examples:
-    - value: true
-    range: boolean
-    description: >- 
-      Boolean value indicating whether or not the 
-      GO_REF is still in use.
-  year:
-    examples:
-    - value: 2014
-    range: integer
-    description: Year in which the GO_REF was created.
-  layout:
-    examples:
-    - value: goref
-    range: string
-    description: Front matter format hint for Markdown rendering.
-  title:
-    examples:
-    - value: OBSOLETE Gene Ontology annotation based on research conference abstracts
-    range: string
-    description: Title.
+      - value: PMID:11374909
+    range: uriorcurie
+    description: Publication for GO_REF.
+
   comments:
-    examples:
-    - value: '["Prior to 2008, FlyBase made GO annotations based on information in
-        abstracts for research conferences, primarily the Annual Drosophila Research
-        Conference and the European Drosophila Research Conference. We no longer curate
-        conference abstracts and we are gradually replacing all abstract-based GO
-        annotation with annotation based on experimental data in primary research
-        papers.""]'
     multivalued: true
     range: string
     description: Comments.
-  external_accession:
-    examples:
-    - value: J:164563
-    multivalued: true
-    range: uriorcurie
-    description: >- 
-      List of cross references from other databases for the same entity.
-  url:
-    examples:
-    - value: http://www.ebi.ac.uk/GOA/ISS_method.html
-    range: uriorcurie
-    description: URL for further information.
-  citation:
-    examples:
-    - value: PMID:11374909
-    range: uriorcurie
-    description: Publication for GO_REF.
-  alt_id:
-    examples:
-    - value: GO_REF:0000009
-    multivalued: true
-    range: uriorcurie
-    description: Alternate IDs for GO_REF.
+
+  description:
+    range: string
+    required: true
+    aliases:
+      - abstract
+      - definition
+
   evidence_codes:
     examples:
-    - value: ECO:0000501
+      - value: ECO:0000501
     multivalued: true
     range: uriorcurie
+    pattern: ECO:[0-9]{7}
     description: Evidence codes for GO_REF.
-  gorefs:
+
+  external_accession:
+    examples:
+      - value: J:164563
     multivalued: true
-    inlined_as_list: true
-    range: GoRef
-    description: List of GO_REFs.
+    range: uriorcurie
+    pattern: '[a-zA-Z\_]+:[0-9a-zA-Z\_]+'
+    description: >-
+      List of cross references from other databases for the same entity.
+
+  id:
+    examples:
+      - value: GO_REF:0000098
+    range: string
+    identifier: true
+    description: GO_REF identifier
+    pattern: GO_REF:[0-9]{7}
+
+  is_obsolete:
+    examples:
+      - value: true
+    range: boolean
+    description: >-
+      Boolean value indicating whether or not the GO_REF is still in use.
+
+  title:
+    examples:
+      - value: OBSOLETE Gene Ontology annotation based on research conference abstracts
+    range: string
+    description: Title.
+    required: true
+
+  url:
+    examples:
+      - value: http://www.ebi.ac.uk/GOA/ISS_method.html
+    range: uriorcurie
+    description: URL for further information.
+    pattern: 'http[s]?://'
+
+  year:
+    examples:
+      - value: 2014
+    range: integer
+    description: Year in which the GO_REF was created.
+    minimum_value: 1998
 
 classes:
-  GoRefCollection:
-    tree_root: true
-    slots:
-    - gorefs
   GoRef:
     slots:
-    - authors
-    - id
-    - is_obsolete
-    - year
-    - layout
-    - title
-    - comments
-    - external_accession
-    - url
-    - citation
-    - alt_id
-    - evidence_codes
+      - alt_id
+      - authors
+      - citation
+      - comments
+      - description
+      - evidence_codes
+      - external_accession
+      - id
+      - is_obsolete
+      - title
+      - url
+      - year

--- a/scripts/goref_parser/goref.py
+++ b/scripts/goref_parser/goref.py
@@ -23,10 +23,7 @@ class GoRef:
         self, portion: Optional[str] = None
     ) -> Union[Tuple[Dict, str], Dict, str]:
         with open(self.yd_path, "r") as file:
-            yd_content = file.read()
-    
-        f = io.StringIO(yd_content)
-        yaml, md = yamldown.load(f)
+            yaml, md = yamldown.load(file)
 
         if portion == "yaml":
             return yaml

--- a/scripts/goref_parser/parser.py
+++ b/scripts/goref_parser/parser.py
@@ -1,71 +1,91 @@
-from email import header
-import os
-import sys
+import collections
 import logging
+import sys
+from pathlib import Path
+
+import mistune
+import yaml
 
 sys.path.append("../parser/goref.py")
 from goref import GoRef
 
-sys.path.append("../parser/utils.py")
-from utils import get_html_string, merge_dicts
-
-import yaml
-import markdown
-
 
 logger = logging.getLogger(__name__)
 
+
+def concat_children(node):
+    result = ""
+    for child in node["children"]:
+        if child["type"] == "text":
+            result += child["raw"]
+        elif child["type"] == "inline_html":
+            if child["raw"] == "<br>":
+                result += "\n"
+            else:
+                result += child["raw"]
+        elif child["type"] == "softbreak":
+            result += " "
+        else:
+            raise ValueError(f"Unexpected child type: {child['type']}")
+    return result
+
+
 if __name__ == "__main__":
     # final list of all dicts that need to be converted to YAML
-    combined_dict_list = []
+    all_gorefs = []
 
-    for file_name in os.listdir("metadata/gorefs/"):
-        if any(
-            non_goref in file_name
-            for non_goref in ["README-editors.md", "Makefile", "README.md"]
-        ):
-            continue
+    markdown = mistune.create_markdown(renderer=None)
 
-        file_name = os.path.join("metadata/gorefs/", file_name)
+    root = Path(__file__).parent / "../../metadata/gorefs"
+    for file_name in sorted(root.glob("goref-*.md")):
+        goref_file = GoRef(str(file_name))
 
-        with open(file_name, "r") as file:
-            data = file.read()
+        (yaml_content, md_content) = goref_file.parse()
+        markdown_ast = markdown(md_content)
 
-        goref = GoRef(file_name)
+        goref = collections.OrderedDict()
 
-        # fetch YAML contents
-        yaml_content = goref.parse(portion="yaml")
+        after_comments_heading = False
+        for node in markdown_ast:
+            if node["type"] == "heading" and node.get('attrs', {}).get('level') == 2:
+                heading = concat_children(node)
+                if "title" not in goref:
+                    goref["title"] = heading
+                elif heading == "Comments":
+                    after_comments_heading = True
 
-        # fetch MD content
-        md_content = goref.parse(portion="md")
+            elif node["type"] == "paragraph":
+                paragraph = concat_children(node)
+                if not after_comments_heading:
+                    if "description" in goref:
+                        goref["description"] += f"\n{paragraph}"
+                    else:
+                        goref["description"] = paragraph
+                else:
+                    if "comments" not in goref:
+                        goref["comments"] = []
+                    goref["comments"].append(paragraph)
 
-        # convert MD into HTML
-        html = markdown.markdown(md_content)
+        for key in goref:
+            try:
+                goref[key] = goref[key].strip()
+            except AttributeError:
+                pass
 
-        # get content between <h2> tags
-        header_contents = get_html_string("h2", html)
+        goref.update(yaml_content)
+        goref.pop("layout", None)
+        goref.move_to_end("id", last=False)
 
-        # get content between <p> tags
-        paragraph_contents = get_html_string("p", html)
-
-        # enable this block if you want to handle multiple comments differently
-        # if len(header_contents) != len(paragraph_contents):
-        #     logger.warning(
-        #         f"There are standalone headers or paragraphs in: {yaml_content['id']}"
-        #     )
-        #     continue
-
-        title_desc_pair = {}
-
-        title_desc_pair["title"] = header_contents[0]
-        title_desc_pair["comments"] = paragraph_contents
-
-        # yamldown content in the form of a dictionary
-        merged_yaml_md = merge_dicts(yaml_content, title_desc_pair)
-
-        combined_dict_list.append(merged_yaml_md)
+        all_gorefs.append(dict(goref))
 
     # export combined list of yamldown dicts compiled from all gorefs
     # and export to YAML
+
+    def str_presenter(dumper, data):
+        if '\n' in data or len(data) > 200:
+            return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='>')
+        return dumper.represent_scalar('tag:yaml.org,2002:str', data)
+    yaml.representer.SafeRepresenter.add_representer(str, str_presenter)
+
     with open("gorefs.yaml", "w") as outfile:
-        yaml.dump_all(combined_dict_list, outfile, sort_keys=False)
+        yaml.safe_dump(all_gorefs, outfile, encoding='utf-8', allow_unicode=True, sort_keys=False)

--- a/scripts/goref_parser/requirements.txt
+++ b/scripts/goref_parser/requirements.txt
@@ -1,5 +1,5 @@
 importlib-metadata==4.10.1
-Markdown==3.3.6
+mistune==3.0.1
 PyYAML==6.0
 yamldown==0.1.8
 zipp==3.7.0


### PR DESCRIPTION
Fixes #2232 

This is just about updating the _format specification_ of `gorefs.yaml` (as reviewed in the issue comments). In particular the LinkML schema that defines it (`metadata/gorefs/linkml-schema/gorefs-model.yaml`) has been updated, and the script to translate the Markdown files into one YAML file adhering to that format has also been updated. 

Updating the actual contents of `gorefs.yaml` as well as reorganizing the file structure to align with other metadata YAML files will be done in https://github.com/geneontology/go-site/issues/2233.