### PR TITLE
Rollback some upstream files to last good

### DIFF
--- a/metadata/datasets/dictybase.yaml
+++ b/metadata/datasets/dictybase.yaml
@@ -52,7 +52,7 @@ datasets:
    dataset: dictybase
    submitter: dictyBase
    compression: gzip
-   source: https://ftp.ebi.ac.uk/pub/contrib/goa/dictyBase.gaf.gz
+   source: https://release.geneontology.org/2024-03-28/products/upstream_and_raw_data/dictybase-src.gaf.gz
    entity_type:
    status: active
    species_code: Ddis

--- a/metadata/datasets/mgi.yaml
+++ b/metadata/datasets/mgi.yaml
@@ -26,7 +26,7 @@ datasets:
    dataset: mgi
    submitter: mgi
    compression: gzip
-   source: https://mirror.geneontology.io/mgi-p2go-homology.gaf.gz
+   source: https://release.geneontology.org/2024-03-28/products/upstream_and_raw_data/mgi-src.gaf.gz
    entity_type:
    status: active
    species_code: Mmus

--- a/metadata/datasets/pombase.yaml
+++ b/metadata/datasets/pombase.yaml
@@ -16,7 +16,7 @@ datasets:
    dataset: pombase
    submitter: pombase
    compression: gzip
-   source: https://www.pombase.org/data/annotations/Gene_ontology/gene_association.pombase.gz
+   source: https://release.geneontology.org/2024-03-28/products/upstream_and_raw_data/pombase-src.gaf.gz
    entity_type:
    status: active
    species_code: Spom

--- a/metadata/datasets/tair.yaml
+++ b/metadata/datasets/tair.yaml
@@ -16,7 +16,7 @@ datasets:
    dataset: tair
    submitter: tair
    compression: gzip
-   source: https://www.arabidopsis.org/download_files/GO_and_PO_Annotations/Gene_Ontology_Annotations/gene_association.tair.gz
+   source: https://release.geneontology.org/2024-03-28/products/upstream_and_raw_data/tair-src.gaf.gz
    entity_type:
    status: active
    species_code: Atal


### PR DESCRIPTION
For https://github.com/geneontology/pipeline/issues/373.

This changes `source:` in these four datasets YAMLs to point to their `*-src.gaf.gz` files in https://release.geneontology.org/2024-03-28/products/upstream_and_raw_data/. This PR is necessary to avoid changes in their current upstream files. I'll provide some simple file length comparisons (`wc -l`) of rollback 2024-03-28 versions vs the current upstreams:

Dictybase - 81166 (rollback) vs 50732 (current)
MGI - 272742 (rollback) vs 310193 (current)
PomBase - 46162 (rollback) vs 45589 (current)
TAIR - 235092 (rollback) vs 189228 (current)

Tagging @kltm @pgaudet 