### PR TITLE
Add paint_japonicusdb dataset to paint.yaml

### DIFF
--- a/metadata/datasets/paint.yaml
+++ b/metadata/datasets/paint.yaml
@@ -146,6 +146,23 @@ datasets:
     - NCBITaxon:4896
    merges_into: pombase
 
+-
+   id: paint_japonicusdb.gaf
+   label: "paint_japonicusdb gaf file"
+   description: "gaf file for paint_japonicusdb from PAINT"
+   type: gaf
+   dataset: paint_japonicusdb
+   submitter: paint
+   compression: gzip
+   source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_japonicusdb.gaf.gz
+   entity_type:
+   status: active
+   species_code: Sjap
+   taxa:
+    - NCBITaxon:4897
+    - NCBITaxon:402676
+   merges_into: japonicusdb
+
  -
    id: paint_rgd.gaf
    label: "paint_rgd gaf file"


### PR DESCRIPTION
For geneontology/pipeline#413.

This should be merged only after the URL for `gene_association.paint_japonicusdb.gaf.gz` is in-place at `ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_japonicusdb.gaf.gz`.

@kltm @pgaudet Let me know when I can start hosting this new file. Specifically, do you want me to wait until we have a finished `snapshot` run on the current IBA data?