### PR TITLE
Bump ontobio for adding gorule-0000064

### DIFF
--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML
-ontobio==2.8.22
+ontobio==2.8.23
 click
 pyparsing==2.4.7
 antlr4-python3-runtime==4.9.3

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML
-ontobio==2.8.23
+ontobio==2.8.24
 click
 pyparsing==2.4.7
 antlr4-python3-runtime==4.9.3


### PR DESCRIPTION
For #2273. This brings in change https://github.com/biolink/ontobio/pull/672 to filter out IEAs with TreeGrafter `GO_REF:0000118` for species in [go-reference-species.yaml](https://github.com/geneontology/go-site/blob/master/metadata/go-reference-species.yaml).