### PR TITLE
Revise Gene Ontology annotation description fixes #2673

### DIFF
--- a/metadata/gorefs.yaml
+++ b/metadata/gorefs.yaml
@@ -804,25 +804,17 @@
 - id: GO_REF:0000043
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   description: |-
-    Transitive assignments using UniProtKB/Swiss-Prot keywords. The UniProtKB keyword
-    controlled vocabulary contains 10 different categories of information to UniProtKB
-    entries. Further information on the UniProtKB keyword resource can be found at
-    https://www.uniprot.org/keywords/. UniProtKB keywords are assigned to UniProtKB/Swiss-Prot
-    entries by UniProt curators as part of the UniProtKB manual curation process.
-    UniProtKB keywords are also automatically assigned to UniProtKB/TrEMBL entries
-    from the underlying nucleic acid databases and/or by the UniProt automatic annotation
-    program. Further information on the two different UniProt annotation methods is
-    available at https://www.uniprot.org/help/keywords.. When a UniProtKB keyword
-    describes a concept that is within the scope of the Gene Ontology, a mapping is
-    manually made to the corresponding GO term.The translation table between GO terms
-    and UniProtKB keywords is maintained by the EBI GOA team and available at
-    http://www.geneontology.org/external2go/uniprotkb_kw2go.
+    Gene Ontology annotation of virus proteins based on UniProtKB/Swiss-Prot keyword mappingT. 
+    The UniProtKB keyword resource can be found at https://www.uniprot.org/keywords/. 
+    UniProtKB keywords are assigned to UniProtKB/Swiss-Prot entries by UniProt curators 
+    as part of the UniProtKB manual curation process. UniProtKB keywords are also automatically 
+    assigned to UniProtKB/TrEMBL entries from sequence databases and/or by the UniProt automatic 
+    annotation program. When a UniProtKB keyword describes a concept that is within the scope of 
+    the Gene Ontology, a mapping is manually made to the corresponding GO term. The translation 
+    table between GO terms and UniProtKB keywords is maintained by the EBI GOA team and available at 
+    http://www.geneontology.org/external2go/uniprotkb_kw2go. 
+    Note that this pipeline was formally run for all species, but is now restricted to viruses (NCBITaxon:10239).
   authors: UniProt-GOA
-  external_accession:
-    - SGD_REF:S000148669
-    - TAIR:AnalysisReference:501756968
-    - TAIR:AnalysisReference:501756970
-    - ZFIN:ZDB-PUB-020723-1
   year: 2012
 - id: GO_REF:0000044
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location

--- a/metadata/gorefs.yaml
+++ b/metadata/gorefs.yaml
@@ -804,7 +804,7 @@
 - id: GO_REF:0000043
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   description: |-
-    Gene Ontology annotation of virus proteins based on UniProtKB/Swiss-Prot keyword mappingT. 
+    Gene Ontology annotation of virus proteins based on UniProtKB/Swiss-Prot keyword mapping. 
     The UniProtKB keyword resource can be found at https://www.uniprot.org/keywords/. 
     UniProtKB keywords are assigned to UniProtKB/Swiss-Prot entries by UniProt curators 
     as part of the UniProtKB manual curation process. UniProtKB keywords are also automatically 


### PR DESCRIPTION
Updated the description for Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping, including a note on the restriction to virus species.