### PR TITLE
updated gorule-0000008.md, do_not_manually_annotate no longer exists

### DIFF
--- a/metadata/rules/gorule-0000008.md
+++ b/metadata/rules/gorule-0000008.md
@@ -14,7 +14,7 @@ examples:
     - comment: fails because GO:0005622 is in the subset gocheck_do_not_manually_annotate
       format: gaf
       input: "UniProtKB	Q9DGE2	mapk14a		GO:0005622	PMID:10995439	IDA		C	Mitogen-activated protein kinase 14A	mapk14a|mapk14	protein	taxon:7955	20180129	UniProt"
-    - comment: fails because GO:0000910 is in the subset gocheck_do_not_manually_annotate
+    - comment: fails because GO:0000910 is in the subset gocheck_do_not_annotate
       format: gaf
       input: "UniProtKB	Q9WVH3	Foxo4		GO:0000910	PMID:12048180	IDA		P	Forkhead box protein O4	Foxo4|Afx|Afx1	protein	taxon:10090	20110425	MGI"
   pass: 
@@ -26,20 +26,14 @@ examples:
 Some terms are too high-level to provide useful information when used
 for annotation, regardless of the evidence code used.
 
-We provide and maintain the list of too high-level terms as two subsets
+We provide and maintain the list of too high-level terms as a subsets
 in the ontology:
 
 -   gocheck\_do\_not\_annotate "Term not to be used for direct
     annotation"
--   gocheck\_do\_not\_manually\_annotate "Term not to be used for direct
-    manual annotation"
 
-Both subsets denote high level terms, not to be used for any manual
+This subset denotes high level terms, not to be used for any manual
 annotation.
 
-For inferred electronic annotations (IEAs), we allow the use of terms
-from the gocheck\_do\_not\_manually\_annotate subset. These terms may
-still offer some general information, but a human curator should always
-be able to find a more specific annotation.
 
 Error report: <group>.report.md


### PR DESCRIPTION
I don't remember why we collapsed the distinction but this no longer exists