### PR TITLE
Remove Noctua edit permissions for inactive users

### DIFF
--- a/metadata/users.yaml
+++ b/metadata/users.yaml
@@ -296,10 +296,6 @@
 -
   accounts:
     github: sandyl27
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.bio.tamu.edu'
   nickname: 'Sandy Labonte'
@@ -351,10 +347,6 @@
 -
   accounts:
     github: dosumis
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://geneontology.org'
   nickname: 'David Osumi-Sutherland'
@@ -367,10 +359,6 @@
   uri: 'GOC:rc'
   xref: 'GOC:rc'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://flybase.org'
   nickname: 'Susan Tweedie'
@@ -393,10 +381,6 @@
   uri: 'GOC:ai'
   xref: 'GOC:ai'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   comment: 'former affiliations: FlyBase, UniProt, GO'
   groups:
     - 'http://www.ucl.ac.uk/functional-gene-annotation/neurological/projects/parkinsons'
@@ -420,10 +404,6 @@
   uri: 'https://orcid.org/0000-0001-9227-417X'
   xref: 'GOC:jid'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://geneontology.org'
   nickname: 'Jane Lomax'
@@ -433,10 +413,6 @@
 -
   accounts:
     github: mcourtot
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://geneontology.org'
   nickname: 'Melanie Courtot'
@@ -446,10 +422,6 @@
 -
   accounts:
     github: paolaroncaglia
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://geneontology.org'
   nickname: 'Paola Roncaglia'
@@ -476,10 +448,6 @@
 -
   accounts:
     github: zebrafishembryo
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://geneontology.org'
   previous-groups:
@@ -490,10 +458,6 @@
 -
   accounts:
     github: esperetta
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.ebi.ac.uk/GOA'
   nickname: 'Elena Speretta'
@@ -503,10 +467,6 @@
 -
   accounts:
     github: ggeorghiou
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.ebi.ac.uk'
   nickname: 'George Georghiou'
@@ -516,10 +476,6 @@
 -
   accounts:
     github: hbye
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.uniprot.org'
   nickname: 'Hema Bye-A-Jee'
@@ -546,10 +502,6 @@
 -
   accounts:
     github: rachhuntley
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   comment: 'formerly GOA'
   groups:
     - 'http://www.ucl.ac.uk/functional-gene-annotation/cardiovascular'
@@ -572,10 +524,6 @@
 -
   accounts:
     github: bmeldal
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   comment: 'Birgit Meldal'
   groups:
     - 'https://www.ebi.ac.uk/intact'
@@ -660,10 +608,6 @@
   uri: 'GOC:id'
   xref: 'GOC:id'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://informatics.jax.org'
     - 'http://geneontology.org'
@@ -700,10 +644,6 @@
 -
   accounts:
     github: judyblake
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://informatics.jax.org'
     - 'http://geneontology.org'
@@ -815,10 +755,6 @@
 -
   accounts:
     github: PolinaEka
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.pombase.org'
   nickname: 'Polina Eka'
@@ -832,10 +768,6 @@
 -
   accounts:
     github: cooperl09
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://oregonstate.edu'
   nickname: 'Laurel Cooper'
@@ -894,10 +826,6 @@
 -
   accounts:
     github: phanivg
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://flybase.org'
   previous-groups:
@@ -937,10 +865,6 @@
 -
   accounts:
     github: slaulederkind
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://rgd.mcw.edu'
   nickname: 'Stan Laulederkind'
@@ -1177,10 +1101,6 @@
   uri: 'https://orcid.org/0000-0001-5472-917X'
   xref: 'GOC:se'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.yeastgenome.org'
   nickname: 'Selina Dwight'
@@ -1190,10 +1110,6 @@
 -
   accounts:
     github: daniwelter
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.ebi.ac.uk/spot'
   nickname: 'Dani Welter'
@@ -1218,10 +1134,6 @@
 -
   accounts:
     github: dhldhl
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.arabidopsis.org'
   nickname: 'Donghui Li'
@@ -1388,10 +1300,6 @@
   uri: 'GOC:ae'
   xref: 'GOC:ae'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.eisai.com'
   nickname: 'Mitsuteru Nakao'
@@ -1448,10 +1356,6 @@
   uri: 'GOC:dl'
   xref: 'GOC:dl'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.uniprot.org'
   nickname: 'Elena Cibrian-Uhalte'
@@ -1501,10 +1405,6 @@
   uri: 'GOC:kd'
   xref: 'GOC:kd'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.uniprot.org'
   nickname: 'Klemens Pichler'
@@ -1585,10 +1485,6 @@
 -
   accounts:
     github: pgarmiri
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.uniprot.org'
   nickname: 'Penelope Garmiri'
@@ -1829,10 +1725,6 @@
   uri: 'https://orcid.org/0000-0002-4142-7153'
   xref: 'GOC:sat'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://zfin.org'
   nickname: 'Ken Frazer'
@@ -1854,10 +1746,6 @@
 -
   accounts:
     github: cmpich
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://zfin.org'
   nickname: 'Christian Pich'
@@ -1882,10 +1770,6 @@
   uri: 'https://orcid.org/0000-0002-8075-8625'
   xref: 'GOC:lb'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.ohsu.edu'
   nickname: 'Melissa Haendel'
@@ -2213,10 +2097,6 @@
 -
   accounts:
     github: monicacecilia
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://lbl.gov'
   nickname: 'Monica Munoz-Torres'
@@ -2229,10 +2109,6 @@
   uri: 'GOC:giardia'
   xref: 'GOC:giardia'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://ronininstitute.org'
   nickname: 'Anne Thessen'
@@ -2266,20 +2142,12 @@
   uri: 'GOC:pnr'
   xref: 'GOC:pnr'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.sib.swiss'
   nickname: 'Aurore Britan'
   organization: SIB
   uri: 'https://orcid.org/0000-0002-9846-2590'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.sib.swiss'
   nickname: 'Valerie Hinard'
@@ -2306,30 +2174,18 @@
   uri: 'GOC:ani'
   xref: 'GOC:ani'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.ebi.ac.uk'
   nickname: "Claire O'Donovan"
   organization: EMBL-EBI
   uri: 'https://orcid.org/0000-0001-8051-7429'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.ebi.ac.uk'
   nickname: 'Amaia Sangrador'
   organization: EMBL-EBI
   uri: 'https://orcid.org/0000-0001-6688-429X'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.ebi.ac.uk'
   nickname: 'Alex Bateman'
@@ -2385,30 +2241,18 @@
   organization: 'GO Central'
   uri: 'https://orcid.org/0000-0002-8688-6599'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.phenotypercn.org'
   nickname: 'Istvan Miko'
   organization: PhenotypeRCN
   uri: 'https://orcid.org/0000-0001-9719-0215'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.ohsu.edu'
   nickname: 'Matthew Brush'
   organization: OHSU
   uri: 'https://orcid.org/0000-0002-1048-5019'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.sandiego.edu'
   nickname: 'Wasila Dahdul'
@@ -2426,10 +2270,6 @@
   uri: 'https://orcid.org/0000-0001-9990-8331'
   xref: 'GOC:add'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.ohsu.edu'
   nickname: 'Jean-Philippe Francois Gourdine'
@@ -2438,10 +2278,6 @@
 -
   accounts:
     github: preecej
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://planteome.org'
   nickname: 'Justin Preece'
@@ -2450,10 +2286,6 @@
 -
   accounts:
     github: jaiswalp
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://planteome.org'
   nickname: 'Pankaj Jaiswal'
@@ -2461,20 +2293,12 @@
   uri: 'https://orcid.org/0000-0002-1005-8383'
   xref: 'GOC:pj'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.buffalo.edu'
   nickname: 'Mark Jensen'
   organization: 'University at Buffalo'
   uri: 'https://orcid.org/0000-0001-9228-8838'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.embo.org'
   nickname: 'Nancy George'
@@ -2483,90 +2307,54 @@
 -
   accounts:
     github: pbuttigieg
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.awi.de'
   nickname: 'Pier Luigi Buttigieg'
   organization: AWI
   uri: 'https://orcid.org/0000-0002-4366-3088'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.hsph.harvard.edu'
   nickname: 'Bridget C Hanna'
   organization: 'Harvard T.H. Chan School of Public Health'
   uri: 'https://orcid.org/0000-0001-8798-3326'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.ohsu.edu'
   nickname: 'Daniel Keith'
   organization: OHSU
   uri: 'https://orcid.org/0000-0002-1643-6242'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://ualr.edu'
   nickname: 'Thomas Hahn'
   organization: UALR
   uri: 'https://orcid.org/0000-0002-3499-1346'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.massgeneral.org'
   nickname: 'Karl Helmer'
   organization: MGH
   uri: 'https://orcid.org/0000-0002-5113-6843'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://oregonstate.edu'
   nickname: 'Justin Elser'
   organization: OSU
   uri: 'https://orcid.org/0000-0003-0921-1982'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.roswellpark.org'
   nickname: 'William Duncan'
   organization: 'Roswell Park Cancer Institute'
   uri: 'https://orcid.org/0000-0001-9625-1899'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.cgiar.org'
   nickname: 'Medha Devare'
   organization: CGIAR
   uri: 'https://orcid.org/0000-0003-0041-4812'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.ncsu.edu'
   nickname: 'Cynthia J Grondin'
@@ -2575,10 +2363,6 @@
 -
   accounts:
     github: selewis
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://geneontology.org'
     - 'http://lbl.gov'
@@ -2586,80 +2370,48 @@
   organization: LBL
   uri: 'https://orcid.org/0000-0002-8343-612X'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.adm.com'
   nickname: 'Jie Liu'
   organization: ADM
   uri: 'https://orcid.org/0000-0002-9280-1539'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.epa.gov'
   nickname: 'Ronglin Wang'
   organization: 'US EPA'
   uri: 'https://orcid.org/0000-0002-6537-9758'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.ucdavis.edu'
   nickname: 'Matthew Lange'
   organization: 'UC Davis'
   uri: 'https://orcid.org/0000-0002-6148-7962'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.ebi.ac.uk'
   nickname: 'Daniel Gonzalez'
   organization: EMBL-EBI
   uri: 'https://orcid.org/0000-0002-3919-1380'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.ebi.ac.uk'
   nickname: 'Emma Hatton-Ellis'
   organization: EMBL-EBI
   uri: 'https://orcid.org/0000-0002-7262-1928'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.ebi.ac.uk'
   nickname: 'Barbara Palka'
   organization: EMBL-EBI
   uri: 'https://orcid.org/0000-0001-8256-1466'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.ebi.ac.uk'
   nickname: 'Ramona Britto'
   organization: EMBL-EBI
   uri: 'https://orcid.org/0000-0003-1011-5410'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.ebi.ac.uk'
   nickname: 'Alistair MacDougall'
@@ -2668,30 +2420,18 @@
 -
   accounts:
     github: tuli
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.wormbase.org'
   nickname: 'Mary Ann Tuli'
   organization: WB
   uri: 'https://orcid.org/0000-0002-4667-9528'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.crick.ac.uk'
   nickname: 'Jacqueline Hayles'
   organization: Crick
   uri: 'https://orcid.org/0000-0002-8599-8206'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.ebi.ac.uk'
   nickname: 'Nidhi Tyagi'
@@ -2711,10 +2451,6 @@
   uri: 'https://orcid.org/0000-0002-3358-4423'
   xref: 'GOC:rz'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://nidm.nidash.org'
   nickname: 'Satrajit Ghosh'
@@ -2772,10 +2508,6 @@
 -
   accounts:
     github: vponferrada
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.xenbase.org'
   nickname: 'Virgilio Ponferrada'
@@ -2784,10 +2516,6 @@
 -
   accounts:
     github: chris-grove
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.wormbase.org'
   nickname: 'Christian Grove'
@@ -2796,10 +2524,6 @@
 -
   accounts:
     github: owlang
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.yeastgenome.org'
   nickname: 'Olivia Lang'
@@ -2834,10 +2558,6 @@
 -
   accounts:
     github: ebakker2
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.arabidopsis.org'
   nickname: 'Erica Bakker'
@@ -2846,10 +2566,6 @@
 -
   accounts:
     github: mchibucos
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.igs.umaryland.edu'
   nickname: 'Marcus Chibucos'
@@ -2872,10 +2588,6 @@
 -
   accounts:
     github: BarbaraCzub
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.ucl.ac.uk/functional-gene-annotation/neurological'
     - 'http://www.ucl.ac.uk/functional-gene-annotation/cardiovascular'
@@ -2887,10 +2599,6 @@
 -
   accounts:
     github: goldturtle
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.wormbase.org'
   nickname: 'Hans-Michael Muller'
@@ -2899,10 +2607,6 @@
 -
   accounts:
     github: kyook
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.wormbase.org'
   nickname: 'Karen Yook'
@@ -2911,10 +2615,6 @@
 -
   accounts:
     github: fatimasilva
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://eupathdb.org'
     - 'http://www.genedb.org'
@@ -2924,10 +2624,6 @@
 -
   accounts:
     github: uliboehme
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.genedb.org'
   nickname: 'Ulrike Bohme'
@@ -2936,10 +2632,6 @@
 -
   accounts:
     github: astridla
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.ntnu.edu'
   nickname: 'Astrid Lægreid'
@@ -2948,10 +2640,6 @@
 -
   accounts:
     github: gthayman
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://rgd.mcw.edu'
   nickname: 'George Thomas Hayman'
@@ -2960,10 +2648,6 @@
 -
   accounts:
     github: emilycamozzi
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.yeastgenome.org'
   nickname: 'Emily Heald Camozzi'
@@ -2984,10 +2668,6 @@
 -
   accounts:
     github: marieALaporte
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.bioversityinternational.org'
   nickname: 'Marie-Angélique Laporte'
@@ -2996,10 +2676,6 @@
 -
   accounts:
     github: austinmeier
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://planteome.org'
   nickname: Austin
@@ -3008,10 +2684,6 @@
 -
   accounts:
     github: grlazo
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.usda.gov'
   nickname: 'Gerard Lazo'
@@ -3020,10 +2692,6 @@
 -
   accounts:
     github: priya8328
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://planteome.org'
   nickname: 'Priyanka Garg'
@@ -3032,10 +2700,6 @@
 -
   accounts:
     github: genizamt
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://oregonstate.edu'
   nickname: 'Matthew Geniza'
@@ -3044,10 +2708,6 @@
 -
   accounts:
     github: noor-albader
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://oregonstate.edu'
   nickname: 'Noor Al-Bader'
@@ -3056,10 +2716,6 @@
 -
   accounts:
     github: naithanis
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://oregonstate.edu'
   nickname: 'Sushma Naithani'
@@ -3068,10 +2724,6 @@
 -
   accounts:
     github: guptapa
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://oregonstate.edu'
   nickname: 'Parul Gupta'
@@ -3080,10 +2732,6 @@
 -
   accounts:
     github: TomConlin
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://monarchinitiative.org'
   nickname: 'Tom Conlin'
@@ -3092,10 +2740,6 @@
 -
   accounts:
     github: gitkumard
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://planteome.org'
   nickname: 'Dhirendra Kumar'
@@ -3104,10 +2748,6 @@
 -
   accounts:
     github: dougli1sqrd
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://geneontology.org'
   nickname: 'Eric Douglass'
@@ -3116,10 +2756,6 @@
 -
   accounts:
     github: kshefchek
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.ohsu.edu'
   nickname: 'Kent Shefchek'
@@ -3128,10 +2764,6 @@
 -
   accounts:
     github: dnahotline
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://monarchinitiative.org'
     - 'https://ncats.nih.gov/translator'
@@ -3177,10 +2809,6 @@
 -
   accounts:
     github: Shellerstedt
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.yeastgenome.org'
   nickname: 'Sage Hellerstedt'
@@ -3189,10 +2817,6 @@
 -
   accounts:
     github: mendelje
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.wormbase.org'
   nickname: 'Jane Mendel'
@@ -3208,10 +2832,6 @@
 -
   accounts:
     github: yy20716
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://lbl.gov'
     - 'http://geneontology.org'
@@ -3221,10 +2841,6 @@
 -
   accounts:
     github: WBjae
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.wormbase.org'
   nickname: 'Jae Cho'
@@ -3258,10 +2874,6 @@
 -
   accounts:
     github: goodb
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://geneontology.org'
   nickname: 'Ben Good'
@@ -3282,10 +2894,6 @@
 -
   accounts:
     github: lpalbou
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://geneontology.org'
   nickname: 'Laurent-Philippe Albou'
@@ -3294,10 +2902,6 @@
 -
   accounts:
     github: paulwsternberg
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.wormbase.org'
   nickname: 'Paul W. Sternberg'
@@ -3318,10 +2922,6 @@
 -
   accounts:
     github: barbdunn
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.yeastgenome.org'
   nickname: 'Barbara Dunn'
@@ -3330,10 +2930,6 @@
 -
   accounts:
     github: Yalbibalderas
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.iner.salud.gob.mx'
     - 'http://www.conacyt.gob.mx/index.php/el-conacyt/desarrollo-cientifico/catedrasconacyt'
@@ -3364,10 +2960,6 @@
   organization: 'Department of Functional Genomics, Center for Neurogenomics and Cognitive Research, Neuroscience Campus Amsterdam, Vrije Universiteit (VU), Amsterdam, the Netherlands'
   uri: 'https://orcid.org/0000-0001-9425-2935'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://syngo.vu.nl'
   nickname: 'Daniela Dieterich'
@@ -3394,10 +2986,6 @@
   organization: 'Department of Neurochemistry and Molecular Biology, Leibniz Institute for Neurobiology, Magdeburg, Germany'
   uri: 'https://orcid.org/0000-0002-0269-0311'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://syngo.vu.nl'
   nickname: 'Eckart Gundelfinger'
@@ -3414,10 +3002,6 @@
   organization: 'Department of Functional Genomics, Center for Neurogenomics and Cognitive Research, Neuroscience Campus Amsterdam, Vrije Universiteit (VU), Amsterdam, the Netherlands'
   uri: 'https://orcid.org/0000-0002-9900-4233'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://syngo.vu.nl'
   nickname: 'Arthur de Jong'
@@ -3444,20 +3028,12 @@
   organization: 'Department of Functional Genomics, Center for Neurogenomics and Cognitive Research, Neuroscience Campus Amsterdam, Vrije Universiteit (VU), Amsterdam, the Netherlands'
   uri: 'https://orcid.org/0000-0002-2514-0216'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://syngo.vu.nl'
   nickname: 'Momchil Ninov'
   organization: 'Department of Neurobiology, Max Planck Institute for Biophysical Chemistry, Gottingen, Germany'
   uri: 'https://orcid.org/0000-0002-0808-7003'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://syngo.vu.nl'
   nickname: 'Mahdokht Kohansalnodehi'
@@ -3474,10 +3050,6 @@
   organization: 'Department of Neurobiology, Max Planck Institute for Biophysical Chemistry, Gottingen, Germany'
   uri: 'https://orcid.org/0000-0003-1542-3498'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://syngo.vu.nl'
   nickname: 'Timothy Ryan'
@@ -3514,10 +3086,6 @@
   organization: 'Department of Biology, Faculty of Science, Utrecht University, Utrecht, the Netherlands'
   uri: 'https://orcid.org/0000-0002-6153-3586'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://syngo.vu.nl'
   nickname: 'Casper Hoogenraad'
@@ -3534,40 +3102,24 @@
   organization: 'University of Lausanne, Department of Fundamental Neuroscience, Lausanne, Switzerland; University of Rome Tor Vergata, Department of Biomedicine and Prevention, Rome, Italy'
   uri: 'https://orcid.org/0000-0002-2094-7491'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://syngo.vu.nl'
   nickname: 'Vittoria Mariano'
   organization: 'University of Lausanne, Department of Fundamental Neuroscience, Lausanne, Switzerland; University of Rome Tor Vergata, Department of Biomedicine and Prevention, Rome, Italy'
   uri: 'https://orcid.org/0000-0002-9848-0262'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://syngo.vu.nl'
   nickname: 'Achsel Tilmann'
   organization: 'University of Lausanne, Department of Fundamental Neuroscience, Lausanne, Switzerland; University of Rome Tor Vergata, Department of Biomedicine and Prevention, Rome, Italy'
   uri: 'https://orcid.org/0000-0002-1190-4481'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://syngo.vu.nl'
   nickname: 'Claudia Bagni'
   organization: 'University of Lausanne, Department of Fundamental Neuroscience, Lausanne, Switzerland; University of Rome Tor Vergata, Department of Biomedicine and Prevention, Rome, Italy'
   uri: 'https://orcid.org/0000-0002-4419-210X'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://syngo.vu.nl'
   nickname: 'Chiara Verpelli'
@@ -3594,10 +3146,6 @@
   organization: 'RG Neuroplasticity, Leibniz Institute for Neurobiology, Magdeburg, Germany'
   uri: 'https://orcid.org/0000-0002-1585-539X'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://syngo.vu.nl'
   nickname: 'Michael Kreutz'
@@ -3624,20 +3172,12 @@
   organization: 'Department of Functional Genomics, Center for Neurogenomics and Cognitive Research, Neuroscience Campus Amsterdam, Vrije Universiteit (VU), Amsterdam, the Netherlands'
   uri: 'https://orcid.org/0000-0001-5259-4945'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://syngo.vu.nl'
   nickname: 'Noa Lipstein'
   organization: "Department of Molecular Neurobiology, Max Planck Institute of Experimental Medicine, Göttingen, Germany"
   uri: 'https://orcid.org/0000-0002-0755-5899'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://syngo.vu.nl'
   nickname: 'Cordelia Imig'
@@ -3654,10 +3194,6 @@
   organization: "Department of Molecular Neurobiology, Max Planck Institute of Experimental Medicine, Göttingen, Germany"
   uri: 'https://orcid.org/0000-0003-3185-5709'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://syngo.vu.nl'
   nickname: 'Nils Brose'
@@ -3674,10 +3210,6 @@
   organization: 'Center for Synaptic Brain Dysfunctions, Institute for Basic Science (IBS) and Department of Biological Sciences, Korea Advanced Institute of Science and Technology (KAIST), South Korea'
   uri: 'https://orcid.org/0000-0001-5518-6584'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://syngo.vu.nl'
   nickname: 'Hana Goldschmidt'
@@ -3704,10 +3236,6 @@
   organization: 'Department of Physiology, Yong Loo Lin School of Medicine, National University of Singapore, Singapore'
   uri: 'https://orcid.org/0000-0002-5615-1014'
 -
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://syngo.vu.nl'
   nickname: 'Roberto Malinow'
@@ -3739,10 +3267,6 @@
 -
   accounts:
     github: luanalicata
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://signor.uniroma2.it'
     - 'http://www.ucl.ac.uk/functional-gene-annotation/cardiovascular'
@@ -3752,10 +3276,6 @@
 -
   accounts:
     github: jrr-cpt
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.bio.tamu.edu'
   nickname: 'Jolene Ramsey'
@@ -3764,10 +3284,6 @@
 -
   accounts:
     github: erbolton
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://rgd.mcw.edu'
   nickname: 'Liz Bolton'
@@ -3776,10 +3292,6 @@
 -
   accounts:
     github: nsuvarnaiari
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.igs.umaryland.edu'
   nickname: 'Suvarna Nadendla'
@@ -3788,10 +3300,6 @@
 -
   accounts:
     github: mgiglio99
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.igs.umaryland.edu'
   nickname: 'Michelle Gwinn Giglio'
@@ -3858,10 +3366,6 @@
 -
   accounts:
     github: ShirinSaverimuttu
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.ucl.ac.uk/functional-gene-annotation/neurological'
     - 'http://www.ucl.ac.uk/functional-gene-annotation/cardiovascular'
@@ -3872,10 +3376,6 @@
 -
   accounts:
     github: MariosMakris
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.ucl.ac.uk/functional-gene-annotation/neurological'
     - 'http://www.ucl.ac.uk/functional-gene-annotation/cardiovascular'
@@ -3886,10 +3386,6 @@
 -
   accounts:
     github: Gschindelman
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.wormbase.org'
   nickname: 'Gary Schindelman'
@@ -3926,10 +3422,6 @@
 -
   accounts:
     github: Fbolio
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.wormbase.org'
   nickname: 'Fernando Bolio'
@@ -3974,10 +3466,6 @@
 -
   accounts:
     github: davidwsant
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://greekc.org'
   nickname: 'David W. Sant'
@@ -3986,10 +3474,6 @@
 -
   accounts:
     github: yazeyen
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.ktu.edu.tr/bmi-cancermodelingresearchgroup'
   nickname: 'Yasemin Zeynep Avci'
@@ -4003,10 +3487,6 @@
 -
   accounts:
     github: bea-liv
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://eupathdb.org'
   nickname: 'Beatrice Amos'
@@ -4014,10 +3494,6 @@
 -
   accounts:
     github: pwilx666
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://eupathdb.org'
   nickname: 'Paul Wilkinson'
@@ -4025,10 +3501,6 @@
 -
   accounts:
     github: obsidian83
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://eupathdb.org'
   nickname: 'David Starns'
@@ -4044,10 +3516,6 @@
 -
   accounts:
     github: GewieksteVos
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://greekc.org'
   nickname: 'Yves Snijckers'
@@ -4068,10 +3536,6 @@
 -
   accounts:
     github: neurogarg
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.wormbase.org'
   nickname: 'Pranjal Garg'
@@ -4080,10 +3544,6 @@
 -
   accounts:
     github: sharan-gh
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.wormbase.org'
   nickname: 'Sharan Prakash'
@@ -4092,10 +3552,6 @@
 -
   accounts:
     github: RahiNav
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.yeastgenome.org'
   nickname: 'Rahi Navelkar'
@@ -4104,10 +3560,6 @@
 -
   accounts:
     github: c02080219
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://geneontology.org'
   nickname: 'YuanChing Chen'
@@ -4140,10 +3592,6 @@
 -
   accounts:
     github: kalpanapanneerselvam
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.ebi.ac.uk/intact'
   nickname: 'Kalpana Panneerselvam'
@@ -4152,10 +3600,6 @@
 -
   accounts:
     github: tgroth58
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.buffalo.edu'
   nickname: 'Theodore Groth'
@@ -4164,10 +3608,6 @@
 -
   accounts:
     github: manulera
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'http://www.pombase.org'
   nickname: 'Manu Lera Ramirez'
@@ -4188,10 +3628,6 @@
 -
   accounts:
     github: moghelab
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.cornell.edu'
   nickname: 'Gaurav Moghe'
@@ -4212,10 +3648,6 @@
 -
   accounts:
     github: dexink
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.ufl.edu'
   nickname: 'Colbie Reed'
@@ -4281,10 +3713,6 @@
 -
   accounts:
     github: IvanTsers
-  authorizations:
-    noctua:
-      go:
-        allow-edit: true
   groups:
     - 'https://www.evolbio.mpg.de'
   nickname: 'Ivan Tsers'

--- a/scripts/bulk-user-update.py
+++ b/scripts/bulk-user-update.py
@@ -1,0 +1,173 @@
+####
+#### Bulk update users.yaml based on a list of ORCIDs.
+####
+#### Example usage:
+####  python3 scripts/bulk-user-update.py --users metadata/users.yaml --list orcids.txt --remove-edit
+####
+
+import argparse
+import re
+import sys
+import yaml
+
+
+def load_orcid_list(path):
+    """Load ORCIDs from a file.
+
+    First column is an ORCID. Remaining columns are ignored.
+    Columns are whitespace or pipe delimited.
+    Lines starting with # are skipped. Blank lines are skipped.
+    """
+    orcids = []
+    seen = set()
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            # Split on whitespace or pipe
+            parts = re.split(r'[\s|]+', line)
+            if parts:
+                orcid = parts[0].strip()
+                if orcid and orcid not in seen:
+                    orcids.append(orcid)
+                    seen.add(orcid)
+    return orcids
+
+
+def find_target_orcids(users, orcid_list):
+    """Parse users YAML and return the set of ORCIDs that have allow-edit."""
+    targets = set()
+    matched = set()
+    for user in users:
+        uri = user.get('uri', '')
+        for orcid in orcid_list:
+            if orcid in uri:
+                matched.add(orcid)
+                go_auths = (user.get('authorizations', {})
+                            .get('noctua', {})
+                            .get('go', {}))
+                if go_auths.get('allow-edit', False):
+                    targets.add(orcid)
+                break
+    return targets, matched
+
+
+def remove_authorizations_block(lines, start):
+    """Remove the authorizations block starting at line index `start`.
+
+    Returns the number of lines removed. The block is the line at `start`
+    (e.g. '  authorizations:\\n') plus all subsequent lines that are indented
+    deeper (more than 2 leading spaces).
+    """
+    count = 1  # the authorizations: line itself
+    base_indent = len(lines[start]) - len(lines[start].lstrip())
+    i = start + 1
+    while i < len(lines):
+        line = lines[i]
+        # Empty lines within a block shouldn't happen, but handle them
+        stripped = line.rstrip('\n')
+        if stripped == '':
+            break
+        indent = len(line) - len(line.lstrip())
+        if indent <= base_indent:
+            break
+        count += 1
+        i += 1
+    return count
+
+
+def main():
+
+    parser = argparse.ArgumentParser(
+        description='Bulk update users.yaml based on a list of ORCIDs.')
+    parser.add_argument('--users', required=True,
+                        help='Path to users.yaml')
+    parser.add_argument('--list', required=True,
+                        help='Path to file with ORCIDs (first column)')
+    parser.add_argument('--remove-edit', action='store_true',
+                        help='Remove allow-edit from noctua.go authorizations')
+    args = parser.parse_args()
+
+    ## Load ORCID list.
+    orcids = load_orcid_list(args.list)
+    print('Loaded {} ORCIDs from {}'.format(len(orcids), args.list))
+
+    ## Load users via YAML to identify targets.
+    with open(args.users) as f:
+        users = yaml.safe_load(f.read())
+
+    if args.remove_edit:
+        targets, matched = find_target_orcids(users, orcids)
+
+        print('Matched {} users'.format(len(matched)))
+        print('{} users have allow-edit to remove'.format(len(targets)))
+
+        ## Warn about ORCIDs not found.
+        unmatched = set(orcids) - matched
+        if unmatched:
+            print('\nWARNING: {} ORCIDs not found in users.yaml:'.format(
+                len(unmatched)))
+            for orcid in sorted(unmatched):
+                print('  {}'.format(orcid))
+
+        ## Now do text-based processing to preserve formatting.
+        with open(args.users) as f:
+            lines = f.readlines()
+
+        modified = 0
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+
+            ## Check if this line has a URI containing a target ORCID.
+            is_target_uri = False
+            if 'uri:' in line:
+                for orcid in targets:
+                    if orcid in line:
+                        is_target_uri = True
+                        break
+
+            ## If we found a target user's URI, scan backwards in the
+            ## current entry to find and mark the authorizations block.
+            ## Also scan forward since authorizations might come after uri.
+            if is_target_uri:
+                ## Find the start of this entry (the preceding '-' line).
+                entry_start = i
+                while entry_start > 0:
+                    if lines[entry_start].startswith('-'):
+                        break
+                    entry_start -= 1
+
+                ## Find the end of this entry (next '-' line or EOF).
+                entry_end = i + 1
+                while entry_end < len(lines):
+                    if lines[entry_end].startswith('-'):
+                        break
+                    entry_end += 1
+
+                ## Find the authorizations line within this entry.
+                for j in range(entry_start, entry_end):
+                    stripped = lines[j].strip()
+                    if stripped == 'authorizations:':
+                        count = remove_authorizations_block(lines, j)
+                        del lines[j:j + count]
+                        modified += 1
+                        ## Adjust i since we removed lines before or at i.
+                        if j <= i:
+                            i -= count
+                        break
+
+            i += 1
+
+        print('Modified {} users'.format(modified))
+
+        ## Write back.
+        with open(args.users, 'w') as f:
+            f.writelines(lines)
+
+        print('Wrote updated {}'.format(args.users))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Removes `allow-edit: true` from `authorizations.noctua.go` for 143 inactive users with no production models (out of 164 ORCIDs listed in #2638; 21 had no authorization block)
- Adds reusable `scripts/bulk-user-update.py` for future bulk user permission changes

## Verification
- `kwalify -E -f metadata/users.schema.yaml metadata/users.yaml` — valid
- `python3 ./scripts/sanity-check-users-and-groups.py --users metadata/users.yaml --groups metadata/groups.yaml` — non-failing run
- `allow-edit` count reduced from 269 to 126 (exactly -143)

## Test plan
- [ ] Verify kwalify schema validation passes
- [ ] Verify sanity-check-users-and-groups.py passes
- [ ] Spot-check a few users from the list to confirm authorizations block was removed

Closes #2638

🤖 Generated with [Claude Code](https://claude.com/claude-code)