### PR TITLE
Update requirements.txt to lock in pysolr version

### DIFF
--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,4 +1,5 @@
 PyYAML
+pysolr==3.6
 ontobio==2.9.12
 click
 pyparsing==2.4.7


### PR DESCRIPTION
For https://github.com/geneontology/go-site/issues/2445 that @dustine32 was working on. 

This may be better done by fixing things up in ontobio, but locking the version at 3.6 (before the recent 3.10 can be installed, which eventually causes the setuptools conflict) seems to do the trick at least for the pipeline use case.