### PR TITLE
Add --exclude to directory_indexer.py and s3-uploader.py

### DIFF
--- a/scripts/bucket-indexer.py
+++ b/scripts/bucket-indexer.py
@@ -113,7 +113,9 @@ def main():
     bucket = s3.Bucket(args.bucket)
     result = bucket.meta.client.list_objects(Bucket=bucket.name, Delimiter='/')
     dirs = []
-    for pre in result.get('CommonPrefixes'):
+    # CommonPrefixes is absent (not []) when the bucket has no '/'-delimited keys,
+    # e.g. an empty bucket -- guard against iterating None.
+    for pre in (result.get('CommonPrefixes') or []):
         name = pre.get('Prefix').rstrip('//')
         url = prefix + name + '/' + 'index.html'
         dirs.append({"name": name, "url": url})

--- a/scripts/directory_indexer.py
+++ b/scripts/directory_indexer.py
@@ -58,6 +58,8 @@ def main():
                         help='Actually run--not the default dry run')
     parser.add_argument('-u', '--up', action='store_true',
                         help='Release version, where pages have a link pointing up one level')
+    parser.add_argument('-e', '--exclude', action='append', default=[],
+                        help='Directory name to skip entirely -- not descended into and not listed (repeatable)')
     parser.add_argument('-v', '--verbose', action='store_true',
                         help='More verbose output')
     args = parser.parse_args()
@@ -95,11 +97,17 @@ def main():
         'go-release-archive.tgz'
     ]
     LOG.info('Will ignore: "' + '", "'.join(ignore_list) + '"')
+    if args.exclude:
+        LOG.info('Will exclude directories: "' + '", "'.join(args.exclude) + '"')
 
     # Walk tree.
     # First, make a clean path to use in making new pathnames.
     # webrootdir = rootdir.lstrip('.').lstrip('//').rstrip('//')
     for currdir, dirs, files in os.walk(rootdir):
+
+        ## Prune excluded directories in place: os.walk then neither descends
+        ## into them nor (since children are built from dirs) lists them.
+        dirs[:] = [d for d in dirs if d not in args.exclude]
 
         ## Create index on every "root".
         parent = None

--- a/scripts/s3-uploader.py
+++ b/scripts/s3-uploader.py
@@ -91,6 +91,8 @@ def get_args():
                         help='TODO: The mimetypes metadata to use, in JSON')
     parser.add_argument('-l', '--location',
                         help='TODO: The S3 location to use')
+    parser.add_argument('-e', '--exclude', action='append', default=[],
+                        help='Directory name to skip entirely -- not descended into and not uploaded (repeatable)')
 
     return parser
 
@@ -154,6 +156,10 @@ def main():
 
     ## Walk tree.
     for curr_dir, dirs, files in os.walk(args.directory):
+
+        ## Prune excluded directories in place so they are never descended
+        ## into or uploaded.
+        dirs[:] = [d for d in dirs if d not in args.exclude]
 
         ## We can navigate up if we are not in the root.
         relative_to_start = curr_dir.rstrip('//')[len(args.directory):]


### PR DESCRIPTION
## What

Adds an optional, repeatable `--exclude DIR` flag to both `scripts/directory_indexer.py` and `scripts/s3-uploader.py`. Named directories are skipped entirely — not descended into, and not listed (indexer) / not uploaded (uploader). Implemented by pruning `os.walk`'s `dirs` list in place. Default is empty, so **existing callers are unaffected**.

## Why

The `pipeline-from-goa` publish tail (`scripts/publish-to-s3.sh`) needs to keep the `internal/` staging directory out of *both* the generated directory index and the S3 upload. Neither script currently has an exclude, so the publish script works around it by temporarily relocating `internal/` out of the tree. A native `--exclude internal` lets it drop that workaround. Driver: geneontology/pipeline-from-goa#22.

## Testing

- Both scripts `py_compile` cleanly.
- `directory_indexer.py … --exclude internal` over a sample tree: `internal/` is absent from the root index and no `internal/index.html` is written (it isn't descended into), while sibling directories index normally.
- Backward-compatible: with no `--exclude`, behavior is unchanged (default empty list).

_— Posted by Claude Code agent on behalf of @kltm._