### PR TITLE
Add GitHub accounts for GO agentic AI workshop participants

### DIFF
--- a/metadata/users.yaml
+++ b/metadata/users.yaml
@@ -666,6 +666,8 @@
   uri: 'GOC:mgi_curators'
   xref: 'GOC:mgi_curators'
 -
+  accounts:
+    github: rwst
   nickname: 'Ralf Stephan'
   organization: MTBbase
   uri: 'GOC:rs'
@@ -807,6 +809,8 @@
   uri: 'GOC:bj'
   xref: 'GOC:bj'
 -
+  accounts:
+    github: gillespm
   nickname: 'Marc Gillespie'
   organization: Reactome
   uri: 'GOC:mg2'
@@ -1318,6 +1322,8 @@
 -
   groups:
     - 'https://www.uniprot.org'
+  accounts:
+    github: alanbridge
   nickname: 'Alan Bridge'
   organization: UniProt
   uri: 'https://orcid.org/0000-0003-2148-9135'
@@ -4039,3 +4045,37 @@
   nickname: 'Emily Bowler-Barnett'
   organization: UniProt
   uri: 'https://orcid.org/0000-0003-4785-7231'
+-
+  accounts:
+    github: karenrothfels
+  nickname: 'Karen Rothfels'
+  organization: OICR
+  uri: 'GOC:krc'
+  xref: 'GOC:krc'
+-
+  accounts:
+    github: lisamatthews
+  nickname: 'Lisa Matthews'
+  organization: Reactome
+  uri: 'GOC:lm'
+  xref: 'GOC:lm'
+-
+  accounts:
+    github: meilbes
+  nickname: 'Melissa Eilbes'
+  organization: MCW
+  uri: 'GOC:me'
+  xref: 'GOC:me'
+-
+  accounts:
+    github: alexsign
+  nickname: 'Alex Signoretti'
+  organization: UniProt
+  uri: 'GOC:as'
+  xref: 'GOC:as'
+-
+  accounts:
+    github: genegodbold
+  nickname: 'Gene Godbold'
+  uri: 'GOC:gg'
+  xref: 'GOC:gg'

--- a/metadata/users.yaml
+++ b/metadata/users.yaml
@@ -917,8 +917,8 @@
     - 'http://www.yeastgenome.org'
   nickname: 'Anand Sethuraman'
   organization: SGD
-  uri: 'GOC:as'
-  xref: 'GOC:as'
+  uri: 'GOC:asign'
+  xref: 'GOC:asign'
 -
   groups:
     - 'http://www.yeastgenome.org'
@@ -4050,32 +4050,32 @@
     github: karenrothfels
   nickname: 'Karen Rothfels'
   organization: OICR
-  uri: 'GOC:krc'
-  xref: 'GOC:krc'
+  uri: 'GOC:krothfels'
+  xref: 'GOC:krothfels'
 -
   accounts:
     github: lisamatthews
   nickname: 'Lisa Matthews'
   organization: Reactome
-  uri: 'GOC:lm'
-  xref: 'GOC:lm'
+  uri: 'GOC:lmatthews'
+  xref: 'GOC:lmatthews'
 -
   accounts:
     github: meilbes
   nickname: 'Melissa Eilbes'
   organization: MCW
-  uri: 'GOC:me'
-  xref: 'GOC:me'
+  uri: 'GOC:meilbes'
+  xref: 'GOC:meilbes'
 -
   accounts:
     github: alexsign
   nickname: 'Alex Signoretti'
   organization: UniProt
-  uri: 'GOC:as'
-  xref: 'GOC:as'
+  uri: 'GOC:asign'
+  xref: 'GOC:asign'
 -
   accounts:
     github: genegodbold
   nickname: 'Gene Godbold'
-  uri: 'GOC:gg'
-  xref: 'GOC:gg'
+  uri: 'GOC:ggodbold'
+  xref: 'GOC:ggodbold'

--- a/metadata/users.yaml
+++ b/metadata/users.yaml
@@ -4071,8 +4071,8 @@
     github: alexsign
   nickname: 'Alex Signoretti'
   organization: UniProt
-  uri: 'GOC:asign'
-  xref: 'GOC:asign'
+  uri: 'GOC:alexsign'
+  xref: 'GOC:alexsign'
 -
   accounts:
     github: genegodbold


### PR DESCRIPTION
## Summary

Add GitHub usernames for 8 users in `metadata/users.yaml` to support JupyterHub GitHub OAuth login for the upcoming GO agentic AI workshop (geneontology/go-jupyter).

The JupyterHub instance uses GitHub OAuth with `users.yaml` as the allowlist. Cloud-init fetches this file at boot to populate the OAuth allowlist.

## Changes

**Existing users — added `accounts.github`:**
- Alan Bridge → `alanbridge`
- Marc Gillespie → `gillespm`
- Ralf Stephan → `rwst`

**New user entries:**
- Karen Rothfels (`karenrothfels`) — OICR
- Lisa Matthews (`lisamatthews`) — Reactome
- Melissa Eilbes (`meilbes`) — MCW
- Alex Signoretti (`alexsign`) — UniProt
- Gene Godbold (`genegodbold`)

## Verification

- [x] YAML parses cleanly after edits
- [x] Total GitHub accounts: 197 → 205
- [ ] @kltm — please verify the new entries and GOC xrefs are reasonable (I used placeholder GOC codes for the new users)

Context: geneontology/go-jupyter#13