### PR TITLE
Update GOA dataset URLs for EBI GOEx filename simplification (SPECIES-{uniprot,mod})

### DIFF
--- a/metadata/datasets/dictybase.yaml
+++ b/metadata/datasets/dictybase.yaml
@@ -16,7 +16,7 @@ datasets:
    dataset: dictybase
    submitter: dictyBase
    compression: gzip
-   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpad/DICDI_44689_UP000002195.gpa.gz
+   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpad/DICDI-mod.gpa.gz
    entity_type:
    status: active
    species_code: Ddis
@@ -31,9 +31,9 @@ datasets:
    dataset: dictybase
    submitter: dictyBase
    compression: gzip
-   #source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/DICDI_44689_UP000002195.gpi.gz
+   #source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/DICDI-mod.gpi.gz
    #source: https://ftp.ebi.ac.uk/pub/contrib/goa/dictyBase.gpi.gz
-   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/DICDI_44689_UP000002195.gpi.gz
+   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/DICDI-mod.gpi.gz
    entity_type:
    status: active
    species_code: Ddis
@@ -49,7 +49,7 @@ datasets:
    submitter: dictyBase
    compression: gzip
    #source: https://release.geneontology.org/2024-03-28/products/upstream_and_raw_data/dictybase-src.gaf.gz
-   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/DICDI_44689_UP000002195.gaf.gz
+   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/DICDI-mod.gaf.gz
    entity_type:
    status: active
    species_code: Ddis

--- a/metadata/datasets/ecocyc.yaml
+++ b/metadata/datasets/ecocyc.yaml
@@ -15,7 +15,7 @@ datasets:
     dataset: ecocyc
     submitter: ecocyc
     compression: gzip
-    source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/ECOLI_83333_UP000000625.gaf.gz
+    source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/ECOLI-mod.gaf.gz
     entity_type:
     status: active
     species_code: Ecol
@@ -29,7 +29,7 @@ datasets:
     dataset: ecocyc
     submitter: ecocyc
     compression: gzip
-    #source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/ECOLI_83333_UP000000625.gpi.gz
+    #source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/ECOLI-mod.gpi.gz
     source: https://www.ai.sri.com/~kr/go/latest/ecocyc.gpi.gz
     entity_type:
     status: active

--- a/metadata/datasets/fb.yaml
+++ b/metadata/datasets/fb.yaml
@@ -16,7 +16,7 @@ datasets:
    dataset: fb
    submitter: fb
    compression: gzip
-   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/DROME_7227_UP000000803.gaf.gz
+   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/DROME-mod.gaf.gz
    #source: https://s3ftp.flybase.org/releases/current/precomputed_files/go/gene_association.fb.gz
    #source: http://experimental.geneontology.io/gene_association.fb.gz
    entity_type:
@@ -33,7 +33,7 @@ datasets:
    dataset: fb
    submitter: fb
    compression: gzip
-   #source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/DROME_7227_UP000000803.gpi.gz
+   #source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/DROME-mod.gpi.gz
    source: https://s3ftp.flybase.org/releases/current/collaborators/gp_information.fb.gz
    #source: http://experimental.geneontology.io/gp_information.fb.gz
    entity_type:

--- a/metadata/datasets/goa.yaml
+++ b/metadata/datasets/goa.yaml
@@ -16,8 +16,8 @@ datasets:
    dataset: goa_chicken
    submitter: goa
    compression: gzip
-   source: https://mirror.geneontology.io/CHICK_9031_UP000000539.gaf.gz
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/CHICK_9031_UP000000539.gaf.gz
+   source: https://mirror.geneontology.io/CHICK-uniprot.gaf.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/CHICK-uniprot.gaf.gz
    entity_type: all
    status: active
    species_code: Ggal
@@ -50,8 +50,8 @@ datasets:
    dataset: goa_chicken
    submitter: goa
    compression: gzip
-   source: https://mirror.geneontology.io/CHICK_9031_UP000000539.gpi.gz
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/CHICK_9031_UP000000539.gpi.gz
+   source: https://mirror.geneontology.io/CHICK-uniprot.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/CHICK-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: Ggal
@@ -67,8 +67,8 @@ datasets:
    dataset: goa_cow
    submitter: goa
    compression: gzip
-   source: https://mirror.geneontology.io/BOVIN_9913_UP000009136.gaf.gz
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/BOVIN_9913_UP000009136.gaf.gz
+   source: https://mirror.geneontology.io/BOVIN-uniprot.gaf.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/BOVIN-uniprot.gaf.gz
    entity_type: all
    status: active
    species_code: Btau
@@ -101,8 +101,8 @@ datasets:
    dataset: goa_cow
    submitter: goa
    compression: gzip
-   source: https://mirror.geneontology.io/BOVIN_9913_UP000009136.gpi.gz
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/BOVIN_9913_UP000009136.gpi.gz
+   source: https://mirror.geneontology.io/BOVIN-uniprot.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/BOVIN-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: Btau
@@ -118,8 +118,8 @@ datasets:
    dataset: goa_dog
    submitter: goa
    compression: gzip
-   source: https://mirror.geneontology.io/CANLF_9615_UP000805418.gaf.gz
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/CANLF_9615_UP000805418.gaf.gz
+   source: https://mirror.geneontology.io/CANLF-uniprot.gaf.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/CANLF-uniprot.gaf.gz
    entity_type: all
    status: active
    species_code: Cfam
@@ -152,8 +152,8 @@ datasets:
    dataset: goa_dog
    submitter: goa
    compression: gzip
-   source: https://mirror.geneontology.io/CANLF_9615_UP000805418.gpi.gz
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/CANLF_9615_UP000805418.gpi.gz
+   source: https://mirror.geneontology.io/CANLF-uniprot.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/CANLF-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: Cfam
@@ -169,8 +169,8 @@ datasets:
    dataset: goa_human
    submitter: goa
    compression: gzip
-   source: https://mirror.geneontology.io/HUMAN_9606_UP000005640.gaf.gz
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/HUMAN_9606_UP000005640.gaf.gz
+   source: https://mirror.geneontology.io/HUMAN-uniprot.gaf.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/HUMAN-uniprot.gaf.gz
    entity_type: all
    status: active
    species_code: Hsap
@@ -203,8 +203,8 @@ datasets:
    dataset: goa_human
    submitter: goa
    compression: gzip
-   source: https://mirror.geneontology.io/HUMAN_9606_UP000005640.gpi.gz
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HUMAN_9606_UP000005640.gpi.gz
+   source: https://mirror.geneontology.io/HUMAN-uniprot.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HUMAN-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: Hsap
@@ -220,8 +220,8 @@ datasets:
    dataset: goa_pig
    submitter: goa
    compression: gzip
-   source: https://mirror.geneontology.io/PIG_9823_UP000008227.gaf.gz
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/PIG_9823_UP000008227.gaf.gz
+   source: https://mirror.geneontology.io/PIG-uniprot.gaf.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/PIG-uniprot.gaf.gz
    entity_type: all
    status: active
    species_code: Sscr
@@ -254,8 +254,8 @@ datasets:
    dataset: goa_pig
    submitter: goa
    compression: gzip
-   source: https://mirror.geneontology.io/PIG_9823_UP000008227.gpi.gz
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/PIG_9823_UP000008227.gpi.gz
+   source: https://mirror.geneontology.io/PIG-uniprot.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/PIG-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: Sscr
@@ -393,8 +393,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_290338
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/CITK8_290338_UP000008148.gpi.gz
-   source: https://mirror.geneontology.io/CITK8_290338_UP000008148.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/CITK8-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/CITK8-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: CITK8
@@ -411,8 +411,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_574
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/KLEPO_574_UP000255382.gpi.gz
-   source: https://mirror.geneontology.io/KLEPO_574_UP000255382.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/KLEPO-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/KLEPO-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: KLEPO
@@ -429,8 +429,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_623
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/SHIFL_623_UP000001006.gpi.gz
-   source: https://mirror.geneontology.io/SHIFL_623_UP000001006.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/SHIFL-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/SHIFL-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: SHIFL
@@ -447,8 +447,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_1353
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/ENTGA_1353_UP000254807.gpi.gz
-   source: https://mirror.geneontology.io/ENTGA_1353_UP000254807.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/ENTGA-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/ENTGA-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: ENTGA
@@ -465,8 +465,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_1392
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/BACAN_1392_UP000000594.gpi.gz
-   source: https://mirror.geneontology.io/BACAN_1392_UP000000594.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/BACAN-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/BACAN-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: BACAN
@@ -483,8 +483,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_1901
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/STRCL_1901_UP000002357.gpi.gz
-   source: https://mirror.geneontology.io/STRCL_1901_UP000002357.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/STRCL-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/STRCL-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: STRCL
@@ -501,8 +501,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_10254
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/VACCW_10254_UP000000344.gpi.gz
-   source: https://mirror.geneontology.io/VACCW_10254_UP000000344.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/VACCW-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/VACCW-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: VACCW
@@ -519,8 +519,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_10299
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HHV11_10299_UP000009294.gpi.gz
-   source: https://mirror.geneontology.io/HHV11_10299_UP000009294.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HHV11-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/HHV11-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: HHV11
@@ -537,8 +537,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_10338
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/VZVD_10338_UP000002602.gpi.gz
-   source: https://mirror.geneontology.io/VZVD_10338_UP000002602.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/VZVD-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/VZVD-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: VZVD
@@ -555,8 +555,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_10360
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HCMVA_10360_UP000008992.gpi.gz
-   source: https://mirror.geneontology.io/HCMVA_10360_UP000008992.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HCMVA-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/HCMVA-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: HCMVA
@@ -573,8 +573,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_12118
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/FMDVO_12118_UP000008765.gpi.gz
-   source: https://mirror.geneontology.io/FMDVO_12118_UP000008765.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/FMDVO-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/FMDVO-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: FMDVO
@@ -591,8 +591,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_63746
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HCV77_63746_UP000000518.gpi.gz
-   source: https://mirror.geneontology.io/HCV77_63746_UP000000518.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HCV77-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/HCV77-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: HCV77
@@ -609,8 +609,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_64320
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/ZIKV_64320_UP000054557.gpi.gz
-   source: https://mirror.geneontology.io/ZIKV_64320_UP000054557.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/ZIKV-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/ZIKV-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: ZIKV
@@ -627,8 +627,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_71421
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HAEIN_71421_UP000000579.gpi.gz
-   source: https://mirror.geneontology.io/HAEIN_71421_UP000000579.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HAEIN-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/HAEIN-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: HAEIN
@@ -645,8 +645,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_85962
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HELPY_85962_UP000000429.gpi.gz
-   source: https://mirror.geneontology.io/HELPY_85962_UP000000429.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HELPY-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/HELPY-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: HELPY
@@ -663,8 +663,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_93061
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/STAA8_93061_UP000008816.gpi.gz
-   source: https://mirror.geneontology.io/STAA8_93061_UP000008816.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/STAA8-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/STAA8-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: STAA8
@@ -681,8 +681,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_99287
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/SALTY_99287_UP000001014.gpi.gz
-   source: https://mirror.geneontology.io/SALTY_99287_UP000001014.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/SALTY-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/SALTY-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: SALTY
@@ -699,8 +699,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_100226
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/STRCO_100226_UP000001973.gpi.gz
-   source: https://mirror.geneontology.io/STRCO_100226_UP000001973.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/STRCO-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/STRCO-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: STRCO
@@ -717,8 +717,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_122586
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/NEIMB_122586_UP000000425.gpi.gz
-   source: https://mirror.geneontology.io/NEIMB_122586_UP000000425.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/NEIMB-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/NEIMB-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: NEIMB
@@ -735,8 +735,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_169963
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/LISMO_169963_UP000000817.gpi.gz
-   source: https://mirror.geneontology.io/LISMO_169963_UP000000817.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/LISMO-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/LISMO-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: LISMO
@@ -753,8 +753,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_170187
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/STRPN_170187_UP000000585.gpi.gz
-   source: https://mirror.geneontology.io/STRPN_170187_UP000000585.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/STRPN-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/STRPN-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: STRPN
@@ -771,8 +771,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_171101
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/STRR6_171101_UP000000586.gpi.gz
-   source: https://mirror.geneontology.io/STRR6_171101_UP000000586.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/STRR6-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/STRR6-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: STRR6
@@ -789,8 +789,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_192222
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/CAMJE_192222_UP000000799.gpi.gz
-   source: https://mirror.geneontology.io/CAMJE_192222_UP000000799.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/CAMJE-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/CAMJE-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: CAMJE
@@ -807,8 +807,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_208964
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/PSEAE_208964_UP000002438.gpi.gz
-   source: https://mirror.geneontology.io/PSEAE_208964_UP000002438.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/PSEAE-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/PSEAE-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: PSEAE
@@ -825,8 +825,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_224308
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/BACSU_224308_UP000001570.gpi.gz
-   source: https://mirror.geneontology.io/BACSU_224308_UP000001570.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/BACSU-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/BACSU-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: BACSU
@@ -843,8 +843,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_226185
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/ENTFA_226185_UP000001415.gpi.gz
-   source: https://mirror.geneontology.io/ENTFA_226185_UP000001415.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/ENTFA-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/ENTFA-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: ENTFA
@@ -861,8 +861,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_243273
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/MYCGE_243273_UP000000807.gpi.gz
-   source: https://mirror.geneontology.io/MYCGE_243273_UP000000807.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/MYCGE-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/MYCGE-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: MYCGE
@@ -879,8 +879,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_272558
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HALH5_272558_UP000001258.gpi.gz
-   source: https://mirror.geneontology.io/HALH5_272558_UP000001258.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HALH5-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/HALH5-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: HALH5
@@ -897,8 +897,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_272634
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/MYCPN_272634_UP000000808.gpi.gz
-   source: https://mirror.geneontology.io/MYCPN_272634_UP000000808.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/MYCPN-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/MYCPN-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: MYCPN
@@ -915,8 +915,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_295027
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HCMVM_295027_UP000000938.gpi.gz
-   source: https://mirror.geneontology.io/HCMVM_295027_UP000000938.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HCMVM-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/HCMVM-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: HCMVM
@@ -933,8 +933,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_301447
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/STRP1_301447_UP000000750.gpi.gz
-   source: https://mirror.geneontology.io/STRP1_301447_UP000000750.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/STRP1-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/STRP1-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: STRP1
@@ -951,8 +951,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_327105
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HV1AN_327105_UP000007689.gpi.gz
-   source: https://mirror.geneontology.io/HV1AN_327105_UP000007689.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HV1AN-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/HV1AN-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: HV1AN
@@ -969,8 +969,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_333760
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HPV16_333760_UP000009251.gpi.gz
-   source: https://mirror.geneontology.io/HPV16_333760_UP000009251.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HPV16-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/HPV16-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: HPV16
@@ -987,8 +987,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_373153
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/STRP2_373153_UP000001452.gpi.gz
-   source: https://mirror.geneontology.io/STRP2_373153_UP000001452.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/STRP2-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/STRP2-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: STRP2
@@ -1005,8 +1005,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_419947
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/MYCTA_419947_UP000001988.gpi.gz
-   source: https://mirror.geneontology.io/MYCTA_419947_UP000001988.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/MYCTA-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/MYCTA-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: MYCTA
@@ -1023,8 +1023,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_565655
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/ENTCA_565655_UP000012675.gpi.gz
-   source: https://mirror.geneontology.io/ENTCA_565655_UP000012675.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/ENTCA-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/ENTCA-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: ENTCA
@@ -1041,8 +1041,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_575584
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/ACIB2_575584_UP000498640.gpi.gz
-   source: https://mirror.geneontology.io/ACIB2_575584_UP000498640.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/ACIB2-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/ACIB2-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: ACIB2
@@ -1059,8 +1059,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_587200
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/VAR67_587200_UP000002060.gpi.gz
-   source: https://mirror.geneontology.io/VAR67_587200_UP000002060.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/VAR67-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/VAR67-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: VAR67
@@ -1077,8 +1077,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_645098
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/MEASC_645098_UP000008699.gpi.gz
-   source: https://mirror.geneontology.io/MEASC_645098_UP000008699.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/MEASC-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/MEASC-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: MEASC
@@ -1095,8 +1095,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_928302
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HBVCJ_928302_UP000008591.gpi.gz
-   source: https://mirror.geneontology.io/HBVCJ_928302_UP000008591.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/HBVCJ-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/HBVCJ-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: HBVCJ
@@ -1113,8 +1113,8 @@ datasets:
    dataset: goa_virus_bacteria_taxon_1125630
    submitter: goa
    compression: gzip
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/KLEPH_1125630_UP000007841.gpi.gz
-   source: https://mirror.geneontology.io/KLEPH_1125630_UP000007841.gpi.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/KLEPH-uniprot.gpi.gz
+   source: https://mirror.geneontology.io/KLEPH-uniprot.gpi.gz
    entity_type: all
    status: active
    species_code: KLEPH

--- a/metadata/datasets/japonicusdb.yaml
+++ b/metadata/datasets/japonicusdb.yaml
@@ -16,7 +16,7 @@ datasets:
    dataset: japonicusdb
    submitter: japonicusdb
    compression: gzip
-   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/SCHJY_402676_UP000001744.gaf.gz
+   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/SCHJY-mod.gaf.gz
    entity_type:
    status: active
    species_code: Sjap

--- a/metadata/datasets/mgi.yaml
+++ b/metadata/datasets/mgi.yaml
@@ -27,7 +27,7 @@ datasets:
    submitter: mgi
    compression: gzip
    #source: https://mirror.geneontology.io/mgi-p2go-homology.gaf.gz
-   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/MOUSE_10090_UP000000589.gaf.gz
+   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/MOUSE-mod.gaf.gz
    entity_type:
    status: active
    species_code: Mmus
@@ -43,7 +43,7 @@ datasets:
    dataset: mgi
    submitter: mgi
    compression: gzip
-   #source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/MOUSE_10090_UP000000589.gpi.gz
+   #source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/MOUSE-mod.gpi.gz
    source: https://www.informatics.jax.org/downloads/reports/mgi.gpi.gz
    entity_type:
    status: active

--- a/metadata/datasets/pombase.yaml
+++ b/metadata/datasets/pombase.yaml
@@ -16,7 +16,7 @@ datasets:
    dataset: pombase
    submitter: pombase
    compression: gzip
-   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/SCHPO_284812_UP000002485.gaf.gz
+   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/SCHPO-mod.gaf.gz
    entity_type:
    status: active
    species_code: Spom
@@ -46,7 +46,7 @@ datasets:
    dataset: pombase
    submitter: pombase
    compression: gzip
-   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpad/SCHPO_284812_UP000002485.gpa.gz
+   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpad/SCHPO-mod.gpa.gz
    entity_type:
    status: active
    species_code: Spom

--- a/metadata/datasets/pseudocap.yaml
+++ b/metadata/datasets/pseudocap.yaml
@@ -16,7 +16,7 @@ datasets:
    dataset: pseudocap
    submitter: pseudocap
    compression: gzip
-   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/PSEAE_208964_UP000002438.gaf.gz
+   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/PSEAE-uniprot.gaf.gz
    entity_type:
    status: active
    species_code: Pseudomonas

--- a/metadata/datasets/rgd.yaml
+++ b/metadata/datasets/rgd.yaml
@@ -16,7 +16,7 @@ datasets:
    dataset: rgd
    submitter: rgd
    compression: gzip
-   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/RAT_10116_UP000002494.gaf.gz
+   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/RAT-mod.gaf.gz
    entity_type:
    status: active
    species_code: Rnor

--- a/metadata/datasets/sgd.yaml
+++ b/metadata/datasets/sgd.yaml
@@ -16,7 +16,7 @@ datasets:
    dataset: sgd
    submitter: sgd
    compression: gzip
-   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/YEAST_559292_UP000002311.gaf.gz
+   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/YEAST-mod.gaf.gz
    entity_type:
    status: active
    species_code: Scer
@@ -31,7 +31,7 @@ datasets:
    dataset: sgd
    submitter: sgd
    compression: gzip
-   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpad/YEAST_559292_UP000002311.gpa.gz
+   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpad/YEAST-mod.gpa.gz
    entity_type:
    status: active
    species_code: Scer
@@ -46,7 +46,7 @@ datasets:
    dataset: sgd
    submitter: sgd
    compression: gzip
-   #source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/YEAST_559292_UP000002311.gpi.gz
+   #source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/YEAST-mod.gpi.gz
    source: https://downloads.yeastgenome.org/latest/gpi.sgd.gz
    entity_type:
    status: active

--- a/metadata/datasets/sgn.yaml
+++ b/metadata/datasets/sgn.yaml
@@ -16,8 +16,8 @@ datasets:
    dataset: sgn
    submitter: sgn
    compression: gzip
-   source: https://mirror.geneontology.io/SOLLC_4081_UP000004994.gaf.gz
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/SOLLC_4081_UP000004994.gaf.gz
+   source: https://mirror.geneontology.io/SOLLC-uniprot.gaf.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/SOLLC-uniprot.gaf.gz
    entity_type: gene
    status: active
    species_code: Solanaceae

--- a/metadata/datasets/tair.yaml
+++ b/metadata/datasets/tair.yaml
@@ -16,8 +16,8 @@ datasets:
    dataset: tair
    submitter: tair
    compression: gzip
-   source: https://mirror.geneontology.io/ARATH_3702_UP000006548.gaf.gz
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/ARATH_3702_UP000006548.gaf.gz
+   source: https://mirror.geneontology.io/ARATH-mod.gaf.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/ARATH-mod.gaf.gz
    entity_type:
    status: active
    species_code: Atal

--- a/metadata/datasets/wb.yaml
+++ b/metadata/datasets/wb.yaml
@@ -23,7 +23,7 @@ datasets:
    dataset: wb
    submitter: wb
    compression: gzip
-   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/CAEEL_6239_UP000001940.gaf.gz
+   source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/CAEEL-mod.gaf.gz
    entity_type:
    status: active
    species_code: Cele
@@ -38,7 +38,7 @@ datasets:
    dataset: wb
    submitter: wb
    compression: gzip
-   #source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/CAEEL_6239_UP000001940.gpi.gz
+   #source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/CAEEL-mod.gpi.gz
    source: https://downloads.wormbase.org/species/c_elegans/PRJNA13758/annotation/gene_product_info/c_elegans.canonical_bioproject.current.gene_product_info.gpi.gz
    entity_type:
    status: active

--- a/metadata/datasets/zfin.yaml
+++ b/metadata/datasets/zfin.yaml
@@ -16,8 +16,8 @@ datasets:
    dataset: zfin
    submitter: zfin
    compression: gzip
-   source: https://mirror.geneontology.io/DANRE_7955_UP000000437.gaf.gz
-   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/DANRE_7955_UP000000437.gaf.gz
+   source: https://mirror.geneontology.io/DANRE-mod.gaf.gz
+   mirror_of: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gaf/DANRE-mod.gaf.gz
    entity_type:
    status: active
    species_code: Drer
@@ -32,7 +32,7 @@ datasets:
    dataset: zfin
    submitter: zfin
    compression: gzip
-   #source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/DANRE_7955_UP000000437.gpi.gz
+   #source: https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/DANRE-mod.gpi.gz
    source: https://zfin.org/downloads/zfin.gpi.gz
    #source: https://release.geneontology.org/2025-07-22/products/upstream_and_raw_data/zfin-src.gpi.gz
    entity_type:


### PR DESCRIPTION
Fixes #2681.

EMBL-EBI / UniProt-GOA simplified the per-species GOEx filenames under
`ftp.ebi.ac.uk/pub/contrib/goa/goex/current/{gaf,gpad,gpi}/`, replacing
the old `SPECIES_<taxon>_<proteome>` scheme with `SPECIES-{uniprot,mod}`.
Our dataset metadata still pointed at the old names, which now 404 — this
breaks the `goa-copy-to-mirror` pipeline branch (geneontology/pipeline#305),
whose bulk `wget -i` over the scraped `ftp.ebi.ac.uk` URLs hit 75 × 404
out of 101 and exits non-zero.

### What changed
`metadata/datasets/*.yaml` — **14 files, 129 substitutions**:
- 75 × `ftp.ebi.ac.uk/.../goex/current/` `source:`/`mirror_of:` URLs → new names (active and commented lines).
- 54 × paired `source: https://mirror.geneontology.io/<OLD>` copies → new basenames, so the mirror stays consistent with what the copy job republishes.

### Why it's safe / deterministic
- Each species publishes exactly **one** variant (`-uniprot` *or* `-mod`), consistent across gaf/gpad/gpi — no judgment call.
- Every new EBI URL returns **200**, verified over **`ftp://`** too (the protocol the pipeline uses), so this metadata change alone unblocks the pipeline — **no Jenkinsfile change required**.
- The 26 non-`goex` EBI URLs (`databases/GO/goa/...`, `external2go`, RNAcentral, Rfam) were unaffected and left untouched.
- Zero old-scheme names remain; every `source`/`mirror_of` pair shares a basename; all YAML parses.

### Note
The mirror will serve the new-named files after the next successful
`goa-copy-to-mirror` run; the old-named mirror copies become stale until
cleaned (the public mirror filenames change with this PR, as agreed).

_— Posted by Claude Code agent on behalf of @kltm._
