### PR TITLE
Modify fail_mode and refine annotation guidelines

### DIFF
--- a/metadata/rules/README.md
+++ b/metadata/rules/README.md
@@ -463,12 +463,10 @@ reasoner such as HermiT.
  * status: implemented
 
 
-There should be no annotations to obsolete terms or to an alternate ID (Column 5 of GAF, Column 4 of GPAD). As well, GO terms present in annotations also should be repaired if possible: 
-* with/from: Column 8 of GAF, Column 7 of GPAD
-* extensions, Column 16 of GAF, Column 11 of GPAD 
+Annotations to obsolete terms or to an alternate ID (Column 5 of GAF, Column 4 of GPAD), in the with/from field (Column 8 of GAF, Column 7 of GPAD) and in extensions, (Column 16 of GAF, Column 11 of GPAD) are not allowed. 
 
-Obsolete terms that have a `replaced_by` tag and terms annotated to one of their alternative IDs (merged terms; `alt_id` in the .obo files) will automatically be repaired to the valid term id.
-If no replacement is found, the annotation will be filtered.
+If there is a 'replaced_by' value or an alternative ID in the ontology file, then the GO term is automatically replaced and a warning is generated. 
+If there is no 'replaced_by' or alternative ID in the ontology file, then the annotation line is filtered. 
 
 
 

--- a/metadata/rules/gorule-0000020.md
+++ b/metadata/rules/gorule-0000020.md
@@ -3,15 +3,13 @@ layout: rule
 id: GORULE:0000020
 title: "Automatic repair of annotations to merged or obsoleted terms when replacement is available; otherwise, filter annotation"
 type: repair
-fail_mode: hard
+fail_mode: mixed
 status: implemented
 contact: "go-quality@lists.stanford.edu"
 ---
-There should be no annotations to obsolete terms or to an alternate ID (Column 5 of GAF, Column 4 of GPAD). As well, GO terms present in annotations also should be repaired if possible: 
-* with/from: Column 8 of GAF, Column 7 of GPAD
-* extensions, Column 16 of GAF, Column 11 of GPAD 
+Annotations to obsolete terms or to an alternate ID (Column 5 of GAF, Column 4 of GPAD), in the with/from field (Column 8 of GAF, Column 7 of GPAD) and in extensions, (Column 16 of GAF, Column 11 of GPAD) are not allowed. 
 
-Obsolete terms that have a `replaced_by` tag and terms annotated to one of their alternative IDs (merged terms; `alt_id` in the .obo files) will automatically be repaired to the valid term id.
-If no replacement is found, the annotation will be filtered.
+If there is a 'replaced_by' value or an alternative ID in the ontology file, then the GO term is automatically replaced and a warning is generated. 
+If there is no 'replaced_by' or alternative ID in the ontology file, then the annotation line is filtered. 
 
 


### PR DESCRIPTION
Updated fail_mode to mixed and clarified annotation rules regarding obsolete terms and alternative IDs.