### PR TITLE
Update db-xrefs.yaml for additional COG entries

### DIFF
--- a/metadata/db-xrefs.yaml
+++ b/metadata/db-xrefs.yaml
@@ -378,9 +378,9 @@
   entity_types:
     - type_name: entity
       type_id: BET:0000000
-      url_syntax: http://www.ncbi.nlm.nih.gov/COG/grace/shokog.cgi?fun=[example_id]
+      url_syntax: https://www.ncbi.nlm.nih.gov/research/cog/cogcategory/[example_id]
       example_id: COG_Function:H
-      example_url: http://www.ncbi.nlm.nih.gov/COG/grace/shokog.cgi?fun=H
+      example_url: https://www.ncbi.nlm.nih.gov/research/cog/cogcategory/H
 - database: COG_Pathway
   name: NCBI COG pathway
   generic_urls:
@@ -388,9 +388,9 @@
   entity_types:
     - type_name: entity
       type_id: BET:0000000
-      url_syntax: http://www.ncbi.nlm.nih.gov/COG/new/release/coglist.cgi?pathw=[example_id]
+      url_syntax: https://www.ncbi.nlm.nih.gov/research/cog/pathway/[example_id]
       example_id: COG_Pathway:14
-      example_url: http://www.ncbi.nlm.nih.gov/COG/new/release/coglist.cgi?pathw=14
+      example_url: https://www.ncbi.nlm.nih.gov/research/cog/pathway/14
 - database: CollecTF
   name: Database of transcription factor binding sites (TFBS) in the Bacteria domain
   generic_urls:


### PR DESCRIPTION
For https://github.com/geneontology/go-site/issues/2374
Additional hints from https://github.com/geneontology/go-site/issues/2374#issuecomment-2422015422

@pgaudet That said, I'm not sure the COG_Pathway entry makes sense any longer. For example, looking at https://www.ncbi.nlm.nih.gov/research/cog/pathway/Na+-translocating%20Fd:NADH%20oxidoreductase/, I'm not sure that there is a real identifier in there: `COG_Pathway:Na+-translocating%20Fd:NADH%20oxidoreductase` seems wrong.

That said, "updating" here for `COG_Pathway` makes us no more wrong, but we might want explore this a little if we actually have xrefs that we need to link.