### PR TITLE
Cap oaklib<0.7 in scripts/requirements.txt

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -4,7 +4,7 @@ click
 pyparsing==2.4.7
 antlr4-python3-runtime==4.9.3
 docutils==0.21.2
-oaklib>=0.6.18
+oaklib>=0.6.18,<0.7
 pysolr==3.10.0
 gocam
 


### PR DESCRIPTION
Caps `oaklib` below 0.7 in `scripts/requirements.txt` (`oaklib>=0.6.18` → `oaklib>=0.6.18,<0.7`).

**Why:** oaklib 0.7 (released 2026-07-02) added `llm` as a core dependency, which cascades a pip resolver backtrack (via a `chardet<5` conflict with modern `pronto`) down to the sdist-only `fastobo 0.10.2.post1` — unbuildable against modern `setuptools-rust` (`ModuleNotFoundError: No module named 'setuptools_rust.utils'`). This broke `pipeline-raw-go-cam` and is a latent break for the main `pipeline`, both of which install this file live from PyPI.

This aligns `requirements.txt` with the sibling `scripts/pyproject.toml`, which already constrains `oaklib = "^0.6.18"` (= `<0.7`). Restores the last-known-good stack (oaklib 0.6.23 / pronto 2.7.3 / fastobo 0.14.1).

Tracking: geneontology/operations#88.

_— Posted by Claude Code agent on behalf of @kltm._