### PR TITLE
add GPIs for 50 vir/bac species

### DIFF
--- a/metadata/datasets/goa.yaml
+++ b/metadata/datasets/goa.yaml
@@ -961,7 +961,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_253.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:253
    exclude: true
@@ -979,7 +978,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_287.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:287
    exclude: true
@@ -997,7 +995,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_470.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:470
    exclude: true
@@ -1015,7 +1012,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_545.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:545
    exclude: true
@@ -1033,7 +1029,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_546.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:546
    exclude: true
@@ -1051,7 +1046,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_548.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:548
    exclude: true
@@ -1069,7 +1063,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_550.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:550
    exclude: true
@@ -1087,7 +1080,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_562.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:562
    exclude: true
@@ -1105,7 +1097,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_571.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:571
    exclude: true
@@ -1123,7 +1114,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_573.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:573
    exclude: true
@@ -1141,7 +1131,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_615.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:615
    exclude: true
@@ -1159,7 +1148,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_623.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:623
    exclude: true
@@ -1177,7 +1165,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_1313.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:1313
    exclude: true
@@ -1195,7 +1182,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_1352.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:1352
    exclude: true
@@ -1213,7 +1199,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_1353.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:1353
    exclude: true
@@ -1231,7 +1216,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_1390.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:1390
    exclude: true
@@ -1249,7 +1233,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_1392.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:1392
    exclude: true
@@ -1267,7 +1250,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_1901.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:1901
    exclude: true
@@ -1285,7 +1267,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_10254.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:10254
    exclude: true
@@ -1303,7 +1284,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_10255.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:10255
    exclude: true
@@ -1321,7 +1301,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_10298.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:10298
    exclude: true
@@ -1339,7 +1318,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_10335.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:10335
    exclude: true
@@ -1357,7 +1335,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_10359.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:10359
    exclude: true
@@ -1375,7 +1352,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_11251.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:11251
    exclude: true
@@ -1393,7 +1369,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_12118.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:12118
    exclude: true
@@ -1411,7 +1386,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_35703.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:35703
    exclude: true
@@ -1429,7 +1403,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_36352.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:36352
    exclude: true
@@ -1447,7 +1420,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_37734.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:37734
    exclude: true
@@ -1465,7 +1437,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_63746.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:63746
    exclude: true
@@ -1483,7 +1454,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_64320.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:64320
    exclude: true
@@ -1501,7 +1471,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_71421.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:71421
    exclude: true
@@ -1519,7 +1488,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_83333.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:83333
    exclude: true
@@ -1537,7 +1505,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_83334.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:83334
    exclude: true
@@ -1555,7 +1522,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_85962.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:85962
    exclude: true
@@ -1573,7 +1539,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_90371.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:90371
    exclude: true
@@ -1591,7 +1556,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_99287.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:99287
    exclude: true
@@ -1609,7 +1573,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_100226.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:100226
    exclude: true
@@ -1627,7 +1590,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_122586.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:122586
    exclude: true
@@ -1645,7 +1607,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_128958.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:128958
    exclude: true
@@ -1663,7 +1624,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_169963.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:169963
    exclude: true
@@ -1681,7 +1641,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_170187.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:170187
    exclude: true
@@ -1699,7 +1658,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_171101.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:171101
    exclude: true
@@ -1717,7 +1675,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_192222.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:192222
    exclude: true
@@ -1735,7 +1692,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_208964.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:208964
    exclude: true
@@ -1753,7 +1709,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_224308.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:224308
    exclude: true
@@ -1771,7 +1726,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_226185.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:226185
    exclude: true
@@ -1789,7 +1743,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_243273.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:243273
    exclude: true
@@ -1807,7 +1760,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_272558.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:272558
    exclude: true
@@ -1825,7 +1777,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_272634.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:272634
    exclude: true
@@ -1843,7 +1794,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_286636.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:286636
    exclude: true
@@ -1861,7 +1811,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_327105.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:327105
    exclude: true
@@ -1879,7 +1828,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_333760.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:333760
    exclude: true
@@ -1897,7 +1845,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_367830.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:367830
    exclude: true
@@ -1915,7 +1862,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_373153.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:373153
    exclude: true
@@ -1933,7 +1879,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_416870.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:416870
    exclude: true
@@ -1951,7 +1896,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_419947.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:419947
    exclude: true
@@ -1969,7 +1913,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_529507.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:529507
    exclude: true
@@ -1987,7 +1930,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_575584.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:575584
    exclude: true
@@ -2005,7 +1947,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_645098.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:645098
    exclude: true
@@ -2023,7 +1964,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_928302.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:928302
    exclude: true
@@ -2041,7 +1981,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_941280.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:941280
    exclude: true
@@ -2059,7 +1998,6 @@ datasets:
    source: https://mirror.geneontology.io/taxon_1125630.gpi.gz
    entity_type: all
    status: active
-   aggregates: goa
    taxa:
     - NCBITaxon:1125630
    exclude: true

--- a/metadata/datasets/goa.yaml
+++ b/metadata/datasets/goa.yaml
@@ -949,6 +949,1122 @@ datasets:
    exclude: true
 
  -
+   id: goa_virus_bacteria_taxon_253.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_253.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_253.gpi.gz
+   source: https://mirror.geneontology.io/taxon_253.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:253
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_287.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_287.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_287.gpi.gz
+   source: https://mirror.geneontology.io/taxon_287.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:287
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_470.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_470.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_470.gpi.gz
+   source: https://mirror.geneontology.io/taxon_470.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:470
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_545.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_545.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_545.gpi.gz
+   source: https://mirror.geneontology.io/taxon_545.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:545
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_546.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_546.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_546.gpi.gz
+   source: https://mirror.geneontology.io/taxon_546.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:546
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_548.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_548.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_548.gpi.gz
+   source: https://mirror.geneontology.io/taxon_548.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:548
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_550.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_550.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_550.gpi.gz
+   source: https://mirror.geneontology.io/taxon_550.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:550
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_562.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_562.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_562.gpi.gz
+   source: https://mirror.geneontology.io/taxon_562.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:562
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_571.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_571.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_571.gpi.gz
+   source: https://mirror.geneontology.io/taxon_571.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:571
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_573.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_573.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_573.gpi.gz
+   source: https://mirror.geneontology.io/taxon_573.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:573
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_615.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_615.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_615.gpi.gz
+   source: https://mirror.geneontology.io/taxon_615.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:615
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_623.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_623.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_623.gpi.gz
+   source: https://mirror.geneontology.io/taxon_623.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:623
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_1313.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_1313.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_1313.gpi.gz
+   source: https://mirror.geneontology.io/taxon_1313.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:1313
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_1352.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_1352.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_1352.gpi.gz
+   source: https://mirror.geneontology.io/taxon_1352.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:1352
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_1353.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_1353.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_1353.gpi.gz
+   source: https://mirror.geneontology.io/taxon_1353.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:1353
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_1390.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_1390.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_1390.gpi.gz
+   source: https://mirror.geneontology.io/taxon_1390.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:1390
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_1392.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_1392.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_1392.gpi.gz
+   source: https://mirror.geneontology.io/taxon_1392.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:1392
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_1901.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_1901.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_1901.gpi.gz
+   source: https://mirror.geneontology.io/taxon_1901.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:1901
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_10254.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_10254.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_10254.gpi.gz
+   source: https://mirror.geneontology.io/taxon_10254.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:10254
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_10255.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_10255.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_10255.gpi.gz
+   source: https://mirror.geneontology.io/taxon_10255.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:10255
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_10298.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_10298.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_10298.gpi.gz
+   source: https://mirror.geneontology.io/taxon_10298.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:10298
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_10335.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_10335.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_10335.gpi.gz
+   source: https://mirror.geneontology.io/taxon_10335.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:10335
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_10359.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_10359.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_10359.gpi.gz
+   source: https://mirror.geneontology.io/taxon_10359.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:10359
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_11251.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_11251.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_11251.gpi.gz
+   source: https://mirror.geneontology.io/taxon_11251.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:11251
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_12118.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_12118.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_12118.gpi.gz
+   source: https://mirror.geneontology.io/taxon_12118.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:12118
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_35703.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_35703.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_35703.gpi.gz
+   source: https://mirror.geneontology.io/taxon_35703.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:35703
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_36352.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_36352.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_36352.gpi.gz
+   source: https://mirror.geneontology.io/taxon_36352.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:36352
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_37734.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_37734.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_37734.gpi.gz
+   source: https://mirror.geneontology.io/taxon_37734.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:37734
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_63746.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_63746.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_63746.gpi.gz
+   source: https://mirror.geneontology.io/taxon_63746.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:63746
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_64320.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_64320.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_64320.gpi.gz
+   source: https://mirror.geneontology.io/taxon_64320.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:64320
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_71421.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_71421.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_71421.gpi.gz
+   source: https://mirror.geneontology.io/taxon_71421.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:71421
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_83333.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_83333.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_83333.gpi.gz
+   source: https://mirror.geneontology.io/taxon_83333.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:83333
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_83334.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_83334.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_83334.gpi.gz
+   source: https://mirror.geneontology.io/taxon_83334.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:83334
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_85962.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_85962.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_85962.gpi.gz
+   source: https://mirror.geneontology.io/taxon_85962.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:85962
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_90371.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_90371.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_90371.gpi.gz
+   source: https://mirror.geneontology.io/taxon_90371.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:90371
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_99287.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_99287.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_99287.gpi.gz
+   source: https://mirror.geneontology.io/taxon_99287.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:99287
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_100226.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_100226.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_100226.gpi.gz
+   source: https://mirror.geneontology.io/taxon_100226.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:100226
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_122586.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_122586.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_122586.gpi.gz
+   source: https://mirror.geneontology.io/taxon_122586.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:122586
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_128958.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_128958.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_128958.gpi.gz
+   source: https://mirror.geneontology.io/taxon_128958.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:128958
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_169963.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_169963.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_169963.gpi.gz
+   source: https://mirror.geneontology.io/taxon_169963.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:169963
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_170187.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_170187.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_170187.gpi.gz
+   source: https://mirror.geneontology.io/taxon_170187.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:170187
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_171101.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_171101.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_171101.gpi.gz
+   source: https://mirror.geneontology.io/taxon_171101.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:171101
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_192222.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_192222.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_192222.gpi.gz
+   source: https://mirror.geneontology.io/taxon_192222.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:192222
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_208964.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_208964.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_208964.gpi.gz
+   source: https://mirror.geneontology.io/taxon_208964.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:208964
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_224308.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_224308.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_224308.gpi.gz
+   source: https://mirror.geneontology.io/taxon_224308.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:224308
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_226185.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_226185.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_226185.gpi.gz
+   source: https://mirror.geneontology.io/taxon_226185.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:226185
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_243273.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_243273.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_243273.gpi.gz
+   source: https://mirror.geneontology.io/taxon_243273.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:243273
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_272558.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_272558.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_272558.gpi.gz
+   source: https://mirror.geneontology.io/taxon_272558.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:272558
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_272634.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_272634.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_272634.gpi.gz
+   source: https://mirror.geneontology.io/taxon_272634.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:272634
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_286636.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_286636.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_286636.gpi.gz
+   source: https://mirror.geneontology.io/taxon_286636.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:286636
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_327105.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_327105.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_327105.gpi.gz
+   source: https://mirror.geneontology.io/taxon_327105.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:327105
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_333760.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_333760.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_333760.gpi.gz
+   source: https://mirror.geneontology.io/taxon_333760.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:333760
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_367830.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_367830.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_367830.gpi.gz
+   source: https://mirror.geneontology.io/taxon_367830.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:367830
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_373153.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_373153.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_373153.gpi.gz
+   source: https://mirror.geneontology.io/taxon_373153.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:373153
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_416870.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_416870.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_416870.gpi.gz
+   source: https://mirror.geneontology.io/taxon_416870.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:416870
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_419947.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_419947.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_419947.gpi.gz
+   source: https://mirror.geneontology.io/taxon_419947.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:419947
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_529507.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_529507.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_529507.gpi.gz
+   source: https://mirror.geneontology.io/taxon_529507.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:529507
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_575584.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_575584.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_575584.gpi.gz
+   source: https://mirror.geneontology.io/taxon_575584.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:575584
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_645098.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_645098.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_645098.gpi.gz
+   source: https://mirror.geneontology.io/taxon_645098.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:645098
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_928302.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_928302.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_928302.gpi.gz
+   source: https://mirror.geneontology.io/taxon_928302.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:928302
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_941280.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_941280.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_941280.gpi.gz
+   source: https://mirror.geneontology.io/taxon_941280.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:941280
+   exclude: true
+
+ -
+   id: goa_virus_bacteria_taxon_1125630.gpi
+   label: "goa_virus_bacteria_gpi4neo"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_1125630.gpi.gz
+   type: gpi
+   dataset: goa_virus_bacteria
+   submitter: goa
+   compression: gzip
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_1125630.gpi.gz
+   source: https://mirror.geneontology.io/taxon_1125630.gpi.gz
+   entity_type: all
+   status: active
+   aggregates: goa
+   taxa:
+    - NCBITaxon:1125630
+   exclude: true
+
+ -
    id: interpro2go
    label: "interpro2go mapping file"
    description: "external2go file to map InterPro entries to GO terms"

--- a/metadata/datasets/goa.yaml
+++ b/metadata/datasets/goa.yaml
@@ -950,11 +950,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_253.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_253"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_253"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_253.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_253
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_253.gpi.gz
@@ -968,11 +968,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_287.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_287"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_287"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_287.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_287
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_287.gpi.gz
@@ -986,11 +986,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_470.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_470"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_470"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_470.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_470
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_470.gpi.gz
@@ -1004,11 +1004,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_545.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_545"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_545"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_545.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_545
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_545.gpi.gz
@@ -1022,11 +1022,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_546.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_546"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_546"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_546.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_546
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_546.gpi.gz
@@ -1040,11 +1040,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_548.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_548"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_548"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_548.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_548
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_548.gpi.gz
@@ -1058,11 +1058,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_550.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_550"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_550"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_550.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_550
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_550.gpi.gz
@@ -1076,11 +1076,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_562.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_562"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_562"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_562.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_562
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_562.gpi.gz
@@ -1094,11 +1094,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_571.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_571"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_571"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_571.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_571
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_571.gpi.gz
@@ -1112,11 +1112,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_573.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_573"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_573"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_573.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_573
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_573.gpi.gz
@@ -1130,11 +1130,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_615.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_615"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_615"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_615.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_615
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_615.gpi.gz
@@ -1148,11 +1148,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_623.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_623"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_623"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_623.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_623
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_623.gpi.gz
@@ -1166,11 +1166,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_1313.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_1313"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_1313"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_1313.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_1313
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_1313.gpi.gz
@@ -1184,11 +1184,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_1352.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_1352"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_1352"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_1352.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_1352
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_1352.gpi.gz
@@ -1202,11 +1202,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_1353.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_1353"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_1353"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_1353.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_1353
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_1353.gpi.gz
@@ -1220,11 +1220,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_1390.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_1390"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_1390"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_1390.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_1390
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_1390.gpi.gz
@@ -1238,11 +1238,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_1392.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_1392"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_1392"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_1392.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_1392
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_1392.gpi.gz
@@ -1256,11 +1256,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_1901.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_1901"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_1901"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_1901.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_1901
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_1901.gpi.gz
@@ -1274,11 +1274,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_10254.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_10254"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_10254"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_10254.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_10254
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_10254.gpi.gz
@@ -1292,11 +1292,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_10255.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_10255"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_10255"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_10255.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_10255
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_10255.gpi.gz
@@ -1310,11 +1310,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_10298.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_10298"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_10298"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_10298.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_10298
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_10298.gpi.gz
@@ -1328,11 +1328,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_10335.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_10335"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_10335"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_10335.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_10335
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_10335.gpi.gz
@@ -1346,11 +1346,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_10359.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_10359"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_10359"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_10359.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_10359
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_10359.gpi.gz
@@ -1364,11 +1364,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_11251.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_11251"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_11251"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_11251.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_11251
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_11251.gpi.gz
@@ -1382,11 +1382,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_12118.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_12118"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_12118"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_12118.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_12118
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_12118.gpi.gz
@@ -1400,11 +1400,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_35703.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_35703"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_35703"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_35703.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_35703
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_35703.gpi.gz
@@ -1418,11 +1418,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_36352.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_36352"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_36352"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_36352.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_36352
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_36352.gpi.gz
@@ -1436,11 +1436,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_37734.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_37734"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_37734"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_37734.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_37734
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_37734.gpi.gz
@@ -1454,11 +1454,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_63746.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_63746"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_63746"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_63746.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_63746
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_63746.gpi.gz
@@ -1472,11 +1472,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_64320.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_64320"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_64320"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_64320.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_64320
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_64320.gpi.gz
@@ -1490,11 +1490,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_71421.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_71421"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_71421"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_71421.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_71421
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_71421.gpi.gz
@@ -1508,11 +1508,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_83333.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_83333"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_83333"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_83333.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_83333
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_83333.gpi.gz
@@ -1526,11 +1526,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_83334.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_83334"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_83334"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_83334.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_83334
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_83334.gpi.gz
@@ -1544,11 +1544,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_85962.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_85962"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_85962"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_85962.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_85962
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_85962.gpi.gz
@@ -1562,11 +1562,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_90371.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_90371"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_90371"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_90371.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_90371
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_90371.gpi.gz
@@ -1580,11 +1580,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_99287.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_99287"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_99287"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_99287.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_99287
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_99287.gpi.gz
@@ -1598,11 +1598,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_100226.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_100226"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_100226"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_100226.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_100226
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_100226.gpi.gz
@@ -1616,11 +1616,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_122586.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_122586"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_122586"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_122586.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_122586
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_122586.gpi.gz
@@ -1634,11 +1634,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_128958.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_128958"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_128958"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_128958.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_128958
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_128958.gpi.gz
@@ -1652,11 +1652,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_169963.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_169963"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_169963"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_169963.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_169963
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_169963.gpi.gz
@@ -1670,11 +1670,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_170187.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_170187"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_170187"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_170187.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_170187
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_170187.gpi.gz
@@ -1688,11 +1688,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_171101.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_171101"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_171101"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_171101.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_171101
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_171101.gpi.gz
@@ -1706,11 +1706,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_192222.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_192222"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_192222"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_192222.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_192222
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_192222.gpi.gz
@@ -1724,11 +1724,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_208964.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_208964"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_208964"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_208964.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_208964
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_208964.gpi.gz
@@ -1742,11 +1742,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_224308.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_224308"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_224308"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_224308.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_224308
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_224308.gpi.gz
@@ -1760,11 +1760,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_226185.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_226185"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_226185"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_226185.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_226185
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_226185.gpi.gz
@@ -1778,11 +1778,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_243273.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_243273"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_243273"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_243273.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_243273
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_243273.gpi.gz
@@ -1796,11 +1796,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_272558.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_272558"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_272558"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_272558.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_272558
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_272558.gpi.gz
@@ -1814,11 +1814,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_272634.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_272634"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_272634"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_272634.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_272634
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_272634.gpi.gz
@@ -1832,11 +1832,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_286636.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_286636"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_286636"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_286636.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_286636
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_286636.gpi.gz
@@ -1850,11 +1850,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_327105.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_327105"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_327105"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_327105.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_327105
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_327105.gpi.gz
@@ -1868,11 +1868,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_333760.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_333760"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_333760"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_333760.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_333760
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_333760.gpi.gz
@@ -1886,11 +1886,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_367830.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_367830"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_367830"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_367830.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_367830
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_367830.gpi.gz
@@ -1904,11 +1904,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_373153.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_373153"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_373153"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_373153.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_373153
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_373153.gpi.gz
@@ -1922,11 +1922,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_416870.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_416870"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_416870"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_416870.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_416870
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_416870.gpi.gz
@@ -1940,11 +1940,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_419947.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_419947"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_419947"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_419947.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_419947
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_419947.gpi.gz
@@ -1958,11 +1958,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_529507.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_529507"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_529507"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_529507.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_529507
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_529507.gpi.gz
@@ -1976,11 +1976,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_575584.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_575584"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_575584"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_575584.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_575584
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_575584.gpi.gz
@@ -1994,11 +1994,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_645098.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_645098"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_645098"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_645098.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_645098
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_645098.gpi.gz
@@ -2012,11 +2012,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_928302.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_928302"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_928302"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_928302.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_928302
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_928302.gpi.gz
@@ -2030,11 +2030,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_941280.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_941280"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_941280"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_941280.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_941280
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_941280.gpi.gz
@@ -2048,11 +2048,11 @@ datasets:
 
  -
    id: goa_virus_bacteria_taxon_1125630.gpi
-   label: "goa_virus_bacteria_gpi4neo"
-   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database"
+   label: "goa_virus_bacteria_gpi4neo taxon_1125630"
+   description: "GPI file for use in NEO for virus and bacteria annotation from EBI Gene Ontology Annotation Database taxon_1125630"
    url: https://current.geneontology.org/annotations/goa_virus_bacteria_taxon_1125630.gpi.gz
    type: gpi
-   dataset: goa_virus_bacteria
+   dataset: goa_virus_bacteria_taxon_1125630
    submitter: goa
    compression: gzip
    mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/virus_bacteria_gpi4neo/taxon_1125630.gpi.gz


### PR DESCRIPTION
For geneontology/neo#116; this adds the (hopefully inactive) metadata necessary for the new request GPIs to filter into the NEO build automagically.

The question here is whether there would be unintended consequences.