### PR TITLE
Revert to ontobio 2.9.2 to get snapshots through

### DIFF
--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML
-ontobio==2.9.7
+ontobio==2.9.2
 click
 pyparsing==2.4.7
 antlr4-python3-runtime==4.9.3


### PR DESCRIPTION
This reverts `ontobio` from 2.9.7 to 2.9.2 for the short-term purpose of getting `snapshot` runs to successfully finish before we are able to fix https://github.com/biolink/ontobio/issues/689. This is the "last good" ontobio installed on the Aug 11 `snapshot` run.

Note: this reversion shouldn't require any `pipeline/Makefile` reversion since the new GPAD/GPI args are compatible with both `ontobio` versions.

Some slack chat left me uncertain whether we should prioritize merging this to get `snapshot`s out or we should be attacking the aforementioned https://github.com/biolink/ontobio/issues/689. @sierra-moxon feel free to merge this if it looks like we're stuck on https://github.com/biolink/ontobio/issues/689 for a while. P.S. I'll also be out tomorrow thru into next week.