### PR TITLE
enable testing on snapshot of MGI upstream GAF produced at GO.  

### DIFF
--- a/metadata/datasets/mgi.yaml
+++ b/metadata/datasets/mgi.yaml
@@ -26,7 +26,7 @@ datasets:
    dataset: mgi
    submitter: mgi
    compression: gzip
-   source: https://release.geneontology.org/2024-03-28/products/upstream_and_raw_data/mgi-src.gaf.gz
+   source: https://mirror.geneontology.io/mgi-p2go-homology.gaf.gz
    entity_type:
    status: active
    species_code: Mmus

--- a/pipeline/Makefile
+++ b/pipeline/Makefile
@@ -88,7 +88,7 @@ SUPPRESS_THESE_TAGS = $(foreach tag,$(GORULE_TAGS_TO_SUPPRESS),--suppress-rule-r
 	# assigns a make variable called `group` computed from the $* generic target stem.
 	# Ex: target/groups/fb/fb.gaf as a target, the stem ($*) is target/groups/fb/fb, so `group` gets assigned to fb
 	$(eval group := $(lastword $(subst /, ,$*)))
-	validate.py -v produce $(group) --gpad --ttl -m $(METADATA_DIR) --target target/ --ontology $< $(DONT_VALIDATE) $(SUPPRESS_THESE_TAGS) --skip-existing-files --gaferencer-file $*.gaferences.json --base-download-url ${DOWNLOAD_URL_FOR_RELATIVE_PATHS}
+	validate.py -v produce $(group) --gpad-gpi-output-version "2.0" --ttl -m $(METADATA_DIR) --target target/ --ontology $< $(DONT_VALIDATE) $(SUPPRESS_THESE_TAGS) --skip-existing-files --gaferencer-file $*.gaferences.json --base-download-url ${DOWNLOAD_URL_FOR_RELATIVE_PATHS}
 	touch $@
 
 # dataset


### PR DESCRIPTION
PR  changes MGI metadata to retrieve upstream from MGI ingest pipeline and adds the GPAD/GPI 2.0 flag to validate.py produce command so that we start outputting GPAD/GPI 2.0 in snapshot. 

This should not be merged until we have a clean snapshot build.  