### PR TITLE
Trigger website rebuild when gorefs.yaml changes

### DIFF
--- a/.github/workflows/trigger-website-rebuild.yaml
+++ b/.github/workflows/trigger-website-rebuild.yaml
@@ -22,6 +22,7 @@ jobs:
       # In theory, a failed validation would have been caught by the qc workflow before this point.
       # But we validate again here just to double-check that we're not triggering a rebuild based
       # on invalid data. This is also simpler than tying this workflow to the qc workflow.
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'

--- a/.github/workflows/trigger-website-rebuild.yaml
+++ b/.github/workflows/trigger-website-rebuild.yaml
@@ -19,11 +19,25 @@ jobs:
   trigger-website-rebuild:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
+      # In theory, a failed validation would have been caught by the qc workflow before this point.
+      # But we validate again here just to double-check that we're not triggering a rebuild based
+      # on invalid data. This is also simpler than tying this workflow to the qc workflow.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - run: pip install linkml
+      - name: Validate gorefs.yaml
+        run: linkml-validate -s metadata/gorefs.schema.yaml metadata/gorefs.yaml
+
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@v1
         id: app-token
         with:
           app-id: ${{ vars.WORKFLOW_BOT_APP_ID }}
           private-key: ${{ secrets.WORKFLOW_BOT_PRIVATE_KEY }}
-      - run: gh workflow run deploy.yaml --repo geneontology/geneontology.github.io
+
+      - name: Trigger deploy workflow in geneontology.github.io
+        run: gh workflow run deploy.yaml --repo geneontology/geneontology.github.io
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/trigger-website-rebuild.yaml
+++ b/.github/workflows/trigger-website-rebuild.yaml
@@ -1,0 +1,29 @@
+# This workflow triggers a rebuild of the GO website when the gorefs.yaml file is updated.
+# This repo has the GO Workflow Bot app installed, and the app's private key is stored as
+# a repo secret. The private key is used to generate an access token. The access token is
+# provided to the GitHub CLI when triggering the deploy workflow in the
+# geneontology.github.io repo. Without the app-generated token, the default GITHUB_TOKEN
+# would not have the necessary permissions to trigger workflows in a different repo.
+
+name: Trigger Website Rebuild
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - metadata/gorefs.yaml
+      - .github/workflows/trigger-website-rebuild.yaml
+
+jobs:
+  trigger-website-rebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.WORKFLOW_BOT_APP_ID }}
+          private-key: ${{ secrets.WORKFLOW_BOT_PRIVATE_KEY }}
+      - run: gh workflow run deploy.yaml --repo geneontology/geneontology.github.io
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Re: https://github.com/geneontology/go-site/issues/2235 -- I will close the issue manually when I'm confident this is working as expected.

### Summary

These changes add a new workflow file (`.github/workflows/trigger-website-rebuild.yaml`) which runs when the `metadata/gorefs.yaml` file is changed in the `master` branch. 

It first validates the `gorefs.yaml` file according to its associated schema. Theoretically any validation issues would have been caught by the `qc.yaml` workflow during a PR. So this is just sort of a fail-safe against someone ignoring that check or committing directly to `master`. 

If the validation passes we generate an access token using the GO Workflow Bot app installed in this repo. Then we use that token and the GitHub CLI[^1] to trigger the `deploy.yaml` workflow[^2] in the `geneontology/geneontology.github.io` repo.

[^1]: https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows
[^2]: https://cli.github.com/manual/gh_workflow_run