### PR TITLE
Update PAINT dataset URLs from ftp.pantherdb.org to data.pantherdb.org

### DIFF
--- a/metadata/datasets/paint.yaml
+++ b/metadata/datasets/paint.yaml
@@ -10,7 +10,7 @@ datasets:
    dataset: paint_cgd
    submitter: paint
    compression: gzip
-   source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_cgd.gaf.gz
+   source: https://data.pantherdb.org/ftp/downloads/paint/presubmission/gene_association.paint_cgd.gaf.gz
    entity_type:
    status: active
    species_code: Calb
@@ -26,7 +26,7 @@ datasets:
    dataset: paint_dictybase
    submitter: paint
    compression: gzip
-   source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_dictyBase.gaf.gz
+   source: https://data.pantherdb.org/ftp/downloads/paint/presubmission/gene_association.paint_dictyBase.gaf.gz
    entity_type:
    status: active
    species_code: Ddis
@@ -45,7 +45,7 @@ datasets:
    dataset: paint_ecocyc
    submitter: paint
    compression: gzip
-   source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_ecocyc.gaf.gz
+   source: https://data.pantherdb.org/ftp/downloads/paint/presubmission/gene_association.paint_ecocyc.gaf.gz
    entity_type:
    status: active
    species_code: Ecol
@@ -61,7 +61,7 @@ datasets:
    dataset: paint_fb
    submitter: paint
    compression: gzip
-   source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_fb.gaf.gz
+   source: https://data.pantherdb.org/ftp/downloads/paint/presubmission/gene_association.paint_fb.gaf.gz
    entity_type:
    status: active
    species_code: Dmel
@@ -77,7 +77,7 @@ datasets:
    dataset: paint_goa_chicken
    submitter: paint
    compression: gzip
-   source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_chicken.gaf.gz
+   source: https://data.pantherdb.org/ftp/downloads/paint/presubmission/gene_association.paint_chicken.gaf.gz
    entity_type: chicken
    status: active
    species_code: Ggal
@@ -92,7 +92,7 @@ datasets:
    dataset: paint_goa_human
    submitter: paint
    compression: gzip
-   source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_human.gaf.gz
+   source: https://data.pantherdb.org/ftp/downloads/paint/presubmission/gene_association.paint_human.gaf.gz
    entity_type: human
    status: active
    species_code: Hsap
@@ -107,7 +107,7 @@ datasets:
    dataset: paint_mgi
    submitter: paint
    compression: gzip
-   source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_mgi.gaf.gz
+   source: https://data.pantherdb.org/ftp/downloads/paint/presubmission/gene_association.paint_mgi.gaf.gz
    entity_type:
    status: active
    species_code: Mmus
@@ -123,7 +123,7 @@ datasets:
    dataset: paint_other
    submitter: paint
    compression: gzip
-   source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_other.gaf.gz
+   source: https://data.pantherdb.org/ftp/downloads/paint/presubmission/gene_association.paint_other.gaf.gz
    entity_type:
    status: active
    species_code:
@@ -137,7 +137,7 @@ datasets:
    dataset: paint_pombase
    submitter: paint
    compression: gzip
-   source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_pombase.gaf.gz
+   source: https://data.pantherdb.org/ftp/downloads/paint/presubmission/gene_association.paint_pombase.gaf.gz
    entity_type:
    status: active
    species_code: Spom
@@ -154,7 +154,7 @@ datasets:
    dataset: paint_japonicusdb
    submitter: paint
    compression: gzip
-   source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_japonicusdb.gaf.gz
+   source: https://data.pantherdb.org/ftp/downloads/paint/presubmission/gene_association.paint_japonicusdb.gaf.gz
    entity_type:
    status: active
    species_code: Sjap
@@ -171,7 +171,7 @@ datasets:
    dataset: paint_rgd
    submitter: paint
    compression: gzip
-   source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_rgd.gaf.gz
+   source: https://data.pantherdb.org/ftp/downloads/paint/presubmission/gene_association.paint_rgd.gaf.gz
    entity_type:
    status: active
    species_code: Rnor
@@ -187,7 +187,7 @@ datasets:
    dataset: paint_sgd
    submitter: paint
    compression: gzip
-   source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_sgd.gaf.gz
+   source: https://data.pantherdb.org/ftp/downloads/paint/presubmission/gene_association.paint_sgd.gaf.gz
    entity_type:
    status: active
    species_code: Scer
@@ -207,7 +207,7 @@ datasets:
    dataset: paint_tair
    submitter: paint
    compression: gzip
-   source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_tair.gaf.gz
+   source: https://data.pantherdb.org/ftp/downloads/paint/presubmission/gene_association.paint_tair.gaf.gz
    entity_type:
    status: active
    species_code: Atal
@@ -223,7 +223,7 @@ datasets:
    dataset: paint_wb
    submitter: paint
    compression: gzip
-   source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_wb.gaf.gz
+   source: https://data.pantherdb.org/ftp/downloads/paint/presubmission/gene_association.paint_wb.gaf.gz
    entity_type:
    status: active
    species_code: Cele
@@ -239,7 +239,7 @@ datasets:
    dataset: paint_xenbase
    submitter: paint
    compression: gzip
-   source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_xenbase.gaf.gz
+   source: https://data.pantherdb.org/ftp/downloads/paint/presubmission/gene_association.paint_xenbase.gaf.gz
    entity_type:
    status: active
    species_code: Xenopus
@@ -256,7 +256,7 @@ datasets:
    dataset: paint_zfin
    submitter: paint
    compression: gzip
-   source: ftp://ftp.pantherdb.org/downloads/paint/presubmission/gene_association.paint_zfin.gaf.gz
+   source: https://data.pantherdb.org/ftp/downloads/paint/presubmission/gene_association.paint_zfin.gaf.gz
    entity_type:
    status: active
    species_code: Drer


### PR DESCRIPTION
## Summary
- Updates all 16 PAINT dataset source URLs in `metadata/datasets/paint.yaml`
- Old: `ftp://ftp.pantherdb.org/downloads/paint/presubmission/...`
- New: `https://data.pantherdb.org/ftp/downloads/paint/presubmission/...`

Fixes #2645

## Test plan
- [ ] Verify downstream pipelines can fetch GAF files from the new URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)