### PR TITLE
add version flag to validate.py produce call in pipeline Makefile in …

### DIFF
--- a/pipeline/Makefile
+++ b/pipeline/Makefile
@@ -86,7 +86,7 @@ SUPPRESS_THESE_TAGS = $(foreach tag,$(GORULE_TAGS_TO_SUPPRESS),--suppress-rule-r
 	# assigns a make variable called `group` computed from the $* generic target stem.
 	# Ex: target/groups/fb/fb.gaf as a target, the stem ($*) is target/groups/fb/fb, so `group` gets assigned to fb
 	$(eval group := $(lastword $(subst /, ,$*)))
-	validate.py -v produce $(group) --gpad --ttl -m $(METADATA_DIR) --target target/ --ontology $< $(DONT_VALIDATE) $(SUPPRESS_THESE_TAGS) --skip-existing-files --gaferencer-file $*.gaferences.json --base-download-url ${DOWNLOAD_URL_FOR_RELATIVE_PATHS}
+	validate.py -v produce $(group) --gpad-gpi-output-version "1.2" --ttl -m $(METADATA_DIR) --target target/ --ontology $< $(DONT_VALIDATE) $(SUPPRESS_THESE_TAGS) --skip-existing-files --gaferencer-file $*.gaferences.json --base-download-url ${DOWNLOAD_URL_FOR_RELATIVE_PATHS}
 	touch $@
 
 # dataset

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML
-ontobio==2.8.24
+ontobio==2.8.25
 click
 pyparsing==2.4.7
 antlr4-python3-runtime==4.9.3


### PR DESCRIPTION
…order to be explicit about which version of GPAD/GPI we're producing in the pipeline.  this is in prep for a switch to GPAD/GPI 2.0 that we want to test in snapshot

NOTE: requires an ontobio release ([after PR is merged](https://github.com/biolink/ontobio/pull/675) to add support for this flag)

the --gpad flag was removed because it did not appear to be used (it controlled whether or not the GPAD file was produced at all by this command).  