### PR TITLE
Change GO_REF rule to filter obsolete references

### DIFF
--- a/metadata/rules/gorule-0000030.md
+++ b/metadata/rules/gorule-0000030.md
@@ -2,10 +2,10 @@
 layout: rule
 id: GORULE:0000030
 title: "Obsolete GO_REFs are not allowed"
-type: report
-fail_mode: soft
+type: filter
+fail_mode: hard
 status: implemented
 contact: "go-quality@lists.stanford.edu"
 ---
 GO_REFs are here: https://github.com/geneontology/go-site/tree/master/metadata/gorefs.yaml
-References for which is_obsolete: `true` should not be allowed as a reference (GAF column 6; GPAD column 5).
+References for which is_obsolete: `true` are not allowed as a reference (GAF column 6; GPAD column 5), and annotations using those as a reference are filtered by the pipeline and reported as errors.


### PR DESCRIPTION
Updated rule to filter out obsolete GO_REFs and change fail mode to hard.