### PR TITLE
Update goex.yaml

### DIFF
--- a/metadata/goex.yaml
+++ b/metadata/goex.yaml
@@ -1403,7 +1403,7 @@ organisms:
     taxonomic_group: NCBITaxon:2
     full_name: Escherichia coli O157:H7
     common_name_goc: E. coli O157:H7
-    common_name_uniprot:
+    common_name_uniprot: E. coli O157:H7
     code_uniprot: ECO57
     code_goc:
     group: UniProt
@@ -1708,14 +1708,4 @@ organisms:
     code_goc:
     group: UniProt
     uniprot_proteome_id: uniprot.proteome:UP000009183
-    mod_id_space: UniProtKB
-  - taxon_id: NCBITaxon:83334
-    taxonomic_group: NCBITaxon:2
-    full_name: Escherichia coli O157:H7
-    common_name_goc: E. coli O157:H7
-    common_name_uniprot: E. coli O157:H7
-    code_uniprot: ECO57
-    code_goc:
-    group: UniProt
-    uniprot_proteome_id: uniprot.proteome:UP000000558
     mod_id_space: UniProtKB


### PR DESCRIPTION
this duplicate entry is causing other pulls to fail. was the intent just to add `common_name_uniprot: E. coli O157:H7` to the existing entry?